### PR TITLE
feat: credential-access policy + auth-token badge

### DIFF
--- a/drizzle/0014_flashy_nightmare.sql
+++ b/drizzle/0014_flashy_nightmare.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "config_versions" ADD COLUMN "reads_claude_token" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1017 @@
+{
+  "id": "622a8edc-d4b4-462e-9248-5a337ca7f133",
+  "prevId": "8c04b62f-589c-4855-9e74-8768933fcf07",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.config_versions": {
+      "name": "config_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interpreter": {
+          "name": "interpreter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_html": {
+          "name": "source_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network_hosts": {
+          "name": "network_hosts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "reads_claude_token": {
+          "name": "reads_claude_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "config_versions_config_version_uq": {
+          "name": "config_versions_config_version_uq",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "config_versions_config_id_configs_id_fk": {
+          "name": "config_versions_config_id_configs_id_fk",
+          "tableFrom": "config_versions",
+          "tableTo": "configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.configs": {
+      "name": "configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interpreter": {
+          "name": "interpreter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upvote_count": {
+          "name": "upvote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "copy_count": {
+          "name": "copy_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "configs_author_created_idx": {
+          "name": "configs_author_created_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "configs_status_created_idx": {
+          "name": "configs_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "configs_status_upvotes_idx": {
+          "name": "configs_status_upvotes_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "upvote_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "configs_author_id_user_id_fk": {
+          "name": "configs_author_id_user_id_fk",
+          "tableFrom": "configs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "configs_slug_unique": {
+          "name": "configs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.copy_events": {
+      "name": "copy_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "copy_events_config_ip_uq": {
+          "name": "copy_events_config_ip_uq",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ip_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "copy_events_config_id_configs_id_fk": {
+          "name": "copy_events_config_id_configs_id_fk",
+          "tableFrom": "copy_events",
+          "tableTo": "configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.previews": {
+      "name": "previews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "script_sha": {
+          "name": "script_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scenario_key": {
+          "name": "scenario_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segments": {
+          "name": "segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_stdout": {
+          "name": "raw_stdout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timed_out": {
+          "name": "timed_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace": {
+          "name": "trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "previews_sha_scenario_uq": {
+          "name": "previews_sha_scenario_uq",
+          "columns": [
+            {
+              "expression": "script_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scenario_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.render_jobs": {
+      "name": "render_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "config_version_id": {
+          "name": "config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "render_jobs_config_version_id_config_versions_id_fk": {
+          "name": "render_jobs_config_version_id_config_versions_id_fk",
+          "tableFrom": "render_jobs",
+          "tableTo": "config_versions",
+          "columnsFrom": [
+            "config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "votes_user_config_uq": {
+          "name": "votes_user_config_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_user_id_user_id_fk": {
+          "name": "votes_user_id_user_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_config_id_configs_id_fk": {
+          "name": "votes_config_id_configs_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1782398086212,
       "tag": "0013_tidy_argent",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1782831062546,
+      "tag": "0014_flashy_nightmare",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -3,6 +3,7 @@ export * from './auth-schema'
 
 import { sql } from 'drizzle-orm'
 import {
+  boolean,
   index,
   integer,
   jsonb,
@@ -78,6 +79,7 @@ export const configVersions = pgTable(
     // highlight failure fall back to live highlighting (resolveSourceHtml in src/lib/highlight.ts).
     sourceHtml: text('source_html'),
     networkHosts: jsonb('network_hosts').$type<string[]>().notNull().default(sql`'[]'::jsonb`),
+    readsClaudeToken: boolean('reads_claude_token').notNull().default(false),
     status: text('status').notNull().default('pending'),
     reviewedBy: text('reviewed_by'),
     reviewedAt: timestamp('reviewed_at', { withTimezone: true }),

--- a/src/gallery/queries.ts
+++ b/src/gallery/queries.ts
@@ -60,6 +60,7 @@ export interface GalleryCard {
   author: ConfigAuthor | null
   preview: AnsiSegment[] | null
   networkHosts: string[]
+  readsClaudeToken: boolean
 }
 
 /** Total published configs — drives the gallery's page count. */
@@ -132,6 +133,7 @@ export async function getPublishedConfigs(
       : null,
     preview: cardPreviews.get(r.version.contentSha256) ?? null,
     networkHosts: r.version.networkHosts ?? [],
+    readsClaudeToken: r.version.readsClaudeToken ?? false,
   }))
 }
 
@@ -176,6 +178,7 @@ export interface ConfigDetail {
   sourceHtml: string | null
   contentSha256: string
   networkHosts: string[]
+  readsClaudeToken: boolean
   previews: RenderedPreview[]
 }
 
@@ -214,6 +217,7 @@ export async function getConfigBySlug(
     sourceHtml: row.version.sourceHtml,
     contentSha256: row.version.contentSha256,
     networkHosts: row.version.networkHosts ?? [],
+    readsClaudeToken: row.version.readsClaudeToken ?? false,
     previews,
   }
 }

--- a/src/review/dashboard-card-parts.tsx
+++ b/src/review/dashboard-card-parts.tsx
@@ -146,23 +146,20 @@ export function NetworkHostList({ hosts }: { hosts: string[] }) {
 
 /** Admin-only toggle for the "reads the Claude Code auth token" disclosure flag. */
 export function CredentialFlagToggle({
+  htmlId,
   value,
   pending,
   onChange,
 }: {
+  htmlId: string
   value: boolean
   pending: boolean
   onChange: (next: boolean) => void
 }) {
   return (
     <Row gap={2} align="center">
-      <Switch
-        id="reads-claude-token"
-        checked={value}
-        disabled={pending}
-        onCheckedChange={onChange}
-      />
-      <Label htmlFor="reads-claude-token">Reads the Claude Code auth token</Label>
+      <Switch id={htmlId} checked={value} disabled={pending} onCheckedChange={onChange} />
+      <Label htmlFor={htmlId}>Reads the Claude Code auth token</Label>
     </Row>
   )
 }

--- a/src/review/dashboard-card-parts.tsx
+++ b/src/review/dashboard-card-parts.tsx
@@ -5,11 +5,49 @@ import { Badge } from '@/ui/badge'
 import { Button } from '@/ui/button'
 import { CodeBlock } from '@/ui/code-block'
 import { Details } from '@/ui/details'
+import { Label } from '@/ui/label'
 import { Row, Stack } from '@/ui/layout'
 import { LocalTime } from '@/ui/local-time'
 import { ScenarioRow } from '@/ui/scenario-row'
 import { StretchedLink } from '@/ui/stretched-link'
+import { Switch } from '@/ui/switch'
 import { Text } from '@/ui/text'
+
+export type RenderStatus = DashboardRow['renderJob']['status']
+export type BadgeVariant = 'secondary' | 'destructive' | 'outline' | 'primaryOutline'
+
+// Render status → badge look + label. Failed is loud (destructive); ready gets a coral *outline*
+// (not a coral fill — that reads as a clickable button) to draw the eye to the actionable row.
+export const RENDER_BADGE: Record<string, { variant: BadgeVariant; label: string }> = {
+  failed: { variant: 'destructive', label: 'failed' },
+  running: { variant: 'secondary', label: 'rendering' },
+  queued: { variant: 'outline', label: 'queued' },
+  done: { variant: 'primaryOutline', label: 'ready' },
+  held: { variant: 'outline', label: 'needs network review' },
+}
+
+export function badgeFor(status: RenderStatus): { variant: BadgeVariant; label: string } {
+  return RENDER_BADGE[status] ?? { variant: 'outline', label: status }
+}
+
+export function StatusSummary({ rows }: { rows: DashboardRow[] }) {
+  const counts = rows.reduce<Record<string, number>>((acc, r) => {
+    acc[r.renderJob.status] = (acc[r.renderJob.status] ?? 0) + 1
+    return acc
+  }, {})
+  const order: RenderStatus[] = ['held', 'failed', 'running', 'queued', 'done']
+  return (
+    <Row gap={2}>
+      {order
+        .filter((s) => counts[s])
+        .map((s) => (
+          <Badge key={s} variant={badgeFor(s).variant}>
+            {counts[s]} {badgeFor(s).label}
+          </Badge>
+        ))}
+    </Row>
+  )
+}
 
 /** A published card's title is a stretched link (whole card → detail page); otherwise plain text. */
 export function titleFor(config: DashboardRow['config'], detailSlug: string | undefined) {
@@ -103,6 +141,29 @@ export function NetworkHostList({ hosts }: { hosts: string[] }) {
         ))}
       </Row>
     </Stack>
+  )
+}
+
+/** Admin-only toggle for the "reads the Claude Code auth token" disclosure flag. */
+export function CredentialFlagToggle({
+  value,
+  pending,
+  onChange,
+}: {
+  value: boolean
+  pending: boolean
+  onChange: (next: boolean) => void
+}) {
+  return (
+    <Row gap={2} align="center">
+      <Switch
+        id="reads-claude-token"
+        checked={value}
+        disabled={pending}
+        onCheckedChange={onChange}
+      />
+      <Label htmlFor="reads-claude-token">Reads the Claude Code auth token</Label>
+    </Row>
   )
 }
 

--- a/src/review/dashboard-card-parts.tsx
+++ b/src/review/dashboard-card-parts.tsx
@@ -13,12 +13,12 @@ import { StretchedLink } from '@/ui/stretched-link'
 import { Switch } from '@/ui/switch'
 import { Text } from '@/ui/text'
 
-export type RenderStatus = DashboardRow['renderJob']['status']
+type RenderStatus = DashboardRow['renderJob']['status']
 export type BadgeVariant = 'secondary' | 'destructive' | 'outline' | 'primaryOutline'
 
 // Render status → badge look + label. Failed is loud (destructive); ready gets a coral *outline*
 // (not a coral fill — that reads as a clickable button) to draw the eye to the actionable row.
-export const RENDER_BADGE: Record<string, { variant: BadgeVariant; label: string }> = {
+const RENDER_BADGE: Record<string, { variant: BadgeVariant; label: string }> = {
   failed: { variant: 'destructive', label: 'failed' },
   running: { variant: 'secondary', label: 'rendering' },
   queued: { variant: 'outline', label: 'queued' },

--- a/src/review/dashboard-card.tsx
+++ b/src/review/dashboard-card.tsx
@@ -3,17 +3,24 @@ import { type ReactNode, useState } from 'react'
 import { toast } from 'sonner'
 import { useMounted } from '@/lib/use-mounted'
 import {
+  type BadgeVariant,
+  badgeFor,
   CardActions,
+  CredentialFlagToggle,
   metaItems,
   NetworkHostList,
   SubmissionDetails,
   titleFor,
 } from '@/review/dashboard-card-parts'
+
+export { StatusSummary } from '@/review/dashboard-card-parts'
+
 import {
   approveVersionFn,
   rejectVersionFn,
   requeueRenderJobFn,
   runNetworkPreviewFn,
+  setReadsClaudeTokenFn,
 } from '@/review/decide'
 import type { DashboardRow } from '@/review/queue'
 import { Badge } from '@/ui/badge'
@@ -23,23 +30,6 @@ import { Notice } from '@/ui/notice'
 import { SectionCard } from '@/ui/section-card'
 import { StatuslinePreview } from '@/ui/statusline-preview'
 import { Text } from '@/ui/text'
-
-type RenderStatus = DashboardRow['renderJob']['status']
-type BadgeVariant = 'secondary' | 'destructive' | 'outline' | 'primaryOutline'
-
-// Render status → badge look + label. Failed is loud (destructive); ready gets a coral *outline*
-// (not a coral fill — that reads as a clickable button) to draw the eye to the actionable row.
-const RENDER_BADGE: Record<string, { variant: BadgeVariant; label: string }> = {
-  failed: { variant: 'destructive', label: 'failed' },
-  running: { variant: 'secondary', label: 'rendering' },
-  queued: { variant: 'outline', label: 'queued' },
-  done: { variant: 'primaryOutline', label: 'ready' },
-  held: { variant: 'outline', label: 'needs network review' },
-}
-
-function badgeFor(status: RenderStatus): { variant: BadgeVariant; label: string } {
-  return RENDER_BADGE[status] ?? { variant: 'outline', label: status }
-}
 
 function waitedSince(date: Date): string {
   const mins = Math.max(0, Math.floor((Date.now() - new Date(date).getTime()) / 60000))
@@ -115,25 +105,6 @@ function cardView(row: DashboardRow, statusMode: 'render' | 'review'): CardView 
   return { ...badgeFor(row.renderJob.status), headline: statusHeadline(row.renderJob) }
 }
 
-export function StatusSummary({ rows }: { rows: DashboardRow[] }) {
-  const counts = rows.reduce<Record<string, number>>((acc, r) => {
-    acc[r.renderJob.status] = (acc[r.renderJob.status] ?? 0) + 1
-    return acc
-  }, {})
-  const order: RenderStatus[] = ['held', 'failed', 'running', 'queued', 'done']
-  return (
-    <Row gap={2}>
-      {order
-        .filter((s) => counts[s])
-        .map((s) => (
-          <Badge key={s} variant={badgeFor(s).variant}>
-            {counts[s]} {badgeFor(s).label}
-          </Badge>
-        ))}
-    </Row>
-  )
-}
-
 export function SubmissionCard({
   row,
   showActions = true,
@@ -196,6 +167,12 @@ export function SubmissionCard({
       "Network preview queued — it'll render with the declared hosts.",
       'Could not start the network preview.',
     )
+  const setCredentialFlag = (value: boolean) =>
+    run(
+      () => setReadsClaudeTokenFn({ data: { versionId: version.id, value } }),
+      value ? 'Flagged as reading the auth token.' : 'Cleared the auth-token flag.',
+      'Could not update the auth-token flag.',
+    )
 
   return (
     <SectionCard interactive={linked} title={titleFor(config, detailSlug)}>
@@ -226,15 +203,22 @@ export function SubmissionCard({
         />
 
         {showActions ? (
-          <CardActions
-            isHeld={isHeld}
-            isReady={isReady}
-            pending={pending}
-            onApprove={approve}
-            onReject={reject}
-            onRequeue={requeue}
-            onRunNetworkPreview={runNetworkPreview}
-          />
+          <Stack gap={3}>
+            <CredentialFlagToggle
+              value={version.readsClaudeToken}
+              pending={pending}
+              onChange={setCredentialFlag}
+            />
+            <CardActions
+              isHeld={isHeld}
+              isReady={isReady}
+              pending={pending}
+              onApprove={approve}
+              onReject={reject}
+              onRequeue={requeue}
+              onRunNetworkPreview={runNetworkPreview}
+            />
+          </Stack>
         ) : null}
       </Stack>
     </SectionCard>

--- a/src/review/dashboard-card.tsx
+++ b/src/review/dashboard-card.tsx
@@ -206,6 +206,7 @@ export function SubmissionCard({
         {showActions ? (
           <Stack gap={3}>
             <CredentialFlagToggle
+              htmlId={`reads-claude-token-${version.id}`}
               value={version.readsClaudeToken}
               pending={pending}
               onChange={setCredentialFlag}

--- a/src/review/dashboard-card.tsx
+++ b/src/review/dashboard-card.tsx
@@ -13,8 +13,6 @@ import {
   titleFor,
 } from '@/review/dashboard-card-parts'
 
-export { StatusSummary } from '@/review/dashboard-card-parts'
-
 import {
   approveVersionFn,
   rejectVersionFn,
@@ -23,6 +21,9 @@ import {
   setReadsClaudeTokenFn,
 } from '@/review/decide'
 import type { DashboardRow } from '@/review/queue'
+
+export { StatusSummary } from '@/review/dashboard-card-parts'
+
 import { Badge } from '@/ui/badge'
 import { Row, Stack } from '@/ui/layout'
 import { MetaList } from '@/ui/meta-list'

--- a/src/review/decide.ts
+++ b/src/review/decide.ts
@@ -50,6 +50,21 @@ export async function rejectVersion(
   if (!row) throw new HttpError(409, 'version not in a reviewable (pending) state')
 }
 
+/** Admin disclosure override: set whether a version is flagged as reading the Claude token. */
+export async function setReadsClaudeToken(
+  database: Db,
+  versionId: string,
+  value: boolean,
+  reviewerId: string,
+): Promise<void> {
+  const [row] = await database
+    .update(configVersions)
+    .set({ readsClaudeToken: value, reviewedBy: reviewerId, reviewedAt: new Date() })
+    .where(eq(configVersions.id, versionId))
+    .returning()
+  if (!row) throw new HttpError(404, 'version not found')
+}
+
 /** Re-attempt a render: reset the version's render job to 'queued'. Only a FAILED job may be
  * re-queued — never a 'held' network job (that's runNetworkPreview's job alone), never a still
  * 'queued'/'running' one, and never a 'done' one (already rendered). Clears error + attempts. */
@@ -99,6 +114,15 @@ export const rejectVersionFn = createServerFn({ method: 'POST' })
         event: 'statusline_rejected',
         properties: { versionId: data.versionId },
       })
+    }),
+  )
+
+export const setReadsClaudeTokenFn = createServerFn({ method: 'POST' })
+  .inputValidator((d: { versionId: string; value: boolean }) => d)
+  .handler(({ data }) =>
+    withHttpStatus(async () => {
+      const admin = await assertAdmin(getRequestHeaders())
+      await setReadsClaudeToken(db, data.versionId, data.value, admin.id)
     }),
   )
 

--- a/src/review/queue.ts
+++ b/src/review/queue.ts
@@ -36,6 +36,7 @@ export interface DashboardRow {
     status: string
     createdAt: Date
     networkHosts: string[]
+    readsClaudeToken: boolean
   }
   renderJob: {
     status: string
@@ -91,6 +92,7 @@ async function mapRow(database: Db, r: RawRow): Promise<DashboardRow> {
       status: r.version.status,
       createdAt: r.version.createdAt,
       networkHosts: r.version.networkHosts ?? [],
+      readsClaudeToken: r.version.readsClaudeToken ?? false,
     },
     renderJob: {
       status: r.job.status,

--- a/src/routes/c.$slug.tsx
+++ b/src/routes/c.$slug.tsx
@@ -89,7 +89,11 @@ function ConfigDetail() {
                 signedIn={!!user}
               />
             </Row>
-            <ConfigBadges interpreter={detail.interpreter} networkHosts={detail.networkHosts} />
+            <ConfigBadges
+              interpreter={detail.interpreter}
+              networkHosts={detail.networkHosts}
+              readsClaudeToken={detail.readsClaudeToken}
+            />
           </Row>
 
           {(detail.author || detail.description) && (

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -98,7 +98,11 @@ function Home() {
                       ⇧ {card.upvoteCount}
                     </Text>
                   </Row>
-                  <ConfigBadges interpreter={card.interpreter} networkHosts={card.networkHosts} />
+                  <ConfigBadges
+                    interpreter={card.interpreter}
+                    networkHosts={card.networkHosts}
+                    readsClaudeToken={card.readsClaudeToken}
+                  />
                 </Row>
               </CardHeader>
               <CardContent>

--- a/src/submit/credential-access.ts
+++ b/src/submit/credential-access.ts
@@ -1,0 +1,39 @@
+/**
+ * Credential-access policy for submitted statusline scripts.
+ *
+ * Reading the Claude Code auth token has a legitimate status-line purpose (plan usage), so we
+ * allow it and disclose it with a badge (`readsClaudeToken`). Reading any OTHER credential —
+ * SSH keys, AWS, .netrc, .npmrc, gcloud, or a non-Claude secret-store entry — has no legitimate
+ * status-line purpose, so `detectForeignCredentialAccess` flags it and submit rejects it, the
+ * same way `detectObfuscation` rejects.
+ *
+ * Pre-filter only — NOT a security guarantee. Human review is the real gate, and the published
+ * script runs unsandboxed on the adopter's machine where a regex enforces nothing.
+ */
+
+/** The Claude Code auth token specifically — allowed, and badged. */
+const CLAUDE_TOKEN =
+  /Claude Code-credentials|claudeAiOauth|\.claude\/credentials|claude-code\/credentials/i
+
+/** Other on-disk credential files — no legitimate status-line use → reject. */
+const FOREIGN_CRED_FILE =
+  /\bid_rsa\b|\bid_ed25519\b|\bid_ecdsa\b|\bid_dsa\b|\.aws\/credentials|\bnetrc\b|\bnpmrc\b|\.config\/gcloud/i
+
+/** Any OS secret-store read (macOS Keychain / libsecret / Python keyring). */
+const SECRET_STORE = /find-(?:generic|internet)-password|\bsecret-tool\b|\bkeyring\b/i
+
+/** Reasons a submission must be REJECTED because it reads a NON-Claude credential. */
+export function detectForeignCredentialAccess(source: string): string[] {
+  const reasons: string[] = []
+  if (FOREIGN_CRED_FILE.test(source))
+    reasons.push('Reads a non-Claude credential file (SSH key, ~/.aws, .netrc, .npmrc, gcloud)')
+  // A secret-store read is foreign UNLESS it targets the Claude Code keychain service.
+  if (SECRET_STORE.test(source) && !/Claude Code-credentials/.test(source))
+    reasons.push('Reads a non-Claude secret-store entry (Keychain / libsecret / keyring)')
+  return reasons
+}
+
+/** Whether the script reads the Claude Code auth token (drives the disclosure badge). */
+export function readsClaudeToken(source: string): boolean {
+  return CLAUDE_TOKEN.test(source)
+}

--- a/src/submit/submit.ts
+++ b/src/submit/submit.ts
@@ -5,6 +5,7 @@ import { configs, configVersions, renderJobs } from '@/db/schema'
 import { tryHighlightSource } from '@/lib/highlight'
 import { HttpError } from '@/lib/http'
 import { INTERPRETERS, type Interpreter } from '@/render/types'
+import { detectForeignCredentialAccess, readsClaudeToken } from './credential-access'
 import { validateNetworkHosts } from './network-hosts'
 import { detectObfuscation } from './obfuscation'
 import { slugify } from './slug'
@@ -79,6 +80,14 @@ export async function submitConfig(db: Db, input: SubmitInput): Promise<SubmitRe
     )
   }
 
+  const foreignCredentials = detectForeignCredentialAccess(input.source)
+  if (foreignCredentials.length > 0) {
+    throw new HttpError(
+      400,
+      `Submission reads non-Claude credentials: ${foreignCredentials.join('; ')}`,
+    )
+  }
+
   const networkHosts = input.networkHosts ?? []
 
   const windowStart = new Date(Date.now() - RATE_WINDOW_MS).toISOString()
@@ -114,6 +123,7 @@ export async function submitConfig(db: Db, input: SubmitInput): Promise<SubmitRe
 
   const slug = `${slugify(input.title)}-${randomUUID().slice(0, 8)}`
   const contentSha256 = createHash('sha256').update(input.source).digest('hex')
+  const readsToken = readsClaudeToken(input.source)
   // Highlight once now (best-effort) so the detail page reads stored HTML instead of running Shiki
   // on every render. The source is immutable for this version, so the stored HTML never goes stale.
   const sourceHtml = await tryHighlightSource(input.source, input.interpreter)
@@ -142,6 +152,7 @@ export async function submitConfig(db: Db, input: SubmitInput): Promise<SubmitRe
         sourceHtml,
         status: 'pending',
         networkHosts,
+        readsClaudeToken: readsToken,
       })
       .returning()
     const ver = verRows[0]

--- a/src/ui/config-badges.tsx
+++ b/src/ui/config-badges.tsx
@@ -12,9 +12,10 @@ const INTERPRETER_ICON: Record<string, React.ComponentType> = {
   python: Braces,
 }
 
-/** The chip pair shown in the top-right of a gallery card and the detail page:
- *  the interpreter (always) and a `network` chip when the config declares hosts.
- *  Both chips share the one style; the network chip carries a tooltip listing the
+/** The chips shown in the top-right of a gallery card and the detail page:
+ *  the interpreter (always), a `network` chip when the config declares hosts,
+ *  and an `auth token` chip when the config reads the Claude Code auth token.
+ *  All chips share the one style; the network chip carries a tooltip listing the
  *  domains it may reach. Rendered once here so both surfaces stay identical. */
 export function ConfigBadges({
   interpreter,

--- a/src/ui/config-badges.tsx
+++ b/src/ui/config-badges.tsx
@@ -1,4 +1,4 @@
-import { Braces, Code, Globe, Hexagon, Terminal } from 'lucide-react'
+import { Braces, Code, Globe, Hexagon, KeyRound, Terminal } from 'lucide-react'
 import type * as React from 'react'
 import { Badge } from '@/ui/badge'
 import { Row, Stack } from '@/ui/layout'
@@ -19,9 +19,11 @@ const INTERPRETER_ICON: Record<string, React.ComponentType> = {
 export function ConfigBadges({
   interpreter,
   networkHosts,
+  readsClaudeToken,
 }: {
   interpreter: string
   networkHosts: string[]
+  readsClaudeToken: boolean
 }): React.ReactElement {
   const InterpreterIcon = INTERPRETER_ICON[interpreter] ?? Code
   return (
@@ -53,6 +55,20 @@ export function ConfigBadges({
             <Badge variant="secondary">
               <Globe />
               network
+            </Badge>
+          </button>
+        </Tooltip>
+      ) : null}
+      {readsClaudeToken ? (
+        <Tooltip content={<Text size="xs">Reads your Claude Code auth token.</Text>}>
+          <button
+            type="button"
+            aria-label="Reads your Claude Code auth token"
+            className="relative z-10 inline-flex cursor-default rounded-4xl p-0 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          >
+            <Badge variant="secondary">
+              <KeyRound />
+              auth token
             </Badge>
           </button>
         </Tooltip>

--- a/src/ui/switch.tsx
+++ b/src/ui/switch.tsx
@@ -20,7 +20,7 @@ function Switch({ id, checked, disabled, onCheckedChange, ...aria }: SwitchProps
       onCheckedChange={(v) => onCheckedChange?.(v === true)}
       data-slot="switch"
       className={cn(
-        'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-4xl border border-transparent shadow-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring data-[state=checked]:bg-primary data-[state=unchecked]:bg-muted',
+        'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-4xl border border-transparent shadow-sm outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-muted',
       )}
       {...aria}
     >

--- a/src/ui/switch.tsx
+++ b/src/ui/switch.tsx
@@ -6,15 +6,17 @@ import { cn } from '@/lib/cn'
 interface SwitchProps {
   id?: string
   checked?: boolean
+  disabled?: boolean
   onCheckedChange?: (checked: boolean) => void
   'aria-label'?: string
 }
 
-function Switch({ id, checked, onCheckedChange, ...aria }: SwitchProps) {
+function Switch({ id, checked, disabled, onCheckedChange, ...aria }: SwitchProps) {
   return (
     <SwitchPrimitive.Root
       id={id}
       {...(checked !== undefined ? { checked } : {})}
+      disabled={disabled}
       onCheckedChange={(v) => onCheckedChange?.(v === true)}
       data-slot="switch"
       className={cn(

--- a/test/review/dashboard-card-toggle.test.tsx
+++ b/test/review/dashboard-card-toggle.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { DashboardRow } from '@/review/queue'
+
+// The card uses useRouter() to invalidate after an action; stub it.
+// Link needs a router context too — stub it to a plain anchor.
+vi.mock('@tanstack/react-router', async (orig) => ({
+  ...(await orig<typeof import('@tanstack/react-router')>()),
+  useRouter: () => ({ invalidate: vi.fn() }),
+  Link: ({
+    to,
+    params,
+    children,
+  }: {
+    to: string
+    params?: Record<string, string>
+    children: React.ReactNode
+  }) => <a href={params ? to.replace(/\$(\w+)/g, (_, k) => params[k] ?? '') : to}>{children}</a>,
+}))
+
+const toast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }))
+vi.mock('sonner', () => ({ toast }))
+
+const setReadsClaudeTokenFn = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+const approveVersionFn = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+const rejectVersionFn = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+const requeueRenderJobFn = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+const runNetworkPreviewFn = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+vi.mock('@/review/decide', () => ({
+  approveVersionFn,
+  rejectVersionFn,
+  requeueRenderJobFn,
+  runNetworkPreviewFn,
+  setReadsClaudeTokenFn,
+}))
+
+const { SubmissionCard } = await import('@/review/dashboard-card')
+
+function row(over: {
+  status: string
+  id?: string
+  error?: string | null
+  withPreview?: boolean
+  versionStatus?: string
+  networkHosts?: string[]
+  readsClaudeToken?: boolean
+}): DashboardRow {
+  return {
+    config: {
+      id: 'c1',
+      slug: 'my-line',
+      title: 'My line',
+      description: '',
+      interpreter: 'bash',
+      status: 'draft',
+      authorId: 'u1',
+      author: { name: 'Test User', username: 'test', image: null },
+      upvoteCount: 0,
+      copyCount: 0,
+      createdAt: new Date('2026-06-13T12:00:00Z'),
+    },
+    version: {
+      id: over.id ?? 'v1',
+      versionNumber: 1,
+      source: '#!/bin/bash\necho hi',
+      contentSha256: 'abc123def456',
+      status: over.versionStatus ?? 'pending',
+      createdAt: new Date('2026-06-13T12:00:00Z'),
+      networkHosts: over.networkHosts ?? [],
+      readsClaudeToken: over.readsClaudeToken ?? false,
+    },
+    renderJob: {
+      status: over.status,
+      attempts: over.status === 'failed' ? 2 : 0,
+      error: over.error ?? null,
+      createdAt: new Date('2026-06-13T12:00:00Z'),
+      finishedAt: over.status === 'done' ? new Date('2026-06-13T12:01:00Z') : null,
+    },
+    previews: over.withPreview
+      ? [
+          {
+            scenarioKey: 'clean-main',
+            segments: [
+              { text: 'hi', fg: null, bg: null, bold: false, italic: false, underline: false },
+            ],
+            rawStdout: 'hi',
+            exitCode: 0,
+            timedOut: false,
+            trace: { commands: [], network: [], files: [] } as never,
+          },
+        ]
+      : [],
+  }
+}
+
+describe('SubmissionCard credential toggle', () => {
+  it('clicking the switch calls setReadsClaudeTokenFn and shows a success toast', async () => {
+    render(<SubmissionCard row={row({ status: 'done', readsClaudeToken: false })} />)
+
+    const toggle = screen.getByRole('switch', { name: /reads the claude code auth token/i })
+    fireEvent.click(toggle)
+
+    await waitFor(() =>
+      expect(setReadsClaudeTokenFn).toHaveBeenCalledWith({
+        data: { versionId: 'v1', value: true },
+      }),
+    )
+    expect(toast.success).toHaveBeenCalledWith('Flagged as reading the auth token.')
+  })
+})

--- a/test/review/dashboard.test.tsx
+++ b/test/review/dashboard.test.tsx
@@ -22,6 +22,7 @@ const { SubmissionCard, StatusSummary } = await import('@/review/dashboard-card'
 
 function row(over: {
   status: string
+  id?: string
   error?: string | null
   withPreview?: boolean
   versionStatus?: string
@@ -43,7 +44,7 @@ function row(over: {
       createdAt: new Date('2026-06-13T12:00:00Z'),
     },
     version: {
-      id: 'v1',
+      id: over.id ?? 'v1',
       versionNumber: 1,
       source: '#!/bin/bash\necho hi',
       contentSha256: 'abc123def456',
@@ -236,6 +237,20 @@ describe('SubmissionCard', () => {
       <SubmissionCard row={row({ status: 'done' })} showActions={false} statusMode="review" />,
     )
     expect(html).not.toContain('Reads the Claude Code auth token')
+  })
+
+  it('two cards with different version ids get distinct auth-token toggle ids', () => {
+    const cardA = renderToStaticMarkup(
+      <SubmissionCard row={row({ status: 'done', id: 'v-aaa' })} />,
+    )
+    const cardB = renderToStaticMarkup(
+      <SubmissionCard row={row({ status: 'done', id: 'v-bbb' })} />,
+    )
+    // Each card must use a version-scoped id, not the bare shared string.
+    expect(cardA).toContain('reads-claude-token-v-aaa')
+    expect(cardB).toContain('reads-claude-token-v-bbb')
+    expect(cardA).not.toContain('id="reads-claude-token"')
+    expect(cardB).not.toContain('id="reads-claude-token"')
   })
 
   it('review mode labels by review outcome, not render step', () => {

--- a/test/review/dashboard.test.tsx
+++ b/test/review/dashboard.test.tsx
@@ -26,6 +26,7 @@ function row(over: {
   withPreview?: boolean
   versionStatus?: string
   networkHosts?: string[]
+  readsClaudeToken?: boolean
 }): DashboardRow {
   return {
     config: {
@@ -49,6 +50,7 @@ function row(over: {
       status: over.versionStatus ?? 'pending',
       createdAt: new Date('2026-06-13T12:00:00Z'),
       networkHosts: over.networkHosts ?? [],
+      readsClaudeToken: over.readsClaudeToken ?? false,
     },
     renderJob: {
       status: over.status,
@@ -220,6 +222,20 @@ describe('SubmissionCard', () => {
     expect(html).toContain('wttr.in')
     expect(html).toContain('*.espn.com')
     expect(html).toMatch(/run network preview/i)
+  })
+
+  it('admin card shows the Claude-token toggle', () => {
+    const html = renderToStaticMarkup(
+      <SubmissionCard row={row({ status: 'done', readsClaudeToken: true })} />,
+    )
+    expect(html).toContain('Reads the Claude Code auth token')
+  })
+
+  it('read-only (/me) card hides the toggle', () => {
+    const html = renderToStaticMarkup(
+      <SubmissionCard row={row({ status: 'done' })} showActions={false} statusMode="review" />,
+    )
+    expect(html).not.toContain('Reads the Claude Code auth token')
   })
 
   it('review mode labels by review outcome, not render step', () => {

--- a/test/review/decide.test.ts
+++ b/test/review/decide.test.ts
@@ -5,7 +5,13 @@ import { migrate } from 'drizzle-orm/pglite/migrator'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import * as schema from '@/db/schema'
 import { FakeSandboxRunner } from '@/render/fake-runner'
-import { approveVersion, rejectVersion, requeueRenderJob, runNetworkPreview } from '@/review/decide'
+import {
+  approveVersion,
+  rejectVersion,
+  requeueRenderJob,
+  runNetworkPreview,
+  setReadsClaudeToken,
+} from '@/review/decide'
 import { submitConfig } from '@/submit/submit'
 import { processNextRenderJob } from '@/submit/worker'
 
@@ -223,5 +229,18 @@ describe('requeueRenderJob held-job invariant', () => {
       .from(schema.renderJobs)
       .where(eq(schema.renderJobs.configVersionId, versionId))
     expect(job?.status).toBe('queued')
+  })
+})
+
+describe('setReadsClaudeToken', () => {
+  it('setReadsClaudeToken flips the stored flag', async () => {
+    const versionId = await seedVersionWithJob(db, { status: 'queued', networkHosts: [] })
+    await setReadsClaudeToken(db, versionId, true, 'u1')
+    const [ver] = await db
+      .select()
+      .from(schema.configVersions)
+      .where(eq(schema.configVersions.id, versionId))
+    expect(ver?.readsClaudeToken).toBe(true)
+    expect(ver?.reviewedBy).toBe('u1')
   })
 })

--- a/test/submit/credential-access.test.ts
+++ b/test/submit/credential-access.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { detectForeignCredentialAccess, readsClaudeToken } from '@/submit/credential-access'
+
+// keyblade's macOS keychain read is a Python LIST — note the `", "` between tokens, not a
+// space. This is the regression an earlier `security\s+find-...` regex missed.
+const KEYBLADE_SNIPPET = [
+  'r = subprocess.run(',
+  '    ["security", "find-generic-password", "-s", "Claude Code-credentials", "-w"],',
+  ')',
+  'token = creds.get("claudeAiOauth", {}).get("accessToken", "")',
+  'with open(os.path.expanduser("~/.claude/credentials.json")) as f:',
+  '    creds = json.load(f)',
+].join('\n')
+
+// Reading the transcript dir + token COUNTS is extremely common and must NOT trip anything.
+const CLEAN_TRANSCRIPT_READER =
+  'json=$(cat ~/.claude/projects/**/*.jsonl | tail -1)\n' +
+  'tokens_in=$(echo "$json" | jq -r \'.usage.input_tokens // 0\')'
+
+describe('detectForeignCredentialAccess', () => {
+  it('allows the keyblade Claude-token reader (no foreign credentials)', () => {
+    expect(detectForeignCredentialAccess(KEYBLADE_SNIPPET)).toEqual([])
+  })
+  it('allows a clean transcript + token-count reader', () => {
+    expect(detectForeignCredentialAccess(CLEAN_TRANSCRIPT_READER)).toEqual([])
+  })
+  it('rejects an SSH private-key read', () => {
+    expect(detectForeignCredentialAccess('open(os.path.expanduser("~/.ssh/id_rsa"))')).toHaveLength(
+      1,
+    )
+  })
+  it('rejects an ~/.npmrc read', () => {
+    expect(detectForeignCredentialAccess('cat ~/.npmrc')).toHaveLength(1)
+  })
+  it('rejects a non-Claude keychain read', () => {
+    expect(
+      detectForeignCredentialAccess('security find-generic-password -s "GitHub"'),
+    ).toHaveLength(1)
+  })
+})
+
+describe('readsClaudeToken', () => {
+  it('is true for the keyblade Claude-token reader', () => {
+    expect(readsClaudeToken(KEYBLADE_SNIPPET)).toBe(true)
+  })
+  it('is false for a clean transcript reader (.claude/projects, not credentials)', () => {
+    expect(readsClaudeToken(CLEAN_TRANSCRIPT_READER)).toBe(false)
+  })
+  it('is false for a plain bash+jq statusline', () => {
+    expect(readsClaudeToken("jq -r '.model.display_name'")).toBe(false)
+  })
+})

--- a/test/submit/submit.test.ts
+++ b/test/submit/submit.test.ts
@@ -170,6 +170,33 @@ describe('submitConfig', () => {
     expect(rows).toHaveLength(0)
   })
 
+  it('rejects a submission that reads a non-Claude credential', async () => {
+    await expect(submitConfig(db, { ...input, source: 'cat ~/.ssh/id_rsa' })).rejects.toThrow(
+      /non-Claude credentials/i,
+    )
+  })
+
+  it('stores readsClaudeToken=true when the script reads the Claude token', async () => {
+    const res = await submitConfig(db, {
+      ...input,
+      source: 'open(os.path.expanduser("~/.claude/credentials.json"))',
+    })
+    const [ver] = await db
+      .select()
+      .from(schema.configVersions)
+      .where(eq(schema.configVersions.id, res.versionId))
+    expect(ver?.readsClaudeToken).toBe(true)
+  })
+
+  it('stores readsClaudeToken=false for a plain statusline', async () => {
+    const res = await submitConfig(db, input) // base input is a plain `echo hi`
+    const [ver] = await db
+      .select()
+      .from(schema.configVersions)
+      .where(eq(schema.configVersions.id, res.versionId))
+    expect(ver?.readsClaudeToken).toBe(false)
+  })
+
   it('gives each submission a unique slug', async () => {
     const a = await submitConfig(db, input)
     const b = await submitConfig(db, input)

--- a/test/ui/config-badges.test.tsx
+++ b/test/ui/config-badges.test.tsx
@@ -7,10 +7,14 @@ import { TooltipProvider } from '@/ui/tooltip'
 
 // The network chip's tooltip relies on a TooltipProvider ancestor (mounted once in
 // shell.tsx for the real app); wrap renders the same way here.
-const renderBadges = (props: { interpreter: string; networkHosts: string[] }) =>
+const renderBadges = (props: {
+  interpreter: string
+  networkHosts: string[]
+  readsClaudeToken?: boolean
+}) =>
   render(
     <TooltipProvider>
-      <ConfigBadges {...props} />
+      <ConfigBadges readsClaudeToken={false} {...props} />
     </TooltipProvider>,
   )
 
@@ -36,5 +40,15 @@ describe('ConfigBadges', () => {
   it('omits the network chip when no hosts are declared', () => {
     renderBadges({ interpreter: 'bash', networkHosts: [] })
     expect(screen.queryByText('network')).toBeNull()
+  })
+
+  it('renders the auth-token chip when readsClaudeToken is true', () => {
+    renderBadges({ interpreter: 'python', networkHosts: [], readsClaudeToken: true })
+    expect(screen.getByText('auth token')).toBeTruthy()
+  })
+
+  it('omits the auth-token chip when readsClaudeToken is false', () => {
+    renderBadges({ interpreter: 'bash', networkHosts: [], readsClaudeToken: false })
+    expect(screen.queryByText('auth token')).toBeNull()
   })
 })


### PR DESCRIPTION
## What

Submitted Claude Code status-line scripts run unsandboxed on the adopter's machine, so reading a secret off disk is a real risk. This adds a credential-access policy:

- **Allow** reading the Claude Code auth token — it has a legitimate status-line use (plan/usage bars). Disclose it with an **"auth token" badge** on the gallery.
- **Reject at submit** any script that reads any *other* credential (SSH keys, `~/.aws`, `.netrc`, `.npmrc`, gcloud, non-Claude secret-store entries) — a hard reject, like the obfuscation check.

This is a best-effort text prefilter plus human review (the real gate), not a runtime guarantee — the published script is unsandboxed on the adopter's machine.

## How it flows

`src/submit/credential-access.ts` answers two questions about a script's source — "reads a non-Claude credential?" (→ reject) and "reads the Claude token?" (→ store a per-version `reads_claude_token` boolean). That flag flows: submit insert → gallery card + detail queries → the badge component, and → the review-queue card, where an admin can override it. The reject path stores nothing.

## Changes

- `src/submit/credential-access.ts` — `detectForeignCredentialAccess` (reject reasons) + `readsClaudeToken` (badge flag), mirrors `obfuscation.ts`
- `config_versions.reads_claude_token` boolean column + migration `0014`
- `submit.ts` — hard-reject foreign-credential reads, store the Claude-token flag
- `decide.ts` — admin-only `setReadsClaudeToken` override + server fn
- gallery queries carry the flag to both card + detail shapes
- `config-badges.tsx` — "auth token" disclosure chip (KeyRound), shown when the flag is set
- review-queue card — admin toggle for the flag (unique per-card DOM id)

## Notes

- The foreign-credential reject is **not** overridable (matches obfuscation); only the disclosure badge is.
- Follow-ups (not in this PR): widen the foreign-credential list to include `~/.git-credentials`; flip keyblade's existing pending version to `reads_claude_token = true`; tune the `id_rsa.pub` false-reject edge.
