### PR TITLE
feat(seo): Phase 1 quick wins — keyword titles, internal links, JSON-LD

### DIFF
--- a/src/gallery/functions.ts
+++ b/src/gallery/functions.ts
@@ -13,6 +13,7 @@ import {
   getPublishedConfigs,
   getPublishedCount,
   getPublishedSlugsForSitemap,
+  getRelatedConfigs,
   PAGE_SIZE,
 } from './queries'
 
@@ -57,9 +58,11 @@ export const getConfigDetail = createServerFn({ method: 'GET' })
       // versions without it. Either way the browser gets escaped HTML, never Shiki itself.
       // resolveSourceHtml always returns a string, so this overrides the nullable ConfigDetail
       // .sourceHtml with a non-null value — the detail page can render it directly.
+      const related = await getRelatedConfigs(db, data.slug)
       return {
         ...detail,
         sourceHtml: await resolveSourceHtml(detail.sourceHtml, detail.source, detail.interpreter),
+        related,
       }
     }),
   )

--- a/src/gallery/queries.ts
+++ b/src/gallery/queries.ts
@@ -225,6 +225,7 @@ export async function getConfigBySlug(
   }
 }
 
-// Re-export from related.ts for backward compatibility (queries and related routes both expect these here)
+// Re-exported so @/gallery/queries stays the single import surface for gallery
+// queries (related.ts exists only to respect the 250-line file gate).
 export type { RelatedConfig } from './related'
 export { getRelatedConfigs, RELATED_LIMIT } from './related'

--- a/src/gallery/queries.ts
+++ b/src/gallery/queries.ts
@@ -142,7 +142,10 @@ export async function getPublishedConfigs(
  * script hashes in a single query, returning a sha → segments map. Replaces the per-card lookup
  * that made the gallery an N+1; selects only `segments` since that's all the card renders.
  */
-async function selectCardPreviews(db: Db, shas: string[]): Promise<Map<string, AnsiSegment[]>> {
+export async function selectCardPreviews(
+  db: Db,
+  shas: string[],
+): Promise<Map<string, AnsiSegment[]>> {
   const bySha = new Map<string, AnsiSegment[]>()
   if (shas.length === 0) return bySha
   const rows = await db
@@ -221,3 +224,7 @@ export async function getConfigBySlug(
     previews,
   }
 }
+
+// Re-export from related.ts for backward compatibility (queries and related routes both expect these here)
+export type { RelatedConfig } from './related'
+export { getRelatedConfigs, RELATED_LIMIT } from './related'

--- a/src/gallery/related.ts
+++ b/src/gallery/related.ts
@@ -1,0 +1,51 @@
+import { and, desc, eq, ne } from 'drizzle-orm'
+import type { PgDatabase } from 'drizzle-orm/pg-core'
+import { configs, configVersions } from '@/db/schema'
+import type { AnsiSegment, Interpreter } from '@/render/types'
+import { coerceInterpreter, selectCardPreviews } from './queries'
+
+// biome-ignore lint/suspicious/noExplicitAny: db type varies by driver (postgres-js/pglite); query surface identical.
+type Db = PgDatabase<any, typeof import('@/db/schema')>
+
+export interface RelatedConfig {
+  slug: string
+  title: string
+  interpreter: Interpreter
+  upvoteCount: number
+  preview: AnsiSegment[] | null
+}
+
+/** How many other configs a config page links to in "More status lines". */
+export const RELATED_LIMIT = 6
+
+/**
+ * Other published configs for the "More status lines" section on a config page —
+ * top-voted first (ties broken by newest), excluding the config being viewed.
+ * Exists for internal linking: without it every config page is a crawl dead end.
+ */
+export async function getRelatedConfigs(
+  db: Db,
+  slug: string,
+  limit = RELATED_LIMIT,
+): Promise<RelatedConfig[]> {
+  const rows = await db
+    .select({ config: configs, version: configVersions })
+    .from(configs)
+    .innerJoin(configVersions, eq(configVersions.id, configs.currentVersionId))
+    .where(and(eq(configs.status, 'published'), ne(configs.slug, slug)))
+    .orderBy(desc(configs.upvoteCount), desc(configs.createdAt))
+    .limit(limit)
+
+  const cardPreviews = await selectCardPreviews(
+    db,
+    rows.map((r) => r.version.contentSha256),
+  )
+
+  return rows.map((r) => ({
+    slug: r.config.slug,
+    title: r.config.title,
+    interpreter: coerceInterpreter(r.config.interpreter),
+    upvoteCount: r.config.upvoteCount,
+    preview: cardPreviews.get(r.version.contentSha256) ?? null,
+  }))
+}

--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -1,0 +1,72 @@
+import { CONTENT_LICENSE } from '@/lib/site'
+
+/**
+ * JSON-LD structured data for search engines. Server-rendered via TanStack
+ * `head().scripts` (the pattern from TanStack Start's SEO guide), so crawlers
+ * see it without JavaScript.
+ */
+
+/**
+ * Wraps JSON-LD data as a head() script descriptor. Escapes `<` so user-supplied
+ * strings (config titles, descriptions) can never contain `</script>` and break
+ * out of the inline script tag.
+ */
+export function jsonLdScript(data: object): { type: 'application/ld+json'; children: string } {
+  return {
+    type: 'application/ld+json',
+    children: JSON.stringify(data).replace(/</g, '\\u003c'),
+  }
+}
+
+/** The gallery home as a CollectionPage whose main entity lists the visible configs. */
+export function homeJsonLd(origin: string, items: Array<{ slug: string; title: string }>): object {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: 'Claude Code Status Lines — Community Gallery',
+    url: origin,
+    mainEntity: {
+      '@type': 'ItemList',
+      itemListElement: items.map((item, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        name: item.title,
+        url: `${origin}/c/${item.slug}`,
+      })),
+    },
+  }
+}
+
+/** A config page as SoftwareSourceCode plus its breadcrumb trail back to the gallery. */
+export function configJsonLd(
+  origin: string,
+  config: {
+    slug: string
+    title: string
+    description: string
+    interpreter: string
+    authorName: string | null
+  },
+): object[] {
+  const url = `${origin}/c/${config.slug}`
+  return [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'SoftwareSourceCode',
+      name: config.title,
+      description: config.description,
+      url,
+      programmingLanguage: config.interpreter,
+      license: CONTENT_LICENSE.url,
+      ...(config.authorName ? { author: { '@type': 'Person', name: config.authorName } } : {}),
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Status lines', item: origin },
+        { '@type': 'ListItem', position: 2, name: config.title, item: url },
+      ],
+    },
+  ]
+}

--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -1,3 +1,4 @@
+import { HOME_TITLE_BASE } from '@/lib/page-title'
 import { CONTENT_LICENSE } from '@/lib/site'
 
 /**
@@ -23,7 +24,7 @@ export function homeJsonLd(origin: string, items: Array<{ slug: string; title: s
   return {
     '@context': 'https://schema.org',
     '@type': 'CollectionPage',
-    name: 'Claude Code Status Lines — Community Gallery',
+    name: HOME_TITLE_BASE,
     url: origin,
     mainEntity: {
       '@type': 'ItemList',

--- a/src/lib/page-title.ts
+++ b/src/lib/page-title.ts
@@ -8,3 +8,6 @@ export function configPageTitle(title: string): string {
 }
 
 export const NOT_FOUND_TITLE = 'Status line not found — statuslin.es'
+
+/** The home page's title base — shared by the <title> tag and the home JSON-LD name. */
+export const HOME_TITLE_BASE = 'Claude Code Status Lines — Community Gallery'

--- a/src/lib/page-title.ts
+++ b/src/lib/page-title.ts
@@ -1,0 +1,10 @@
+/**
+ * <title> templates for config pages. The template exists so every config page's
+ * title states the target search phrase ("Claude Code Status Line") — titles are
+ * the strongest on-page ranking signal, and the config name alone doesn't say it.
+ */
+export function configPageTitle(title: string): string {
+  return `${title} — Claude Code Status Line | statuslin.es`
+}
+
+export const NOT_FOUND_TITLE = 'Status line not found — statuslin.es'

--- a/src/routes/c.$slug.tsx
+++ b/src/routes/c.$slug.tsx
@@ -187,11 +187,15 @@ function ConfigDetail() {
                       </Text>
                     </Row>
                   </CardHeader>
-                  {r.preview !== null && (
-                    <CardContent>
+                  <CardContent>
+                    {r.preview !== null ? (
                       <StatuslinePreview segments={r.preview} />
-                    </CardContent>
-                  )}
+                    ) : (
+                      <Text muted size="sm">
+                        No preview.
+                      </Text>
+                    )}
+                  </CardContent>
                 </Card>
               ))}
             </Stack>

--- a/src/routes/c.$slug.tsx
+++ b/src/routes/c.$slug.tsx
@@ -9,12 +9,15 @@ import { configPageTitle, NOT_FOUND_TITLE } from '@/lib/page-title'
 import { configSocialMeta } from '@/og/meta'
 import { orderByScenario, SCENARIO_BY_KEY } from '@/render/scenarios'
 import { AuthorChip } from '@/ui/author-chip'
+import { Card, CardContent, CardHeader, CardTitle } from '@/ui/card'
 import { ConfigBadges } from '@/ui/config-badges'
 import { HighlightedCode } from '@/ui/highlighted-code'
 import { Row, Stack } from '@/ui/layout'
 import { ScenarioRow } from '@/ui/scenario-row'
 import { SectionCard } from '@/ui/section-card'
 import { PageShell } from '@/ui/shell'
+import { StatuslinePreview } from '@/ui/statusline-preview'
+import { StretchedLink } from '@/ui/stretched-link'
 import { Heading, Text, TextLink } from '@/ui/text'
 import { UpvoteButton } from '@/votes/upvote-button'
 
@@ -154,6 +157,35 @@ function ConfigDetail() {
         >
           <HighlightedCode html={detail.sourceHtml} />
         </SectionCard>
+
+        {/* Internal links: without these, every config page is a crawl dead end. */}
+        {detail.related.length > 0 && (
+          <SectionCard title="More status lines">
+            <Stack gap={3}>
+              {detail.related.map((r) => (
+                <Card key={r.slug} interactive>
+                  <CardHeader>
+                    <Row gap={2}>
+                      <CardTitle>
+                        <StretchedLink to="/c/$slug" params={{ slug: r.slug }}>
+                          {r.title}
+                        </StretchedLink>
+                      </CardTitle>
+                      <Text muted size="sm">
+                        ⇧ {r.upvoteCount}
+                      </Text>
+                    </Row>
+                  </CardHeader>
+                  {r.preview !== null && (
+                    <CardContent>
+                      <StatuslinePreview segments={r.preview} />
+                    </CardContent>
+                  )}
+                </Card>
+              ))}
+            </Stack>
+          </SectionCard>
+        )}
       </Stack>
     </PageShell>
   )

--- a/src/routes/c.$slug.tsx
+++ b/src/routes/c.$slug.tsx
@@ -5,7 +5,9 @@ import { AdoptPrompt, CopyScriptButton } from '@/adopt/adopt-actions'
 import { getConfigDetail } from '@/gallery/functions'
 import { getSession } from '@/lib/auth-functions'
 import { canonicalLink } from '@/lib/canonical'
+import { configJsonLd, jsonLdScript } from '@/lib/json-ld'
 import { configPageTitle, NOT_FOUND_TITLE } from '@/lib/page-title'
+import { siteUrl } from '@/lib/site'
 import { configSocialMeta } from '@/og/meta'
 import { orderByScenario, SCENARIO_BY_KEY } from '@/render/scenarios'
 import { AuthorChip } from '@/ui/author-chip'
@@ -52,6 +54,15 @@ export const Route = createFileRoute('/c/$slug')({
       // Only a real config gets a canonical URL; the notFound page (no detail) is a 404 and
       // shouldn't point search engines at a canonical that doesn't exist.
       ...(detail ? { links: [canonicalLink(`/c/${detail.slug}`)] } : {}),
+      scripts: detail
+        ? configJsonLd(siteUrl(), {
+            slug: detail.slug,
+            title: detail.title,
+            description: detail.description,
+            interpreter: detail.interpreter,
+            authorName: detail.author?.name ?? null,
+          }).map(jsonLdScript)
+        : [],
     }
   },
   notFoundComponent: () => (

--- a/src/routes/c.$slug.tsx
+++ b/src/routes/c.$slug.tsx
@@ -5,6 +5,7 @@ import { AdoptPrompt, CopyScriptButton } from '@/adopt/adopt-actions'
 import { getConfigDetail } from '@/gallery/functions'
 import { getSession } from '@/lib/auth-functions'
 import { canonicalLink } from '@/lib/canonical'
+import { configPageTitle, NOT_FOUND_TITLE } from '@/lib/page-title'
 import { configSocialMeta } from '@/og/meta'
 import { orderByScenario, SCENARIO_BY_KEY } from '@/render/scenarios'
 import { AuthorChip } from '@/ui/author-chip'
@@ -30,7 +31,7 @@ export const Route = createFileRoute('/c/$slug')({
     const detail = loaderData?.detail
     return {
       meta: [
-        { title: detail ? `${detail.title} — statuslin.es` : 'Not found — statuslin.es' },
+        { title: detail ? configPageTitle(detail.title) : NOT_FOUND_TITLE },
         {
           name: 'description',
           content:

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -4,6 +4,8 @@ import { getGallery } from '@/gallery/functions'
 import { coercePage, coerceSort, type GallerySort } from '@/gallery/queries'
 import { getSession } from '@/lib/auth-functions'
 import { canonicalLink } from '@/lib/canonical'
+import { homeJsonLd, jsonLdScript } from '@/lib/json-ld'
+import { siteUrl } from '@/lib/site'
 import { AuthorChip } from '@/ui/author-chip'
 import { Button } from '@/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/ui/card'
@@ -29,7 +31,7 @@ export const Route = createFileRoute('/')({
     user: await getSession(),
     gallery: await getGallery({ data: { sort: deps.sort ?? 'new', page: deps.page ?? 1 } }),
   }),
-  head: () => ({
+  head: ({ loaderData }) => ({
     meta: [
       { title: 'Claude Code Status Lines — Community Gallery | statuslin.es' },
       {
@@ -39,6 +41,7 @@ export const Route = createFileRoute('/')({
       },
     ],
     links: [canonicalLink('/')],
+    scripts: loaderData ? [jsonLdScript(homeJsonLd(siteUrl(), loaderData.gallery.cards))] : [],
   }),
   component: Home,
 })

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -5,6 +5,7 @@ import { coercePage, coerceSort, type GallerySort } from '@/gallery/queries'
 import { getSession } from '@/lib/auth-functions'
 import { canonicalLink } from '@/lib/canonical'
 import { homeJsonLd, jsonLdScript } from '@/lib/json-ld'
+import { HOME_TITLE_BASE } from '@/lib/page-title'
 import { siteUrl } from '@/lib/site'
 import { AuthorChip } from '@/ui/author-chip'
 import { Button } from '@/ui/button'
@@ -33,7 +34,7 @@ export const Route = createFileRoute('/')({
   }),
   head: ({ loaderData }) => ({
     meta: [
-      { title: 'Claude Code Status Lines — Community Gallery | statuslin.es' },
+      { title: `${HOME_TITLE_BASE} | statuslin.es` },
       {
         name: 'description',
         content:

--- a/test/gallery/related.test.ts
+++ b/test/gallery/related.test.ts
@@ -1,0 +1,116 @@
+import { PGlite } from '@electric-sql/pglite'
+import { eq } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/pglite'
+import { migrate } from 'drizzle-orm/pglite/migrator'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import * as schema from '@/db/schema'
+import { getRelatedConfigs, RELATED_LIMIT } from '@/gallery/queries'
+import { storePreviews } from '@/render/store'
+
+let client: PGlite
+let db: ReturnType<typeof drizzle<typeof schema>>
+beforeAll(async () => {
+  client = new PGlite()
+  db = drizzle({ client, schema })
+  await migrate(db, { migrationsFolder: './drizzle' })
+  // Seed the author referenced by the configs FK (author_id → user.id)
+  await db
+    .insert(schema.user)
+    .values({
+      id: 'u1',
+      name: 'Author One',
+      username: 'authorone',
+      email: 'author1@test.com',
+      image: 'https://example.com/avatar.png',
+      emailVerified: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .onConflictDoNothing()
+})
+afterAll(async () => {
+  await client.close()
+})
+
+// Mirrors the seed helper in test/gallery/queries.test.ts: config first (so the
+// version's config_id FK is satisfiable), then back-patch current_version_id.
+async function seedPublished(opts: {
+  slug: string
+  title: string
+  sha: string
+  upvoteCount?: number
+}) {
+  const cfgRows = await db
+    .insert(schema.configs)
+    .values({
+      slug: opts.slug,
+      title: opts.title,
+      description: 'desc',
+      authorId: 'u1',
+      interpreter: 'bash',
+      status: 'published',
+      upvoteCount: opts.upvoteCount ?? 0,
+    })
+    .returning()
+  const cfg = cfgRows[0]!
+  const verRows = await db
+    .insert(schema.configVersions)
+    .values({
+      configId: cfg.id,
+      versionNumber: 1,
+      source: '#!/usr/bin/env bash\necho hi',
+      interpreter: 'bash',
+      contentSha256: opts.sha,
+      status: 'approved',
+    })
+    .returning()
+  const ver = verRows[0]!
+  await db
+    .update(schema.configs)
+    .set({ currentVersionId: ver.id })
+    .where(eq(schema.configs.id, cfg.id))
+  await storePreviews(db, opts.sha, [
+    {
+      scenarioKey: 'clean-main',
+      segments: [
+        { text: opts.title, fg: null, bg: null, bold: false, italic: false, underline: false },
+      ],
+      rawStdout: opts.title,
+      exitCode: 0,
+      timedOut: false,
+      trace: { networkAttempts: [], sensitiveReads: [], spawnedProcesses: [] },
+    },
+  ])
+  return cfg
+}
+
+describe('getRelatedConfigs', () => {
+  it('returns other published configs top-voted first, excluding the viewed slug', async () => {
+    await seedPublished({ slug: 'viewed', title: 'Viewed', sha: 'a'.repeat(64), upvoteCount: 99 })
+    await seedPublished({ slug: 'popular', title: 'Popular', sha: 'b'.repeat(64), upvoteCount: 5 })
+    await seedPublished({ slug: 'quiet', title: 'Quiet', sha: 'c'.repeat(64), upvoteCount: 1 })
+    await db.insert(schema.configs).values({
+      slug: 'draft-one',
+      title: 'Draft',
+      description: '',
+      authorId: 'u1',
+      interpreter: 'bash',
+      status: 'draft',
+    })
+
+    const related = await getRelatedConfigs(db, 'viewed')
+    const slugs = related.map((r) => r.slug)
+    expect(slugs).not.toContain('viewed')
+    expect(slugs).not.toContain('draft-one')
+    expect(slugs.indexOf('popular')).toBeLessThan(slugs.indexOf('quiet'))
+    expect(related[0]?.preview?.[0]?.text).toBe('Popular')
+  })
+
+  it('caps results at the limit', async () => {
+    // 3 published configs exist beyond 'viewed' after this insert
+    await seedPublished({ slug: 'third', title: 'Third', sha: 'd'.repeat(64), upvoteCount: 2 })
+    const related = await getRelatedConfigs(db, 'viewed', 2)
+    expect(related).toHaveLength(2)
+    expect(RELATED_LIMIT).toBe(6)
+  })
+})

--- a/test/lib/json-ld.test.ts
+++ b/test/lib/json-ld.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { configJsonLd, homeJsonLd, jsonLdScript } from '@/lib/json-ld'
+
+describe('jsonLdScript', () => {
+  it('serializes to an application/ld+json script descriptor', () => {
+    const s = jsonLdScript({ '@type': 'Thing', name: 'x' })
+    expect(s.type).toBe('application/ld+json')
+    expect(JSON.parse(s.children)).toEqual({ '@type': 'Thing', name: 'x' })
+  })
+
+  it('escapes < so user content cannot close the script tag', () => {
+    const s = jsonLdScript({ name: '</script><script>alert(1)' })
+    expect(s.children).not.toContain('</script>')
+    expect(s.children).toContain('\\u003c/script>')
+  })
+})
+
+describe('homeJsonLd', () => {
+  it('builds a CollectionPage with an ItemList of config URLs', () => {
+    const data = homeJsonLd('https://statuslin.es', [
+      { slug: 'a-1', title: 'Alpha' },
+      { slug: 'b-2', title: 'Beta' },
+    ]) as Record<string, unknown>
+    expect(data['@type']).toBe('CollectionPage')
+    const list = data.mainEntity as { itemListElement: Array<Record<string, unknown>> }
+    expect(list.itemListElement).toHaveLength(2)
+    expect(list.itemListElement[0]).toMatchObject({
+      position: 1,
+      name: 'Alpha',
+      url: 'https://statuslin.es/c/a-1',
+    })
+  })
+})
+
+describe('configJsonLd', () => {
+  it('builds SoftwareSourceCode + BreadcrumbList for a config', () => {
+    const [code, crumbs] = configJsonLd('https://statuslin.es', {
+      slug: 'powerline-dracula-6936b97c',
+      title: 'Powerline Dracula',
+      description: 'A Powerline-style status line.',
+      interpreter: 'bash',
+      authorName: 'LindseyB',
+    }) as Array<Record<string, unknown>>
+    expect(code).toMatchObject({
+      '@type': 'SoftwareSourceCode',
+      name: 'Powerline Dracula',
+      programmingLanguage: 'bash',
+      url: 'https://statuslin.es/c/powerline-dracula-6936b97c',
+      author: { '@type': 'Person', name: 'LindseyB' },
+    })
+    expect(code!.license).toContain('creativecommons.org')
+    expect(crumbs?.['@type']).toBe('BreadcrumbList')
+  })
+
+  it('omits author when there is none', () => {
+    const [code] = configJsonLd('https://statuslin.es', {
+      slug: 's',
+      title: 'T',
+      description: 'd',
+      interpreter: 'bash',
+      authorName: null,
+    }) as Array<Record<string, unknown>>
+    expect(code).not.toHaveProperty('author')
+  })
+})

--- a/test/lib/page-title.test.ts
+++ b/test/lib/page-title.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { configPageTitle, NOT_FOUND_TITLE } from '@/lib/page-title'
+
+describe('configPageTitle', () => {
+  it('wraps the config name in the keyword template', () => {
+    expect(configPageTitle('Powerline Dracula')).toBe(
+      'Powerline Dracula — Claude Code Status Line | statuslin.es',
+    )
+  })
+
+  it('keeps the not-found title on-brand and two-worded', () => {
+    expect(NOT_FOUND_TITLE).toBe('Status line not found — statuslin.es')
+  })
+})

--- a/test/lib/page-title.test.ts
+++ b/test/lib/page-title.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { configPageTitle, NOT_FOUND_TITLE } from '@/lib/page-title'
+import { configPageTitle, HOME_TITLE_BASE, NOT_FOUND_TITLE } from '@/lib/page-title'
 
 describe('configPageTitle', () => {
   it('wraps the config name in the keyword template', () => {
@@ -10,5 +10,9 @@ describe('configPageTitle', () => {
 
   it('keeps the not-found title on-brand and two-worded', () => {
     expect(NOT_FOUND_TITLE).toBe('Status line not found — statuslin.es')
+  })
+
+  it('exposes the home title base for the title tag and JSON-LD to share', () => {
+    expect(HOME_TITLE_BASE).toBe('Claude Code Status Lines — Community Gallery')
   })
 })


### PR DESCRIPTION
Phase 1 of the SEO plan: make every config page state the target keyword, stop config pages being crawl dead ends, and give search engines structured data.

## Changes

- **Config page titles** now follow `{Name} — Claude Code Status Line | statuslin.es` via a new `src/lib/page-title.ts` template (not-found title included). Previously titles omitted the keyword entirely.
- **"More status lines" section** on every config page: up to 6 other published configs (top-voted first), server-rendered links with previews, via a new `getRelatedConfigs` query (`src/gallery/related.ts`, re-exported from `@/gallery/queries`). Config pages previously linked to zero other configs.
- **JSON-LD structured data** (`src/lib/json-ld.ts`): `CollectionPage` + `ItemList` on the gallery home, `SoftwareSourceCode` + `BreadcrumbList` on config pages, server-rendered through TanStack's `head().scripts`. `<` is escaped in the serialized JSON so user-supplied titles/descriptions can't break out of the script tag.
- Review fixes: null-preview fallback on related cards (matches the home gallery), home title single-sourced in `HOME_TITLE_BASE`.

## Verification

- Full gate (`check:ci`): typecheck, Biome, frontend + boundary gates, 650 tests passed / 0 failed.
- `bun run build` exit 0 (client-bundle gate — both route `head()`s changed).
- Served-HTML checks against a local dev server: homepage emits 1 `application/ld+json` script, config pages 2, 404 page 0; "More status lines" present server-side with working links.

After merge: deploy staging → verify live → promote to prod by digest (plan Task 5), then request indexing in GSC + register Bing (Task 6).