### PR TITLE
feat(seo): home title/H1 keywords, meta description, OG image dimensions

### DIFF
--- a/src/og/dimensions.ts
+++ b/src/og/dimensions.ts
@@ -1,0 +1,8 @@
+/**
+ * OG card pixel size — the single source for both the image renderer (`render.ts`) and the
+ * `og:image:width/height` meta (`meta.ts`). Kept in its own dependency-free module so the
+ * client-reachable `meta.ts` can import the numbers without dragging resvg/satori (server-only
+ * native deps in `render.ts`) into the client bundle.
+ */
+export const CARD_WIDTH = 1200
+export const CARD_HEIGHT = 630

--- a/src/og/meta.ts
+++ b/src/og/meta.ts
@@ -1,5 +1,5 @@
 import { siteUrl } from '@/lib/site'
-import { CARD_HEIGHT, CARD_WIDTH } from '@/og/render'
+import { CARD_HEIGHT, CARD_WIDTH } from '@/og/dimensions'
 
 export function rootSocialMeta(): Array<Record<string, string>> {
   const base = siteUrl()

--- a/src/og/meta.ts
+++ b/src/og/meta.ts
@@ -1,4 +1,5 @@
 import { siteUrl } from '@/lib/site'
+import { CARD_HEIGHT, CARD_WIDTH } from '@/og/render'
 
 export function rootSocialMeta(): Array<Record<string, string>> {
   const base = siteUrl()
@@ -13,6 +14,8 @@ export function rootSocialMeta(): Array<Record<string, string>> {
     { property: 'og:title', content: 'statuslin.es' },
     { property: 'og:description', content: 'A community gallery of Claude Code status lines.' },
     { property: 'og:image', content: `${base}/og/home.png` },
+    { property: 'og:image:width', content: String(CARD_WIDTH) },
+    { property: 'og:image:height', content: String(CARD_HEIGHT) },
     { name: 'twitter:card', content: 'summary_large_image' },
     { name: 'twitter:image', content: `${base}/og/home.png` },
   ]
@@ -32,6 +35,8 @@ export function configSocialMeta(input: {
       content: input.description || 'A reviewed Claude Code status line.',
     },
     { property: 'og:image', content: image },
+    { property: 'og:image:width', content: String(CARD_WIDTH) },
+    { property: 'og:image:height', content: String(CARD_HEIGHT) },
     { name: 'twitter:image', content: image },
   ]
 }

--- a/src/og/render.ts
+++ b/src/og/render.ts
@@ -3,8 +3,8 @@ import type { ReactElement } from 'react'
 import satori from 'satori'
 import { loadEmojiAsset, loadOgFonts } from '@/og/font'
 
-const CARD_WIDTH = 1200
-const CARD_HEIGHT = 630
+export const CARD_WIDTH = 1200
+export const CARD_HEIGHT = 630
 
 /** satori(element) -> SVG, then resvg -> PNG. resvg needs no fonts: satori embeds text as vector
  * paths, so resvg only rasterizes finished shapes. */

--- a/src/og/render.ts
+++ b/src/og/render.ts
@@ -1,10 +1,8 @@
 import { Resvg } from '@resvg/resvg-js'
 import type { ReactElement } from 'react'
 import satori from 'satori'
+import { CARD_HEIGHT, CARD_WIDTH } from '@/og/dimensions'
 import { loadEmojiAsset, loadOgFonts } from '@/og/font'
-
-export const CARD_WIDTH = 1200
-export const CARD_HEIGHT = 630
 
 /** satori(element) -> SVG, then resvg -> PNG. resvg needs no fonts: satori embeds text as vector
  * paths, so resvg only rasterizes finished shapes. */

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -15,6 +15,7 @@ import { StatuslinePreview } from '@/ui/statusline-preview'
 import { StretchedLink } from '@/ui/stretched-link'
 import { SubmitCta } from '@/ui/submit-cta'
 import { Text } from '@/ui/text'
+import { VisuallyHidden } from '@/ui/visually-hidden'
 
 export const Route = createFileRoute('/')({
   // sort + page are optional in the URL (defaults: 'new', page 1), so Links to "/" can omit them.
@@ -30,10 +31,11 @@ export const Route = createFileRoute('/')({
   }),
   head: () => ({
     meta: [
-      { title: 'statuslin.es' },
+      { title: 'Claude Code Status Lines — Community Gallery | statuslin.es' },
       {
         name: 'description',
-        content: 'The Claude Code status line catalogue',
+        content:
+          'Browse a community gallery of Claude Code status lines — see rendered previews, upvote your favorites, and copy one into your own terminal in a single paste.',
       },
     ],
     links: [canonicalLink('/')],
@@ -62,6 +64,7 @@ function Home() {
           custom config for others, or find one you like and use it for yourself.
         </Text>
         <Stack gap={4}>
+          <VisuallyHidden as="h2">Status lines</VisuallyHidden>
           <Row gap={4} justify="between" wrap>
             <Row gap={1}>
               {SORT_TABS.map((tab) => (

--- a/src/ui/home-hero.tsx
+++ b/src/ui/home-hero.tsx
@@ -1,14 +1,15 @@
+import { VisuallyHidden } from '@/ui/visually-hidden'
 import { Wordmark } from '@/ui/wordmark'
 
 /**
  * Home-page hero: the shared statuslin.es wordmark at hero size, centered, with the terminal block
- * cursor after it. Same wordmark (coral dot) as the app header — just larger. The h1 keeps the mono
- * family + 5xl size so the cursor matches the wordmark; the wordmark also sets its own.
+ * cursor after it. The visible text is unchanged; a screen-reader-only phrase adds the target
+ * keyword so the h1 reads "statuslin.es Claude Code status lines" to crawlers and assistive tech.
  */
 export function HomeHero() {
   return (
     <h1 className="text-center font-mono text-[clamp(1.5rem,10vw,3rem)] text-foreground">
-      <Wordmark size="hero" />▒
+      <Wordmark size="hero" />▒<VisuallyHidden>Claude Code status lines</VisuallyHidden>
     </h1>
   )
 }

--- a/src/ui/visually-hidden.tsx
+++ b/src/ui/visually-hidden.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react'
+
+/**
+ * Renders text that's available to screen readers and crawlers but invisible on screen
+ * (Tailwind's `sr-only`). Lets routes add keyword/heading text without a raw `className`
+ * (which the frontend boundary rule forbids outside `src/ui`). `as` is intentionally narrow —
+ * only the tags used today.
+ */
+export function VisuallyHidden({
+  as: Tag = 'span',
+  children,
+}: {
+  as?: 'span' | 'h2'
+  children: ReactNode
+}) {
+  return <Tag className="sr-only">{children}</Tag>
+}

--- a/test/og/meta.test.ts
+++ b/test/og/meta.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { configSocialMeta, rootSocialMeta } from '@/og/meta'
+import { CARD_HEIGHT, CARD_WIDTH } from '@/og/render'
 
 const ORIGINAL = process.env.BETTER_AUTH_URL
 afterEach(() => {
@@ -25,5 +26,17 @@ describe('social meta', () => {
       content: 'https://statuslin.es/og/c/my-line.png',
     })
     expect(meta.find((m) => m.property === 'og:title')?.content).toBe('My Line — statuslin.es')
+  })
+  it('root declares the og:image dimensions from the render constants', () => {
+    process.env.BETTER_AUTH_URL = 'https://statuslin.es'
+    const meta = rootSocialMeta()
+    expect(meta).toContainEqual({ property: 'og:image:width', content: String(CARD_WIDTH) })
+    expect(meta).toContainEqual({ property: 'og:image:height', content: String(CARD_HEIGHT) })
+  })
+  it('config declares the og:image dimensions from the render constants', () => {
+    process.env.BETTER_AUTH_URL = 'https://statuslin.es'
+    const meta = configSocialMeta({ slug: 'my-line', title: 'My Line', description: 'hi' })
+    expect(meta).toContainEqual({ property: 'og:image:width', content: String(CARD_WIDTH) })
+    expect(meta).toContainEqual({ property: 'og:image:height', content: String(CARD_HEIGHT) })
   })
 })

--- a/test/og/meta.test.ts
+++ b/test/og/meta.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
+import { CARD_HEIGHT, CARD_WIDTH } from '@/og/dimensions'
 import { configSocialMeta, rootSocialMeta } from '@/og/meta'
-import { CARD_HEIGHT, CARD_WIDTH } from '@/og/render'
 
 const ORIGINAL = process.env.BETTER_AUTH_URL
 afterEach(() => {

--- a/test/ui/home-hero.test.tsx
+++ b/test/ui/home-hero.test.tsx
@@ -11,4 +11,20 @@ describe('HomeHero', () => {
     expect(dot?.textContent).toBe('.')
     expect(dot?.className).toContain('text-primary')
   })
+
+  it('renders an h1 that still shows the wordmark and adds the keyword for crawlers', () => {
+    const { container } = render(<HomeHero />)
+    const h1 = container.querySelector('h1')
+    expect(h1).not.toBeNull()
+    // Visible wordmark is preserved...
+    expect(h1?.textContent).toContain('statuslin.es')
+    // ...and the keyword phrase is present in the heading's text.
+    expect(h1?.textContent).toContain('Claude Code status lines')
+  })
+
+  it('keeps the keyword phrase in an sr-only element', () => {
+    const { container } = render(<HomeHero />)
+    const srOnly = container.querySelector('.sr-only')
+    expect(srOnly?.textContent).toBe('Claude Code status lines')
+  })
 })

--- a/test/ui/visually-hidden.test.tsx
+++ b/test/ui/visually-hidden.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { VisuallyHidden } from '@/ui/visually-hidden'
+
+describe('VisuallyHidden', () => {
+  it('renders a span with the sr-only class by default', () => {
+    const { container } = render(<VisuallyHidden>Claude Code status lines</VisuallyHidden>)
+    const el = container.firstChild as HTMLElement
+    expect(el.tagName).toBe('SPAN')
+    expect(el.textContent).toBe('Claude Code status lines')
+    expect(el.className).toContain('sr-only')
+  })
+
+  it('renders the requested tag when `as` is set', () => {
+    const { container } = render(<VisuallyHidden as="h2">Status lines</VisuallyHidden>)
+    const el = container.firstChild as HTMLElement
+    expect(el.tagName).toBe('H2')
+    expect(el.textContent).toBe('Status lines')
+    expect(el.className).toContain('sr-only')
+  })
+})


### PR DESCRIPTION
## Summary
- Puts the target keyword into the home page's two heaviest on-page signals — the `<title>` and the `<h1>` — which were previously brand-only (`statuslin.es`). No visible layout change: the keyword and the new H2 are screen-reader-only, the wordmark hero is untouched.
- Also improves the home meta description and declares OG image dimensions.
- From the 2026-07-01 SEO audit (findings #1 title/H1, #5 heading outline, #7 OG dimensions).

## Changes
- **Title**: `statuslin.es` → `Claude Code Status Lines — Community Gallery | statuslin.es`.
- **Meta description**: rewritten from 37 chars to a keyword-rich ~150-char sentence.
- **H1 keyword**: keeps the visible wordmark + cursor; appends a screen-reader-only `Claude Code status lines`, so crawlers and assistive tech read the keyword while sighted users see no change.
- **`VisuallyHidden` component** (new, `src/ui`): a closed component that renders `sr-only` text, so routes can add hidden text/headings without a raw `className` (frontend boundary rule).
- **Heading outline**: adds an sr-only `<h2>Status lines</h2>` above the gallery grid, so the outline is H1 → H2 → H3 instead of skipping.
- **OG image dimensions**: `og:image:width`/`height` (1200×630) on both the home and per-config social cards, sourced from a new dependency-free `src/og/dimensions.ts`.

The `fix` commit matters: importing the card-size constants from `og/render.ts` (which pulls in the `@resvg/resvg-js` native module + `satori`) into the client-reachable `og/meta.ts` broke the client `vite build`. Moving the two constants to `src/og/dimensions.ts` keeps those server-only deps out of the client bundle.

## Verified
- Full gate `bun run check`: 638 passed | 7 skipped.
- `bun --bun vite build`: exit 0; resvg appears only in the server/nitro build, not the client.
- Served SSR HTML confirmed to contain the new title, description, OG dimensions, sr-only H2, and sr-only H1 keyword.
- Real-browser `getComputedStyle` on the H1 sr-only span: `position: absolute`, `clip-path: inset(50%)`, 1×1px — genuinely hidden; visible H1 text stays `statuslin.es▒`.

## Follow-up (separate)
`bun run check` does not run `vite build`, so the client-bundle break above was invisible to the gate and only caught by manual review. Worth adding a `vite build` step to CI (or a lint/boundary rule flagging client-reachable imports of the server-only `@/og/render`).