### PR TITLE
Seed wave 1: license labels + 15 vetted community status lines (staging)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,13 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**", "!**/routeTree.gen.ts", "!src/db/auth-schema.ts", "!drizzle"]
+    "includes": [
+      "**",
+      "!**/routeTree.gen.ts",
+      "!src/db/auth-schema.ts",
+      "!drizzle",
+      "!scripts/seed-data/sources"
+    ]
   },
   "formatter": {
     "enabled": true,

--- a/drizzle/0016_far_rafael_vega.sql
+++ b/drizzle/0016_far_rafael_vega.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "config_versions" ADD COLUMN "license" text;--> statement-breakpoint
+ALTER TABLE "config_versions" ADD COLUMN "source_url" text;

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,1035 @@
+{
+  "id": "74eae93e-663c-4300-8a41-0283e76a14a2",
+  "prevId": "4a29be39-ec53-497f-864f-c51b9e0e5071",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.config_versions": {
+      "name": "config_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interpreter": {
+          "name": "interpreter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_sha256": {
+          "name": "content_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_html": {
+          "name": "source_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "network_hosts": {
+          "name": "network_hosts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "reads_claude_token": {
+          "name": "reads_claude_token",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_content": {
+          "name": "generated_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "config_versions_config_version_uq": {
+          "name": "config_versions_config_version_uq",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "config_versions_config_id_configs_id_fk": {
+          "name": "config_versions_config_id_configs_id_fk",
+          "tableFrom": "config_versions",
+          "tableTo": "configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.configs": {
+      "name": "configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interpreter": {
+          "name": "interpreter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upvote_count": {
+          "name": "upvote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "copy_count": {
+          "name": "copy_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "configs_author_created_idx": {
+          "name": "configs_author_created_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "configs_status_created_idx": {
+          "name": "configs_status_created_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "configs_status_upvotes_idx": {
+          "name": "configs_status_upvotes_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "upvote_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "configs_author_id_user_id_fk": {
+          "name": "configs_author_id_user_id_fk",
+          "tableFrom": "configs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "configs_slug_unique": {
+          "name": "configs_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.copy_events": {
+      "name": "copy_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_hash": {
+          "name": "ip_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "copy_events_config_ip_uq": {
+          "name": "copy_events_config_ip_uq",
+          "columns": [
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ip_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "copy_events_config_id_configs_id_fk": {
+          "name": "copy_events_config_id_configs_id_fk",
+          "tableFrom": "copy_events",
+          "tableTo": "configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.previews": {
+      "name": "previews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "script_sha": {
+          "name": "script_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scenario_key": {
+          "name": "scenario_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segments": {
+          "name": "segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_stdout": {
+          "name": "raw_stdout",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timed_out": {
+          "name": "timed_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trace": {
+          "name": "trace",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "previews_sha_scenario_uq": {
+          "name": "previews_sha_scenario_uq",
+          "columns": [
+            {
+              "expression": "script_sha",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scenario_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.render_jobs": {
+      "name": "render_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "config_version_id": {
+          "name": "config_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "render_jobs_config_version_id_config_versions_id_fk": {
+          "name": "render_jobs_config_version_id_config_versions_id_fk",
+          "tableFrom": "render_jobs",
+          "tableTo": "config_versions",
+          "columnsFrom": [
+            "config_version_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.votes": {
+      "name": "votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "votes_user_config_uq": {
+          "name": "votes_user_config_uq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "votes_user_id_user_id_fk": {
+          "name": "votes_user_id_user_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "votes_config_id_configs_id_fk": {
+          "name": "votes_config_id_configs_id_fk",
+          "tableFrom": "votes",
+          "tableTo": "configs",
+          "columnsFrom": [
+            "config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1783025481002,
       "tag": "0015_wealthy_morlocks",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1783341596733,
+      "tag": "0016_far_rafael_vega",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build:e2b-template": "bun run scripts/build-e2b-template.ts",
     "build:font": "bun run scripts/build-font-subset.ts",
     "seed:gallery": "bun run scripts/seed-gallery.ts",
+    "seed:community": "bun run scripts/run-seed-community.ts",
     "generate:content": "bun run scripts/generate-content.ts",
     "profile:bench": "bun run scripts/profiling/bench-phases.ts",
     "profile:server": "bun run scripts/profiling/profile-server.ts",

--- a/scripts/run-seed-community.ts
+++ b/scripts/run-seed-community.ts
@@ -1,0 +1,22 @@
+import '@/lib/refuse-in-production'
+import { db } from '@/db'
+import { publishRenderedSeeds, releaseHeldSeeds, seedCommunity } from './seed-community'
+import { COMMUNITY_CONFIGS } from './seed-data/community-configs'
+
+const mode = process.argv[2] ?? 'seed'
+if (mode === 'seed') {
+  const outcomes = await seedCommunity(db, COMMUNITY_CONFIGS)
+  for (const o of outcomes)
+    console.log(
+      `[${o.status}] ${o.login} — ${o.title}${o.slug ? ` → /${o.slug}` : ''}${o.reason ? ` (${o.reason})` : ''}`,
+    )
+} else if (mode === 'release-held') {
+  console.log(`released ${await releaseHeldSeeds(db)} held render jobs`)
+} else if (mode === 'publish-rendered') {
+  const { published, skipped } = await publishRenderedSeeds(db)
+  console.log(`published ${published}, skipped ${skipped} (render not done)`)
+} else {
+  console.error('usage: bun run seed:community [seed|release-held|publish-rendered]')
+  process.exit(1)
+}
+process.exit(0)

--- a/scripts/seed-community.ts
+++ b/scripts/seed-community.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { and, eq, ne, sql } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import type { PgDatabase } from 'drizzle-orm/pg-core'
 import { account, configs, configVersions, renderJobs, user } from '@/db/schema'
 import type { Interpreter } from '@/render/types'
@@ -202,10 +202,16 @@ export async function releaseHeldSeeds(db: Db): Promise<number> {
   return held.length
 }
 
-/** Approves (and thereby publishes) every seeded version whose render job finished successfully
- *  and whose config isn't published yet — the batched equivalent of clicking "approve" in the
- *  review queue for each seeded submission. Versions whose render isn't done are left alone and
- *  counted as skipped so a re-run of `publish-rendered` picks them up once the worker catches up. */
+/** Approves (and thereby publishes) every seed-authored version whose render job finished
+ *  successfully and whose config is still a draft — the batched equivalent of clicking "approve"
+ *  in the review queue for each seeded submission. Versions whose render isn't done are left
+ *  alone and counted as skipped so a re-run of `publish-rendered` picks them up once the worker
+ *  catches up. Scoped to seed authors (shadow users created by ensureSeededAuthor, whose email is
+ *  `seed+<login>@statuslin.es`) via the same innerJoin-to-user pattern as releaseHeldSeeds: a
+ *  pending version from a real web submission must NOT be swept up and auto-approved by this
+ *  batch tool — prod's human review gate must stay untouchable by it. Filters on
+ *  `configs.status = 'draft'` (not merely "not published") so a taken-down (`removed`) config can
+ *  never be re-published by a stray done render job. */
 export async function publishRenderedSeeds(
   db: Db,
 ): Promise<{ published: number; skipped: number }> {
@@ -215,7 +221,14 @@ export async function publishRenderedSeeds(
     .from(configVersions)
     .innerJoin(configs, eq(configVersions.configId, configs.id))
     .innerJoin(renderJobs, eq(renderJobs.configVersionId, configVersions.id))
-    .where(and(eq(configVersions.status, 'pending'), ne(configs.status, 'published')))
+    .innerJoin(user, eq(configs.authorId, user.id))
+    .where(
+      and(
+        eq(configVersions.status, 'pending'),
+        eq(configs.status, 'draft'),
+        sql`${user.email} LIKE ${'seed+%'}`,
+      ),
+    )
 
   let published = 0
   let skipped = 0

--- a/scripts/seed-community.ts
+++ b/scripts/seed-community.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from 'node:crypto'
-import { and, eq, sql } from 'drizzle-orm'
+import { and, eq, ne, sql } from 'drizzle-orm'
 import type { PgDatabase } from 'drizzle-orm/pg-core'
-import { account, configs, user } from '@/db/schema'
+import { account, configs, configVersions, renderJobs, user } from '@/db/schema'
 import type { Interpreter } from '@/render/types'
+import { approveVersion, runNetworkPreview } from '@/review/decide'
 import { submitConfig, validateSubmitInput } from '@/submit/submit'
 
 // biome-ignore lint/suspicious/noExplicitAny: db type varies by driver (postgres-js/pglite); query surface identical.
@@ -85,6 +86,13 @@ export interface CommunityConfig {
   description: string
   interpreter: Interpreter
   source: string
+  /** Hosts this script needs network egress to (routed through the same validation + held-job
+   *  gate as a normal web submission — see validateSubmitInput/submitConfig). */
+  networkHosts?: string[]
+  /** SPDX license of the third-party source being seeded, e.g. 'MIT'. */
+  license: string
+  /** Upstream URL the source was seeded from (dotfiles repo, gist, etc.). */
+  sourceUrl: string
 }
 
 export type SeedStatus = 'submitted' | 'skipped' | 'error'
@@ -125,8 +133,16 @@ export async function seedCommunityConfig(
     description: entry.description,
     interpreter: entry.interpreter,
     source: entry.source,
+    ...(entry.networkHosts ? { networkHosts: entry.networkHosts } : {}),
   })
-  const { configId, slug } = await submitConfig(db, { ...validated, authorId })
+  // license/sourceUrl aren't submit-form fields (validateSubmitInput doesn't validate them) —
+  // pass them straight through to submitConfig, which stores them on the version.
+  const { configId, slug } = await submitConfig(db, {
+    ...validated,
+    authorId,
+    license: entry.license,
+    sourceUrl: entry.sourceUrl,
+  })
   return { login: entry.githubLogin, title: entry.title, status: 'submitted', slug, configId }
 }
 
@@ -153,6 +169,57 @@ export async function seedCommunity(db: Db, entries: CommunityConfig[]): Promise
     }
   }
   return outcomes
+}
+
+/** Site owner to attribute admin actions (release/publish) to on staging/prod runs: the first
+ *  admin, else the first user. Mirrors scripts/seed-gallery.ts's seedAuthorId(). */
+async function resolveAdminId(db: Db): Promise<string> {
+  const users = await db.select().from(user)
+  const admin = users.find((u) => u.role === 'admin') ?? users[0]
+  if (!admin) throw new Error('No user to act as reviewer — sign in once first.')
+  return admin.id
+}
+
+/** Promotes every 'held' render job (parked by seedCommunityConfig for a network-using seed) to
+ *  'queued' so the always-on worker renders it — the same explicit admin action as the review
+ *  queue's "run network preview" button, just batched across every seeded held job. */
+export async function releaseHeldSeeds(db: Db): Promise<number> {
+  const held = await db
+    .select({ configVersionId: renderJobs.configVersionId })
+    .from(renderJobs)
+    .where(eq(renderJobs.status, 'held'))
+  for (const job of held) {
+    await runNetworkPreview(db, job.configVersionId)
+  }
+  return held.length
+}
+
+/** Approves (and thereby publishes) every seeded version whose render job finished successfully
+ *  and whose config isn't published yet — the batched equivalent of clicking "approve" in the
+ *  review queue for each seeded submission. Versions whose render isn't done are left alone and
+ *  counted as skipped so a re-run of `publish-rendered` picks them up once the worker catches up. */
+export async function publishRenderedSeeds(
+  db: Db,
+): Promise<{ published: number; skipped: number }> {
+  const adminId = await resolveAdminId(db)
+  const rows = await db
+    .select({ versionId: configVersions.id, jobStatus: renderJobs.status })
+    .from(configVersions)
+    .innerJoin(configs, eq(configVersions.configId, configs.id))
+    .innerJoin(renderJobs, eq(renderJobs.configVersionId, configVersions.id))
+    .where(and(eq(configVersions.status, 'pending'), ne(configs.status, 'published')))
+
+  let published = 0
+  let skipped = 0
+  for (const row of rows) {
+    if (row.jobStatus === 'done') {
+      await approveVersion(db, row.versionId, adminId)
+      published++
+    } else {
+      skipped++
+    }
+  }
+  return { published, skipped }
 }
 
 // CLI entry: submit every entry in the data file against the env-configured DB.

--- a/scripts/seed-community.ts
+++ b/scripts/seed-community.ts
@@ -180,14 +180,22 @@ async function resolveAdminId(db: Db): Promise<string> {
   return admin.id
 }
 
-/** Promotes every 'held' render job (parked by seedCommunityConfig for a network-using seed) to
- *  'queued' so the always-on worker renders it — the same explicit admin action as the review
- *  queue's "run network preview" button, just batched across every seeded held job. */
+/** Promotes every 'held' render job belonging to a seed-authored submission (parked by
+ *  seedCommunityConfig for a network-using seed) to 'queued' so the always-on worker renders it —
+ *  the same explicit admin action as the review queue's "run network preview" button, just
+ *  batched across every seeded held job. Scoped to seed authors (shadow users created by
+ *  ensureSeededAuthor, whose email is `seed+<login>@statuslin.es`) via a join from renderJobs to
+ *  configVersions to configs to user: a held job from a real web submission must NOT be swept up
+ *  by this batch release — it still needs the per-item human network-preview gate a real
+ *  (non-seed) submitter's script goes through. */
 export async function releaseHeldSeeds(db: Db): Promise<number> {
   const held = await db
     .select({ configVersionId: renderJobs.configVersionId })
     .from(renderJobs)
-    .where(eq(renderJobs.status, 'held'))
+    .innerJoin(configVersions, eq(renderJobs.configVersionId, configVersions.id))
+    .innerJoin(configs, eq(configVersions.configId, configs.id))
+    .innerJoin(user, eq(configs.authorId, user.id))
+    .where(and(eq(renderJobs.status, 'held'), sql`${user.email} LIKE ${'seed+%'}`))
   for (const job of held) {
     await runNetworkPreview(db, job.configVersionId)
   }
@@ -220,34 +228,4 @@ export async function publishRenderedSeeds(
     }
   }
   return { published, skipped }
-}
-
-// CLI entry: submit every entry in the data file against the env-configured DB.
-// Run against STAGING first, then promote the same change to production:
-//   fly ssh console --app statuslines-staging --command "bun run scripts/seed-community.ts"
-//   fly ssh console --app statuslines          --command "bun run scripts/seed-community.ts"
-// Submit-only: the always-on worker renders each queued job, then an admin approves it in the
-// review queue. Nothing is auto-published — untrusted community scripts get the normal human
-// review gate. (Intentionally does NOT import refuse-in-production: it forges no sessions and
-// grants no admin, only normal role:'user' placeholders, and is meant to run in prod.)
-if (import.meta.main) {
-  const { db } = await import('@/db')
-  const { COMMUNITY_CONFIGS } = await import('./seed-data/community-configs')
-
-  if (COMMUNITY_CONFIGS.length === 0) {
-    console.log('No community configs to seed (scripts/seed-data/community-configs.ts is empty).')
-    process.exit(0)
-  }
-
-  const outcomes = await seedCommunity(db, COMMUNITY_CONFIGS)
-  for (const o of outcomes) {
-    const suffix = o.slug ? ` → /${o.slug}` : o.reason ? ` — ${o.reason}` : ''
-    console.log(`[${o.status}] @${o.login} — "${o.title}"${suffix}`)
-  }
-  const errored = outcomes.filter((o) => o.status === 'error')
-  console.log(
-    `\nSeed complete: ${outcomes.length} processed, ${errored.length} errored. ` +
-      'Submitted configs await render + admin review in the queue.',
-  )
-  process.exit(errored.length > 0 ? 1 : 0)
 }

--- a/scripts/seed-data/community-configs.ts
+++ b/scripts/seed-data/community-configs.ts
@@ -26,7 +26,7 @@ export const COMMUNITY_CONFIGS: CommunityConfig[] = [
     githubId: '36623265',
     title: 'Everything Bar',
     description:
-      'Model, directory and branch with diff counts, context tokens, reasoning effort, and live five-hour and seven-day limits from the usage API. Checks for new versions of itself once a day.',
+      "Model, directory and branch with diff counts, context tokens, reasoning effort, and five-hour and seven-day limits from Claude Code's own rate-limit data, with the usage API as fallback. Checks for new versions of itself once a day.",
     interpreter: 'bash',
     source: src('01-everything-bar.sh'),
     networkHosts: ['api.anthropic.com', 'api.github.com'],
@@ -39,7 +39,7 @@ export const COMMUNITY_CONFIGS: CommunityConfig[] = [
     githubId: '4921183',
     title: 'Usage Dot Bars',
     description:
-      'Context, directory and branch up top; five-hour and weekly quota as dot bars with reset times underneath. Warns when --dangerously-skip-permissions is on. By Kamran Ahmed of roadmap.sh.',
+      'Model, context, directory and branch up top; five-hour and weekly quota as dot bars with reset times underneath. Flags --dangerously-skip-permissions with a lightning bolt. By Kamran Ahmed of roadmap.sh.',
     interpreter: 'bash',
     source: src('02-usage-dot-bars.sh'),
     networkHosts: ['api.anthropic.com'],
@@ -52,7 +52,7 @@ export const COMMUNITY_CONFIGS: CommunityConfig[] = [
     githubId: '41281835',
     title: 'Three-Line Cockpit',
     description:
-      'Model and context on the first line, a context bar with token counts on the second, session cost on the third. Everything comes from stdin; no network calls.',
+      'Model, context, lines changed and branch on the first line; a context bar with token counts on the second; session cost on the third. No network calls, just stdin and local git.',
     interpreter: 'bash',
     source: src('03-three-line-cockpit.sh'),
     networkHosts: [],
@@ -65,7 +65,7 @@ export const COMMUNITY_CONFIGS: CommunityConfig[] = [
     githubId: '3247643',
     title: 'Quota at a Glance',
     description:
-      'One line of Python: model, color-coded five-hour and seven-day usage from the usage API, and the current directory.',
+      'Everything on one line: model, color-coded five-hour and seven-day usage from the usage API, and the current directory. Written in Python.',
     interpreter: 'python',
     source: src('04-quota-at-a-glance.py'),
     networkHosts: ['api.anthropic.com'],
@@ -91,7 +91,7 @@ export const COMMUNITY_CONFIGS: CommunityConfig[] = [
     githubId: '6722315',
     title: 'Gradient Dashboard',
     description:
-      'Gradient progress bars for context and quotas, plus cost, duration and lines changed. Pure bash and jq, fully offline.',
+      'A gradient progress bar for context with quota percentages beside it, plus cost, duration and lines changed. Bash and jq, fully offline.',
     interpreter: 'bash',
     source: src('06-gradient-dashboard.sh'),
     networkHosts: [],
@@ -115,9 +115,9 @@ export const COMMUNITY_CONFIGS: CommunityConfig[] = [
   {
     githubLogin: 'Astro-Han',
     githubId: '255364436',
-    title: 'Pace Bars',
+    title: 'Pace Arrows',
     description:
-      'Are you burning quota faster than the clock? Five-hour and seven-day bars with over- and under-pace arrows, plus context and git diff stats. Reads rate limits from stdin only.',
+      'Are you burning quota faster than the clock? Five-hour and seven-day usage with over- and under-pace arrows, plus a context bar and git diff stats. Reads rate limits from stdin only.',
     interpreter: 'bash',
     source: src('08-pace-bars.sh'),
     networkHosts: [],
@@ -130,7 +130,7 @@ export const COMMUNITY_CONFIGS: CommunityConfig[] = [
     githubId: '46619650',
     title: 'Git Detective',
     description:
-      'Bucketed git status counts, ahead-behind arrows, prompt-cache stats with an expiry countdown, and a warning when CLAUDE.md changed mid-session. Dependency-free Node.',
+      'Bucketed git status counts, ahead-behind arrows, prompt-cache stats with an expiry countdown, and a heads-up when CLAUDE.md, AGENTS.md and GEMINI.md fall out of sync. Dependency-free Node.',
     interpreter: 'node',
     source: src('09-git-detective.js'),
     networkHosts: [],
@@ -156,7 +156,7 @@ export const COMMUNITY_CONFIGS: CommunityConfig[] = [
     githubId: '41576951',
     title: 'Width-Aware Monitor',
     description:
-      'Fits itself to your terminal by dropping the lowest-priority segments first. Model, project, context gauge with token counts, pace-aware quota bars, cost and duration.',
+      'Keeps itself inside a width budget (80 columns by default) by dropping the lowest-priority segments first. Model, project, context gauge with token counts, quota bars and duration; pace arrows and a cost readout are opt-in.',
     interpreter: 'python',
     source: src('11-width-aware-monitor.py'),
     networkHosts: ['api.anthropic.com'],
@@ -195,7 +195,7 @@ export const COMMUNITY_CONFIGS: CommunityConfig[] = [
     githubId: '109059318',
     title: 'Traffic-Light Context',
     description:
-      'A context bar that shifts green to orange to red at 40 and 60 percent, with rate-limit countdowns and the git branch. Stdin only.',
+      'A context bar that shifts green to orange to red at 40 and 60 percent, a five-hour reset countdown, the weekly reset day, and the git branch. Stdin only.',
     interpreter: 'bash',
     source: src('14-traffic-light-context.sh'),
     networkHosts: [],
@@ -208,7 +208,7 @@ export const COMMUNITY_CONFIGS: CommunityConfig[] = [
     githubId: '12295159',
     title: 'Cost Thresholds',
     description:
-      'Directory, Node version when a package.json is around, net lines changed, a token bar, and a session cost that changes color as it grows.',
+      'Directory, Node version when a package.json is around, added and removed lines with a net-direction arrow, a token bar, and a session cost that changes color as it grows.',
     interpreter: 'bash',
     source: src('15-cost-thresholds.sh'),
     networkHosts: [],

--- a/scripts/seed-data/community-configs.ts
+++ b/scripts/seed-data/community-configs.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import type { CommunityConfig } from '../seed-community'
 
 // One entry per person we seed. Populated during the outreach phase. Keep titles/descriptions
@@ -11,4 +12,207 @@ import type { CommunityConfig } from '../seed-community'
 // Keep it to a few entries per GitHub author: the submit pipeline caps 3 submissions per author
 // per hour, so a 4th entry for the same person in one run fails with a rate-limit error (re-run
 // after an hour to land it). For the usual "one entry per person" list this never bites.
-export const COMMUNITY_CONFIGS: CommunityConfig[] = []
+//
+// `source` is vendored verbatim (byte-for-byte MIT/copyright headers preserved) from each pinned
+// ref into `./sources/`; see the seed-wave manifest for provenance. Two entries carry a
+// `[statuslin.es] trimmed:` comment at the top of their source file (rows 11/12 in the manifest)
+// noting what was cut and why.
+const src = (name: string): string =>
+  readFileSync(new URL(`./sources/${name}`, import.meta.url), 'utf8')
+
+export const COMMUNITY_CONFIGS: CommunityConfig[] = [
+  {
+    githubLogin: 'daniel3303',
+    githubId: '36623265',
+    title: 'Everything Bar',
+    description:
+      'Model, directory and branch with diff counts, context tokens, reasoning effort, and live five-hour and seven-day limits from the usage API. Checks for new versions of itself once a day.',
+    interpreter: 'bash',
+    source: src('01-everything-bar.sh'),
+    networkHosts: ['api.anthropic.com', 'api.github.com'],
+    license: 'MIT',
+    sourceUrl:
+      'https://github.com/daniel3303/ClaudeCodeStatusLine/blob/5da96959df726707fe8ff41c5645b4f7b8c7eac9/statusline.sh',
+  },
+  {
+    githubLogin: 'nilbuild',
+    githubId: '4921183',
+    title: 'Usage Dot Bars',
+    description:
+      'Context, directory and branch up top; five-hour and weekly quota as dot bars with reset times underneath. Warns when --dangerously-skip-permissions is on. By Kamran Ahmed of roadmap.sh.',
+    interpreter: 'bash',
+    source: src('02-usage-dot-bars.sh'),
+    networkHosts: ['api.anthropic.com'],
+    license: 'MIT',
+    sourceUrl:
+      'https://github.com/nilbuild/claude-statusline/blob/ea02c0e6dcd532fea6056f7eec2b7545b3666248/bin/statusline.sh',
+  },
+  {
+    githubLogin: 'loadbalance-sudachi-kun',
+    githubId: '41281835',
+    title: 'Three-Line Cockpit',
+    description:
+      'Model and context on the first line, a context bar with token counts on the second, session cost on the third. Everything comes from stdin; no network calls.',
+    interpreter: 'bash',
+    source: src('03-three-line-cockpit.sh'),
+    networkHosts: [],
+    license: 'MIT',
+    sourceUrl:
+      'https://github.com/loadbalance-sudachi-kun/claude-code-statusline/blob/23d2b2d7ab2d2f845550f0d5d2c2b4281ee950ad/statusline-command.sh',
+  },
+  {
+    githubLogin: 'lbenothman',
+    githubId: '3247643',
+    title: 'Quota at a Glance',
+    description:
+      'One line of Python: model, color-coded five-hour and seven-day usage from the usage API, and the current directory.',
+    interpreter: 'python',
+    source: src('04-quota-at-a-glance.py'),
+    networkHosts: ['api.anthropic.com'],
+    license: 'MIT',
+    sourceUrl:
+      'https://github.com/lbenothman/claude-code-statusline/blob/b5df77334fa61a4485a9dc81063994a430f55578/statusline.py',
+  },
+  {
+    githubLogin: 'aleksander-dytko',
+    githubId: '102789122',
+    title: 'Overage Watcher',
+    description:
+      'Watches plan limits and extra-usage spending in dollars, next to model, branch with diff stats, context and cost. Env vars switch it between one and two lines.',
+    interpreter: 'bash',
+    source: src('05-overage-watcher.sh'),
+    networkHosts: ['api.anthropic.com'],
+    license: 'MIT',
+    sourceUrl:
+      'https://github.com/aleksander-dytko/claude-code-statusline/blob/13f38409755c6eede26864e803211773049cafb1/statusline.sh',
+  },
+  {
+    githubLogin: 'kcchien',
+    githubId: '6722315',
+    title: 'Gradient Dashboard',
+    description:
+      'Gradient progress bars for context and quotas, plus cost, duration and lines changed. Pure bash and jq, fully offline.',
+    interpreter: 'bash',
+    source: src('06-gradient-dashboard.sh'),
+    networkHosts: [],
+    license: 'MIT',
+    sourceUrl:
+      'https://github.com/kcchien/claude-code-statusline/blob/877d24480ca9a37b8eefc0448a6a73a111989b6d/statusline.sh',
+  },
+  {
+    githubLogin: 'TahaSabir0',
+    githubId: '187144240',
+    title: 'Todo Ticker',
+    description:
+      'Shows the task Claude is working on right now, read from the session todo list, beside context and five-hour usage bars.',
+    interpreter: 'node',
+    source: src('07-todo-ticker.js'),
+    networkHosts: ['api.anthropic.com'],
+    license: 'MIT',
+    sourceUrl:
+      'https://github.com/TahaSabir0/Best-ClaudeCode-statusline/blob/60304674fb210dced7ed2034904e94efbb0f8f18/statusline.js',
+  },
+  {
+    githubLogin: 'Astro-Han',
+    githubId: '255364436',
+    title: 'Pace Bars',
+    description:
+      'Are you burning quota faster than the clock? Five-hour and seven-day bars with over- and under-pace arrows, plus context and git diff stats. Reads rate limits from stdin only.',
+    interpreter: 'bash',
+    source: src('08-pace-bars.sh'),
+    networkHosts: [],
+    license: 'MIT',
+    sourceUrl:
+      'https://github.com/Astro-Han/claude-pace/blob/f13a3ec2c5bc6c01c76bd230742b94025dac3bc7/claude-pace.sh',
+  },
+  {
+    githubLogin: 'ilia-pluzhnikov',
+    githubId: '46619650',
+    title: 'Git Detective',
+    description:
+      'Bucketed git status counts, ahead-behind arrows, prompt-cache stats with an expiry countdown, and a warning when CLAUDE.md changed mid-session. Dependency-free Node.',
+    interpreter: 'node',
+    source: src('09-git-detective.js'),
+    networkHosts: [],
+    license: 'MIT',
+    sourceUrl:
+      'https://github.com/ilia-pluzhnikov/claude-code-statusline/blob/256eb2314c53c986fb3e7e47b8bf4db306d234bd/statusline.js',
+  },
+  {
+    githubLogin: 'ohugonnot',
+    githubId: '13014954',
+    title: 'Quota Fallback',
+    description:
+      'Branch, model with effort level, a context bar and the five-hour quota with reset countdown. Only calls the usage API when stdin lacks rate limits.',
+    interpreter: 'bash',
+    source: src('10-quota-fallback.sh'),
+    networkHosts: ['api.anthropic.com'],
+    license: 'MIT',
+    sourceUrl:
+      'https://github.com/ohugonnot/claude-code-statusline/blob/d45b420cca872092f6beca6550feacf32e73d6df/statusline.sh',
+  },
+  {
+    githubLogin: 'aiedwardyi',
+    githubId: '41576951',
+    title: 'Width-Aware Monitor',
+    description:
+      'Fits itself to your terminal by dropping the lowest-priority segments first. Model, project, context gauge with token counts, pace-aware quota bars, cost and duration.',
+    interpreter: 'python',
+    source: src('11-width-aware-monitor.py'),
+    networkHosts: ['api.anthropic.com'],
+    license: 'MIT',
+    sourceUrl:
+      'https://github.com/aiedwardyi/claude-usage-monitor/blob/4627e5e1c57ca6713011fe0250391173450b4c8d/statusline.py',
+  },
+  {
+    githubLogin: 'JungHoonGhae',
+    githubId: '42439321',
+    title: 'Activity Feed',
+    description:
+      'A header with model, context and burn rate per hour, then live tool and agent activity parsed from the session transcript.',
+    interpreter: 'bash',
+    source: src('12-activity-feed.sh'),
+    networkHosts: ['api.anthropic.com'],
+    license: 'MIT',
+    sourceUrl:
+      'https://github.com/JungHoonGhae/claude-statusline/blob/6465e466c4832509c5bbc2a253581fa322618e1c/statusline.sh',
+  },
+  {
+    githubLogin: 'tzengyuxio',
+    githubId: '938388',
+    title: 'Nerd Font Duo',
+    description:
+      'Two Nerd Font lines: model, a 16-segment context bar, cost and quotas on top; directory, git counts, Python venv and vim mode below.',
+    interpreter: 'bash',
+    source: src('13-nerd-font-duo.sh'),
+    networkHosts: ['api.anthropic.com'],
+    license: 'MIT',
+    sourceUrl:
+      'https://github.com/tzengyuxio/claude-statusline/blob/7dc647a9332dcbcb9f250bf1cf4882dea6e548cc/statusline-command.sh',
+  },
+  {
+    githubLogin: 'bitcoin21ideas',
+    githubId: '109059318',
+    title: 'Traffic-Light Context',
+    description:
+      'A context bar that shifts green to orange to red at 40 and 60 percent, with rate-limit countdowns and the git branch. Stdin only.',
+    interpreter: 'bash',
+    source: src('14-traffic-light-context.sh'),
+    networkHosts: [],
+    license: 'MIT',
+    sourceUrl:
+      'https://github.com/bitcoin21ideas/claude-statusline/blob/d0ba9b8a075d079d0627d307deb7f174223159b4/statusline.sh',
+  },
+  {
+    githubLogin: 'Mohamed3on',
+    githubId: '12295159',
+    title: 'Cost Thresholds',
+    description:
+      'Directory, Node version when a package.json is around, net lines changed, a token bar, and a session cost that changes color as it grows.',
+    interpreter: 'bash',
+    source: src('15-cost-thresholds.sh'),
+    networkHosts: [],
+    license: 'MIT',
+    sourceUrl: 'https://gist.github.com/Mohamed3on/70780575570a07985916e5f50e290382',
+  },
+]

--- a/scripts/seed-data/sources/01-everything-bar.sh
+++ b/scripts/seed-data/sources/01-everything-bar.sh
@@ -1,0 +1,520 @@
+#!/bin/bash
+# Source: https://github.com/daniel3303/ClaudeCodeStatusLine
+# Single line: Model | tokens | %used | %remain | think | 5h bar @reset | 7d bar @reset | extra
+
+set -f  # disable globbing
+VERSION="1.4.4"
+
+input=$(cat)
+
+if [ -z "$input" ]; then
+    printf "Claude"
+    exit 0
+fi
+
+# ANSI colors matching oh-my-posh theme
+blue='\033[38;2;0;153;255m'
+orange='\033[38;2;255;176;85m'
+green='\033[38;2;0;160;0m'
+cyan='\033[38;2;46;149;153m'
+red='\033[38;2;255;85;85m'
+yellow='\033[38;2;230;200;0m'
+purple='\033[38;2;167;139;250m'
+white='\033[38;2;220;220;220m'
+dim='\033[2m'
+reset='\033[0m'
+
+# Format token counts (e.g., 50k / 200k)
+format_tokens() {
+    local num=$1
+    if [ "$num" -ge 1000000 ]; then
+        awk "BEGIN {v=sprintf(\"%.1f\",$num/1000000)+0; if(v==int(v)) printf \"%dm\",v; else printf \"%.1fm\",v}"
+    elif [ "$num" -ge 1000 ]; then
+        awk "BEGIN {printf \"%.0fk\", $num / 1000}"
+    else
+        printf "%d" "$num"
+    fi
+}
+
+# Format number with commas (e.g., 134,938)
+format_commas() {
+    printf "%'d" "$1"
+}
+
+# Return color escape based on usage percentage
+# Usage: usage_color <pct>
+usage_color() {
+    local pct=$1
+    if [ "$pct" -ge 90 ]; then echo "$red"
+    elif [ "$pct" -ge 70 ]; then echo "$orange"
+    elif [ "$pct" -ge 50 ]; then echo "$yellow"
+    else echo "$green"
+    fi
+}
+
+# Resolve config directory: CLAUDE_CONFIG_DIR (set by alias) or default ~/.claude
+claude_config_dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+
+# Return 0 (true) if $1 > $2 using semantic versioning
+version_gt() {
+    local a="${1#v}" b="${2#v}"
+    local IFS='.'
+    read -r a1 a2 a3 <<< "$a"
+    read -r b1 b2 b3 <<< "$b"
+    a1=${a1:-0}; a2=${a2:-0}; a3=${a3:-0}
+    b1=${b1:-0}; b2=${b2:-0}; b3=${b3:-0}
+    [ "$a1" -gt "$b1" ] 2>/dev/null && return 0
+    [ "$a1" -lt "$b1" ] 2>/dev/null && return 1
+    [ "$a2" -gt "$b2" ] 2>/dev/null && return 0
+    [ "$a2" -lt "$b2" ] 2>/dev/null && return 1
+    [ "$a3" -gt "$b3" ] 2>/dev/null && return 0
+    return 1
+}
+# ===== Extract data from JSON =====
+model_name=$(echo "$input" | jq -r '.model.display_name // "Claude"')
+model_name=$(echo "$model_name" | sed 's/ *(\([0-9.]*[kKmM]*\) context)/ \1/')  # "(1M context)" → "1M"
+
+# Context window
+size=$(echo "$input" | jq -r '.context_window.context_window_size // 200000')
+[ "$size" -eq 0 ] 2>/dev/null && size=200000
+
+# Token usage
+input_tokens=$(echo "$input" | jq -r '.context_window.current_usage.input_tokens // 0')
+cache_create=$(echo "$input" | jq -r '.context_window.current_usage.cache_creation_input_tokens // 0')
+cache_read=$(echo "$input" | jq -r '.context_window.current_usage.cache_read_input_tokens // 0')
+current=$(( input_tokens + cache_create + cache_read ))
+
+used_tokens=$(format_tokens $current)
+total_tokens=$(format_tokens $size)
+
+if [ "$size" -gt 0 ]; then
+    pct_used=$(( current * 100 / size ))
+else
+    pct_used=0
+fi
+pct_remain=$(( 100 - pct_used ))
+
+used_comma=$(format_commas $current)
+remain_comma=$(format_commas $(( size - current )))
+
+settings_path="$claude_config_dir/settings.json"
+effort_level=""
+stdin_effort=$(echo "$input" | jq -r '.effort.level // empty' 2>/dev/null)
+if [ -n "$stdin_effort" ]; then
+    effort_level="$stdin_effort"
+elif [ -n "$CLAUDE_CODE_EFFORT_LEVEL" ]; then
+    effort_level="$CLAUDE_CODE_EFFORT_LEVEL"
+elif [ -f "$settings_path" ]; then
+    effort_val=$(jq -r '.effortLevel // empty' "$settings_path" 2>/dev/null)
+    [ -n "$effort_val" ] && effort_level="$effort_val"
+fi
+[ -z "$effort_level" ] && effort_level="medium"
+
+# ===== Claude CLI version (cached, 1h TTL) =====
+cli_version_cache="/tmp/claude/statusline-cli-version"
+cli_version=""
+cli_version_max_age=3600
+
+if [ -f "$cli_version_cache" ]; then
+    cv_mtime=$(stat -c %Y "$cli_version_cache" 2>/dev/null || stat -f %m "$cli_version_cache" 2>/dev/null)
+    cv_now=$(date +%s)
+    cv_age=$(( cv_now - cv_mtime ))
+    if [ "$cv_age" -lt "$cli_version_max_age" ]; then
+        cli_version=$(cat "$cli_version_cache" 2>/dev/null)
+    fi
+fi
+
+if [ -z "$cli_version" ]; then
+    cli_version=$(claude --version 2>/dev/null | awk '{print $1}')
+    if [ -n "$cli_version" ]; then
+        mkdir -p /tmp/claude 2>/dev/null
+        echo "$cli_version" > "$cli_version_cache"
+    fi
+fi
+
+# ===== Build single-line output =====
+out=""
+out+="${blue}${model_name}${reset}"
+
+# Current working directory
+cwd=$(echo "$input" | jq -r '.cwd // empty')
+if [ -n "$cwd" ]; then
+    display_dir="${cwd##*/}"
+    git_branch=$(git -C "${cwd}" rev-parse --abbrev-ref HEAD 2>/dev/null)
+    out+=" ${dim}|${reset} "
+    out+="${cyan}${display_dir}${reset}"
+    if [ -n "$git_branch" ]; then
+        out+="${dim}@${reset}${green}${git_branch}${reset}"
+        git_stat=$(git -C "${cwd}" diff --numstat 2>/dev/null | awk '{a+=$1; d+=$2} END {if (a+d>0) printf "+%d -%d", a, d}')
+        [ -n "$git_stat" ] && out+=" ${dim}(${reset}${green}${git_stat%% *}${reset} ${red}${git_stat##* }${reset}${dim})${reset}"
+    fi
+fi
+
+out+=" ${dim}|${reset} "
+out+="${orange}${used_tokens}/${total_tokens}${reset} ${dim}(${reset}${green}${pct_used}%${reset}${dim})${reset}"
+out+=" ${dim}|${reset} "
+out+="effort: "
+case "$effort_level" in
+    low)    out+="${dim}${effort_level}${reset}" ;;
+    medium) out+="${orange}med${reset}" ;;
+    high)   out+="${green}${effort_level}${reset}" ;;
+    xhigh)  out+="${purple}${effort_level}${reset}" ;;
+    max)    out+="${red}${effort_level}${reset}" ;;
+    *)      out+="${green}${effort_level}${reset}" ;;
+esac
+
+# ===== Cross-platform OAuth token resolution (from statusline.sh) =====
+# Tries credential sources in order: env var → macOS Keychain → Linux creds file → GNOME Keyring
+get_oauth_token() {
+    local token=""
+
+    # 1. Explicit env var override
+    if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+        echo "$CLAUDE_CODE_OAUTH_TOKEN"
+        return 0
+    fi
+
+    # 2. macOS Keychain (Claude Code appends a SHA256 hash of CLAUDE_CONFIG_DIR to the service name)
+    if command -v security >/dev/null 2>&1; then
+        local keychain_svc="Claude Code-credentials"
+        if [ -n "$CLAUDE_CONFIG_DIR" ]; then
+            local dir_hash
+            dir_hash=$(echo -n "$CLAUDE_CONFIG_DIR" | shasum -a 256 | cut -c1-8)
+            keychain_svc="Claude Code-credentials-${dir_hash}"
+        fi
+        local blob
+        blob=$(security find-generic-password -s "$keychain_svc" -w 2>/dev/null)
+        if [ -n "$blob" ]; then
+            token=$(echo "$blob" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
+            if [ -n "$token" ] && [ "$token" != "null" ]; then
+                echo "$token"
+                return 0
+            fi
+        fi
+    fi
+
+    # 3. Linux credentials file
+    local creds_file="${claude_config_dir}/.credentials.json"
+    if [ -f "$creds_file" ]; then
+        token=$(jq -r '.claudeAiOauth.accessToken // empty' "$creds_file" 2>/dev/null)
+        if [ -n "$token" ] && [ "$token" != "null" ]; then
+            echo "$token"
+            return 0
+        fi
+    fi
+
+    # 4. GNOME Keyring via secret-tool
+    if command -v secret-tool >/dev/null 2>&1; then
+        local blob
+        blob=$(timeout 2 secret-tool lookup service "Claude Code-credentials" 2>/dev/null)
+        if [ -n "$blob" ]; then
+            token=$(echo "$blob" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
+            if [ -n "$token" ] && [ "$token" != "null" ]; then
+                echo "$token"
+                return 0
+            fi
+        fi
+    fi
+
+    echo ""
+}
+
+# ===== LINE 2 & 3: Usage limits with progress bars =====
+# First, try to use rate_limits data provided directly by Claude Code in the JSON input.
+# This is the most reliable source — no OAuth token or API call required.
+builtin_five_hour_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+builtin_five_hour_reset=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
+builtin_seven_day_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+builtin_seven_day_reset=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
+
+use_builtin=false
+if [ -n "$builtin_five_hour_pct" ] || [ -n "$builtin_seven_day_pct" ]; then
+    use_builtin=true
+fi
+
+# Cache setup — shared across all Claude Code instances to avoid rate limits
+claude_config_dir_hash=$(echo -n "$claude_config_dir" | shasum -a 256 2>/dev/null || echo -n "$claude_config_dir" | sha256sum 2>/dev/null)
+claude_config_dir_hash=$(echo "$claude_config_dir_hash" | cut -c1-8)
+cache_file="/tmp/claude/statusline-usage-cache-${claude_config_dir_hash}.json"
+cache_max_age=60  # seconds between API calls
+mkdir -p /tmp/claude
+
+needs_refresh=true
+usage_data=""
+
+# Always load cache — used as primary source for API path, and as fallback when builtin reports zero
+if [ -f "$cache_file" ] && [ -s "$cache_file" ]; then
+    cache_mtime=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null)
+    now=$(date +%s)
+    cache_age=$(( now - cache_mtime ))
+    if [ "$cache_age" -lt "$cache_max_age" ]; then
+        needs_refresh=false
+    fi
+    usage_data=$(cat "$cache_file" 2>/dev/null)
+fi
+
+# When builtin values are all zero AND reset timestamps are missing, it likely indicates
+# an API failure on Claude's side — fall through to cached data instead of displaying
+# misleading 0%. Genuine zero responses (after a billing reset) still include valid
+# resets_at timestamps, so we trust those.
+effective_builtin=false
+if $use_builtin; then
+    # Trust builtin if any percentage is non-zero
+    if { [ -n "$builtin_five_hour_pct" ] && [ "$(printf '%.0f' "$builtin_five_hour_pct" 2>/dev/null)" != "0" ]; } || \
+       { [ -n "$builtin_seven_day_pct" ] && [ "$(printf '%.0f' "$builtin_seven_day_pct" 2>/dev/null)" != "0" ]; }; then
+        effective_builtin=true
+    fi
+    # Also trust if reset timestamps are present — genuine zero responses include valid reset times
+    if ! $effective_builtin; then
+        if { [ -n "$builtin_five_hour_reset" ] && [ "$builtin_five_hour_reset" != "null" ] && [ "$builtin_five_hour_reset" != "0" ]; } || \
+           { [ -n "$builtin_seven_day_reset" ] && [ "$builtin_seven_day_reset" != "null" ] && [ "$builtin_seven_day_reset" != "0" ]; }; then
+            effective_builtin=true
+        fi
+    fi
+fi
+
+# Refresh API cache when stale — runs regardless of builtin rate_limits because
+# extra_usage is only exposed through the OAuth usage endpoint (not stdin JSON).
+# Throttled to cache_max_age and stampede-locked via touch for shared panes.
+if $needs_refresh; then
+    touch "$cache_file"  # stampede lock: prevent parallel panes from fetching simultaneously
+    token=$(get_oauth_token)
+    if [ -n "$token" ] && [ "$token" != "null" ]; then
+        response=$(curl -s --max-time 10 \
+            -H "Accept: application/json" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $token" \
+            -H "anthropic-beta: oauth-2025-04-20" \
+            -H "User-Agent: claude-code/2.1.34" \
+            "https://api.anthropic.com/api/oauth/usage" 2>/dev/null)
+        # Only cache valid usage responses (not error/rate-limit JSON)
+        if [ -n "$response" ] && echo "$response" | jq -e '.five_hour' >/dev/null 2>&1; then
+            usage_data="$response"
+            echo "$response" > "$cache_file"
+        fi
+    fi
+    # Remove the stampede sentinel if the fetch failed to produce valid JSON —
+    # otherwise an empty cache file would suppress retries for a full cache_max_age window.
+    [ -f "$cache_file" ] && [ ! -s "$cache_file" ] && rm -f "$cache_file"
+fi
+
+# Cross-platform ISO to epoch conversion
+# Converts ISO 8601 timestamp (e.g. "2025-06-15T12:30:00Z" or "2025-06-15T12:30:00.123+00:00") to epoch seconds.
+# Properly handles UTC timestamps and converts to local time.
+iso_to_epoch() {
+    local iso_str="$1"
+
+    # Try GNU date first (Linux) — handles ISO 8601 format automatically
+    local epoch
+    epoch=$(date -d "${iso_str}" +%s 2>/dev/null)
+    if [ -n "$epoch" ]; then
+        echo "$epoch"
+        return 0
+    fi
+
+    # BSD date (macOS) - handle various ISO 8601 formats
+    local stripped="${iso_str%%.*}"          # Remove fractional seconds (.123456)
+    stripped="${stripped%%Z}"                 # Remove trailing Z
+    stripped="${stripped%%+*}"               # Remove timezone offset (+00:00)
+    stripped="${stripped%%-[0-9][0-9]:[0-9][0-9]}"  # Remove negative timezone offset
+
+    # Check if timestamp is UTC (has Z or +00:00 or -00:00)
+    if [[ "$iso_str" == *"Z"* ]] || [[ "$iso_str" == *"+00:00"* ]] || [[ "$iso_str" == *"-00:00"* ]]; then
+        # For UTC timestamps, parse with timezone set to UTC
+        epoch=$(env TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$stripped" +%s 2>/dev/null)
+    else
+        epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$stripped" +%s 2>/dev/null)
+    fi
+
+    if [ -n "$epoch" ]; then
+        echo "$epoch"
+        return 0
+    fi
+
+    return 1
+}
+
+# Format ISO reset time to compact local time
+# Usage: format_reset_time <iso_string> <style: time|datetime|date>
+format_reset_time() {
+    local iso_str="$1"
+    local style="$2"
+    { [ -z "$iso_str" ] || [ "$iso_str" = "null" ]; } && return
+
+    # Parse ISO datetime and convert to local time (cross-platform)
+    local epoch
+    epoch=$(iso_to_epoch "$iso_str")
+    [ -z "$epoch" ] && return
+
+    # Format based on style
+    # Try GNU date first (Linux), then BSD date (macOS)
+    # Previous implementation piped BSD date through sed/tr, which always returned
+    # exit code 0 from the last pipe stage, preventing the GNU date fallback from
+    # ever executing on Linux.
+    local formatted=""
+    case "$style" in
+        time)
+            formatted=$(date -d "@$epoch" +"%H:%M" 2>/dev/null) || \
+            formatted=$(date -j -r "$epoch" +"%H:%M" 2>/dev/null)
+            ;;
+        datetime)
+            formatted=$(date -d "@$epoch" +"%a %b %-d, %H:%M" 2>/dev/null) || \
+            formatted=$(date -j -r "$epoch" +"%a %b %-d, %H:%M" 2>/dev/null)
+            ;;
+        *)
+            formatted=$(date -d "@$epoch" +"%b %-d" 2>/dev/null) || \
+            formatted=$(date -j -r "$epoch" +"%b %-d" 2>/dev/null)
+            ;;
+    esac
+    [ -n "$formatted" ] && echo "$formatted"
+}
+
+sep=" ${dim}|${reset} "
+
+# Render extra_usage segment from API usage data (not available via stdin rate_limits).
+# Appends to the global $out. No-op when data is missing or is_enabled is false.
+render_extra_usage() {
+    local data="$1"
+    [ -z "$data" ] && return
+    local enabled
+    enabled=$(echo "$data" | jq -r '.extra_usage.is_enabled // false' 2>/dev/null)
+    [ "$enabled" != "true" ] && return
+
+    local pct used limit
+    pct=$(echo "$data" | jq -r '.extra_usage.utilization // 0' | awk '{printf "%.0f", $1}')
+    used=$(echo "$data" | jq -r '.extra_usage.used_credits // 0' | LC_NUMERIC=C awk '{printf "%.2f", $1/100}')
+    limit=$(echo "$data" | jq -r '.extra_usage.monthly_limit // 0' | LC_NUMERIC=C awk '{printf "%.2f", $1/100}')
+
+    if [ -n "$used" ] && [ -n "$limit" ] && [[ "$used" != *'$'* ]] && [[ "$limit" != *'$'* ]]; then
+        local color
+        color=$(usage_color "$pct")
+        out+="${sep}${white}extra${reset} ${color}\$${used}/\$${limit}${reset}"
+    else
+        out+="${sep}${white}extra${reset} ${green}enabled${reset}"
+    fi
+}
+
+if $effective_builtin; then
+    # ---- Use rate_limits data provided directly by Claude Code in JSON input ----
+    # resets_at values are Unix epoch integers in this source
+    if [ -n "$builtin_five_hour_pct" ]; then
+        five_hour_pct=$(printf "%.0f" "$builtin_five_hour_pct")
+        five_hour_color=$(usage_color "$five_hour_pct")
+        out+="${sep}${white}5h${reset} ${five_hour_color}${five_hour_pct}%${reset}"
+        if [ -n "$builtin_five_hour_reset" ] && [ "$builtin_five_hour_reset" != "null" ]; then
+            five_hour_reset=$(date -j -r "$builtin_five_hour_reset" +"%H:%M" 2>/dev/null || date -d "@$builtin_five_hour_reset" +"%H:%M" 2>/dev/null)
+            [ -n "$five_hour_reset" ] && out+=" ${dim}@${five_hour_reset}${reset}"
+        fi
+    fi
+
+    if [ -n "$builtin_seven_day_pct" ]; then
+        seven_day_pct=$(printf "%.0f" "$builtin_seven_day_pct")
+        seven_day_color=$(usage_color "$seven_day_pct")
+        out+="${sep}${white}7d${reset} ${seven_day_color}${seven_day_pct}%${reset}"
+        if [ -n "$builtin_seven_day_reset" ] && [ "$builtin_seven_day_reset" != "null" ]; then
+            seven_day_reset=$(date -j -r "$builtin_seven_day_reset" +"%a %b %-d, %H:%M" 2>/dev/null || date -d "@$builtin_seven_day_reset" +"%a %b %-d, %H:%M" 2>/dev/null)
+            [ -n "$seven_day_reset" ] && out+=" ${dim}@${seven_day_reset}${reset}"
+        fi
+    fi
+
+    # Render extra_usage from API cache (stdin rate_limits doesn't expose it)
+    render_extra_usage "$usage_data"
+
+    # Cache builtin values so they're available as fallback when API is unavailable.
+    # Convert epoch resets_at to ISO 8601 for compatibility with the API-format cache parser.
+    # Preserve extra_usage from prior API response so we don't clobber it.
+    _fh_reset_json="null"
+    if [ -n "$builtin_five_hour_reset" ] && [ "$builtin_five_hour_reset" != "null" ] && [ "$builtin_five_hour_reset" != "0" ]; then
+        _fh_iso=$(date -u -r "$builtin_five_hour_reset" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || \
+                  date -u -d "@$builtin_five_hour_reset" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null)
+        [ -n "$_fh_iso" ] && _fh_reset_json="\"$_fh_iso\""
+    fi
+    _sd_reset_json="null"
+    if [ -n "$builtin_seven_day_reset" ] && [ "$builtin_seven_day_reset" != "null" ] && [ "$builtin_seven_day_reset" != "0" ]; then
+        _sd_iso=$(date -u -r "$builtin_seven_day_reset" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || \
+                  date -u -d "@$builtin_seven_day_reset" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null)
+        [ -n "$_sd_iso" ] && _sd_reset_json="\"$_sd_iso\""
+    fi
+    _extra_json=$(echo "$usage_data" | jq -c '.extra_usage // null' 2>/dev/null)
+    [ -z "$_extra_json" ] && _extra_json="null"
+    printf '{"five_hour":{"utilization":%s,"resets_at":%s},"seven_day":{"utilization":%s,"resets_at":%s},"extra_usage":%s}' \
+        "${builtin_five_hour_pct:-0}" "$_fh_reset_json" \
+        "${builtin_seven_day_pct:-0}" "$_sd_reset_json" \
+        "$_extra_json" > "$cache_file" 2>/dev/null
+elif [ -n "$usage_data" ] && echo "$usage_data" | jq -e '.five_hour' >/dev/null 2>&1; then
+    # ---- Fall back: API-fetched usage data ----
+    # ---- 5-hour (current) ----
+    five_hour_pct=$(echo "$usage_data" | jq -r '.five_hour.utilization // 0' | awk '{printf "%.0f", $1}')
+    five_hour_reset_iso=$(echo "$usage_data" | jq -r '.five_hour.resets_at // empty')
+    five_hour_reset=$(format_reset_time "$five_hour_reset_iso" "time")
+    five_hour_color=$(usage_color "$five_hour_pct")
+
+    out+="${sep}${white}5h${reset} ${five_hour_color}${five_hour_pct}%${reset}"
+    [ -n "$five_hour_reset" ] && out+=" ${dim}@${five_hour_reset}${reset}"
+
+    # ---- 7-day (weekly) ----
+    seven_day_pct=$(echo "$usage_data" | jq -r '.seven_day.utilization // 0' | awk '{printf "%.0f", $1}')
+    seven_day_reset_iso=$(echo "$usage_data" | jq -r '.seven_day.resets_at // empty')
+    seven_day_reset=$(format_reset_time "$seven_day_reset_iso" "datetime")
+    seven_day_color=$(usage_color "$seven_day_pct")
+
+    out+="${sep}${white}7d${reset} ${seven_day_color}${seven_day_pct}%${reset}"
+    [ -n "$seven_day_reset" ] && out+=" ${dim}@${seven_day_reset}${reset}"
+
+    render_extra_usage "$usage_data"
+else
+    # No valid usage data — show placeholders
+    out+="${sep}${white}5h${reset} ${dim}-${reset}"
+    out+="${sep}${white}7d${reset} ${dim}-${reset}"
+fi
+
+# ===== Update check (cached, 24h TTL) =====
+# Set STATUSLINE_CHECK_UPDATES=false to disable the update check (no network calls).
+update_line=""
+if [ "${STATUSLINE_CHECK_UPDATES:-true}" != "false" ]; then
+    version_cache_file="/tmp/claude/statusline-version-cache.json"
+    version_cache_max_age=86400  # 24 hours
+
+    version_needs_refresh=true
+    version_data=""
+
+    if [ -f "$version_cache_file" ]; then
+        vc_mtime=$(stat -c %Y "$version_cache_file" 2>/dev/null || stat -f %m "$version_cache_file" 2>/dev/null)
+        vc_now=$(date +%s)
+        vc_age=$(( vc_now - vc_mtime ))
+        if [ "$vc_age" -lt "$version_cache_max_age" ]; then
+            version_needs_refresh=false
+        fi
+        version_data=$(cat "$version_cache_file" 2>/dev/null)
+    fi
+
+    if $version_needs_refresh; then
+        touch "$version_cache_file" 2>/dev/null
+        vc_response=$(curl -s --max-time 5 \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/daniel3303/ClaudeCodeStatusLine/releases/latest" 2>/dev/null)
+        if [ -n "$vc_response" ] && echo "$vc_response" | jq -e '.tag_name' >/dev/null 2>&1; then
+            version_data="$vc_response"
+            echo "$vc_response" > "$version_cache_file"
+        elif [ ! -s "$version_cache_file" ]; then
+            rm -f "$version_cache_file" 2>/dev/null
+        fi
+    fi
+
+    if [ -n "$version_data" ]; then
+        latest_tag=$(echo "$version_data" | jq -r '.tag_name // empty')
+        if [ -n "$latest_tag" ] && version_gt "$latest_tag" "$VERSION"; then
+            update_line="\n${dim}Update available: ${latest_tag} → Tell Claude: \"Find my installed status bar and update it\"${reset}"
+        fi
+    fi
+fi
+
+# Append CLI version as last segment
+if [ -n "$cli_version" ]; then
+    out+=" ${dim}|${reset} ${orange}v${cli_version}${reset}"
+fi
+
+# Output
+printf "%b" "$out$update_line"
+
+exit 0

--- a/scripts/seed-data/sources/02-usage-dot-bars.sh
+++ b/scripts/seed-data/sources/02-usage-dot-bars.sh
@@ -1,0 +1,335 @@
+#!/bin/bash
+set -f
+
+input=$(cat)
+
+if [ -z "$input" ]; then
+    printf "Claude"
+    exit 0
+fi
+
+# ── Colors ──────────────────────────────────────────────
+blue='\033[38;2;0;153;255m'
+orange='\033[38;2;255;176;85m'
+green='\033[38;2;0;175;80m'
+cyan='\033[38;2;86;182;194m'
+red='\033[38;2;255;85;85m'
+yellow='\033[38;2;230;200;0m'
+white='\033[38;2;220;220;220m'
+magenta='\033[38;2;180;140;255m'
+dim='\033[2m'
+reset='\033[0m'
+
+sep=" ${dim}│${reset} "
+
+# ── Helpers ─────────────────────────────────────────────
+color_for_pct() {
+    local pct=$1
+    if [ "$pct" -ge 90 ]; then printf "$red"
+    elif [ "$pct" -ge 70 ]; then printf "$yellow"
+    elif [ "$pct" -ge 50 ]; then printf "$orange"
+    else printf "$green"
+    fi
+}
+
+build_bar() {
+    local pct=$1
+    local width=$2
+    [ "$pct" -lt 0 ] 2>/dev/null && pct=0
+    [ "$pct" -gt 100 ] 2>/dev/null && pct=100
+
+    local filled=$(( pct * width / 100 ))
+    local empty=$(( width - filled ))
+    local bar_color
+    bar_color=$(color_for_pct "$pct")
+
+    local filled_str="" empty_str=""
+    for ((i=0; i<filled; i++)); do filled_str+="●"; done
+    for ((i=0; i<empty; i++)); do empty_str+="○"; done
+
+    printf "${bar_color}${filled_str}${dim}${empty_str}${reset}"
+}
+
+format_epoch_time() {
+    local epoch=$1
+    local style=$2
+    [ -z "$epoch" ] || [ "$epoch" = "null" ] || [ "$epoch" = "0" ] && return
+
+    local result=""
+    case "$style" in
+        time)
+            result=$(date -j -r "$epoch" +"%l:%M%p" 2>/dev/null)
+            [ -z "$result" ] && result=$(date -d "@$epoch" +"%l:%M%P" 2>/dev/null)
+            result=$(echo "$result" | sed 's/^ //; s/\.//g' | tr '[:upper:]' '[:lower:]')
+            ;;
+        datetime)
+            result=$(date -j -r "$epoch" +"%b %-d, %l:%M%p" 2>/dev/null)
+            [ -z "$result" ] && result=$(date -d "@$epoch" +"%b %-d, %l:%M%P" 2>/dev/null)
+            result=$(echo "$result" | sed 's/  / /g; s/^ //; s/\.//g' | tr '[:upper:]' '[:lower:]')
+            ;;
+        *)
+            result=$(date -j -r "$epoch" +"%b %-d" 2>/dev/null)
+            [ -z "$result" ] && result=$(date -d "@$epoch" +"%b %-d" 2>/dev/null)
+            result=$(echo "$result" | tr '[:upper:]' '[:lower:]')
+            ;;
+    esac
+    printf "%s" "$result"
+}
+
+iso_to_epoch() {
+    local iso_str="$1"
+
+    local epoch
+    epoch=$(date -d "${iso_str}" +%s 2>/dev/null)
+    if [ -n "$epoch" ]; then
+        echo "$epoch"
+        return 0
+    fi
+
+    local stripped="${iso_str%%.*}"
+    stripped="${stripped%%Z}"
+    stripped="${stripped%%+*}"
+    stripped="${stripped%%-[0-9][0-9]:[0-9][0-9]}"
+
+    if [[ "$iso_str" == *"Z"* ]] || [[ "$iso_str" == *"+00:00"* ]] || [[ "$iso_str" == *"-00:00"* ]]; then
+        epoch=$(env TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$stripped" +%s 2>/dev/null)
+        [ -z "$epoch" ] && epoch=$(env TZ=UTC date -d "${stripped/T/ }" +%s 2>/dev/null)
+    else
+        epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$stripped" +%s 2>/dev/null)
+        [ -z "$epoch" ] && epoch=$(date -d "${stripped/T/ }" +%s 2>/dev/null)
+    fi
+
+    if [ -n "$epoch" ]; then
+        echo "$epoch"
+        return 0
+    fi
+
+    return 1
+}
+
+# ── Extract JSON data ───────────────────────────────────
+model_name=$(echo "$input" | jq -r '.model.display_name // "Claude"')
+
+size=$(echo "$input" | jq -r '.context_window.context_window_size // 200000')
+[ "$size" -eq 0 ] 2>/dev/null && size=200000
+
+input_tokens=$(echo "$input" | jq -r '.context_window.current_usage.input_tokens // 0')
+cache_create=$(echo "$input" | jq -r '.context_window.current_usage.cache_creation_input_tokens // 0')
+cache_read=$(echo "$input" | jq -r '.context_window.current_usage.cache_read_input_tokens // 0')
+current=$(( input_tokens + cache_create + cache_read ))
+
+if [ "$size" -gt 0 ]; then
+    pct_used=$(( current * 100 / size ))
+else
+    pct_used=0
+fi
+
+effort="default"
+settings_path="$HOME/.claude/settings.json"
+if [ -f "$settings_path" ]; then
+    effort=$(jq -r '.effortLevel // "default"' "$settings_path" 2>/dev/null)
+fi
+
+# ── LINE 1: Model │ Context % │ Directory (branch) │ Session │ Effort ──
+pct_color=$(color_for_pct "$pct_used")
+cwd=$(echo "$input" | jq -r '.cwd // ""')
+[ -z "$cwd" ] || [ "$cwd" = "null" ] && cwd=$(pwd)
+dirname=$(basename "$cwd")
+
+git_branch=""
+git_dirty=""
+if git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git_branch=$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null)
+    if [ -n "$(git -C "$cwd" --no-optional-locks status --porcelain 2>/dev/null)" ]; then
+        git_dirty="*"
+    fi
+fi
+
+session_duration=""
+session_start=$(echo "$input" | jq -r '.session.start_time // empty')
+if [ -n "$session_start" ] && [ "$session_start" != "null" ]; then
+    start_epoch=$(iso_to_epoch "$session_start")
+    if [ -n "$start_epoch" ]; then
+        now_epoch=$(date +%s)
+        elapsed=$(( now_epoch - start_epoch ))
+        if [ "$elapsed" -ge 3600 ]; then
+            session_duration="$(( elapsed / 3600 ))h$(( (elapsed % 3600) / 60 ))m"
+        elif [ "$elapsed" -ge 60 ]; then
+            session_duration="$(( elapsed / 60 ))m"
+        else
+            session_duration="${elapsed}s"
+        fi
+    fi
+fi
+
+skip_perms=""
+parent_cmd=$(ps -o args= -p "$PPID" 2>/dev/null)
+if [[ "$parent_cmd" == *"--dangerously-skip-permissions"* ]]; then
+    skip_perms="⚡  "
+fi
+
+line1="${blue}${model_name}${reset}"
+line1+="${sep}"
+line1+="✍️ ${pct_color}${pct_used}%${reset}"
+line1+="${sep}"
+line1+="${skip_perms}${cyan}${dirname}${reset}"
+if [ -n "$git_branch" ]; then
+    line1+=" ${green}(${git_branch}${red}${git_dirty}${green})${reset}"
+fi
+if [ -n "$session_duration" ]; then
+    line1+="${sep}"
+    line1+="${dim}⏱ ${reset}${white}${session_duration}${reset}"
+fi
+line1+="${sep}"
+case "$effort" in
+    high)   line1+="${magenta}● ${effort}${reset}" ;;
+    medium) line1+="${dim}◑ ${effort}${reset}" ;;
+    low)    line1+="${dim}◔ ${effort}${reset}" ;;
+    *)      line1+="${dim}◑ ${effort}${reset}" ;;
+esac
+
+# ── Rate limits from stdin (primary) ───────────────────
+has_stdin_rates=false
+five_hour_pct=""
+five_hour_reset_epoch=""
+seven_day_pct=""
+seven_day_reset_epoch=""
+
+stdin_five_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+if [ -n "$stdin_five_pct" ]; then
+    has_stdin_rates=true
+    five_hour_pct=$(printf "%.0f" "$stdin_five_pct")
+    five_hour_reset_epoch=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
+    seven_day_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty' | awk '{printf "%.0f", $1}')
+    seven_day_reset_epoch=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
+fi
+
+# ── Fallback: API call (cached) ────────────────────────
+cache_file="/tmp/claude/statusline-usage-cache.json"
+cache_max_age=60
+mkdir -p /tmp/claude
+
+usage_data=""
+extra_enabled="false"
+
+if ! $has_stdin_rates; then
+    needs_refresh=true
+
+    if [ -f "$cache_file" ]; then
+        cache_mtime=$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null)
+        now=$(date +%s)
+        cache_age=$(( now - cache_mtime ))
+        if [ "$cache_age" -lt "$cache_max_age" ]; then
+            needs_refresh=false
+            usage_data=$(cat "$cache_file" 2>/dev/null)
+        fi
+    fi
+
+    if $needs_refresh; then
+        token=""
+        if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            token="$CLAUDE_CODE_OAUTH_TOKEN"
+        elif command -v security >/dev/null 2>&1; then
+            blob=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null)
+            if [ -n "$blob" ]; then
+                token=$(echo "$blob" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
+            fi
+        fi
+        if [ -z "$token" ] || [ "$token" = "null" ]; then
+            creds_file="${HOME}/.claude/.credentials.json"
+            if [ -f "$creds_file" ]; then
+                token=$(jq -r '.claudeAiOauth.accessToken // empty' "$creds_file" 2>/dev/null)
+            fi
+        fi
+        if [ -z "$token" ] || [ "$token" = "null" ]; then
+            if command -v secret-tool >/dev/null 2>&1; then
+                blob=$(timeout 2 secret-tool lookup service "Claude Code-credentials" 2>/dev/null)
+                if [ -n "$blob" ]; then
+                    token=$(echo "$blob" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
+                fi
+            fi
+        fi
+
+        if [ -n "$token" ] && [ "$token" != "null" ]; then
+            response=$(curl -s --max-time 5 \
+                -H "Accept: application/json" \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $token" \
+                -H "anthropic-beta: oauth-2025-04-20" \
+                -H "User-Agent: claude-code/2.1.34" \
+                "https://api.anthropic.com/api/oauth/usage" 2>/dev/null)
+            if [ -n "$response" ] && echo "$response" | jq -e '.five_hour' >/dev/null 2>&1; then
+                usage_data="$response"
+                echo "$response" > "$cache_file"
+            fi
+        fi
+        if [ -z "$usage_data" ] && [ -f "$cache_file" ]; then
+            usage_data=$(cat "$cache_file" 2>/dev/null)
+        fi
+    fi
+
+    if [ -n "$usage_data" ] && echo "$usage_data" | jq -e . >/dev/null 2>&1; then
+        five_hour_pct=$(echo "$usage_data" | jq -r '.five_hour.utilization // 0' | awk '{printf "%.0f", $1}')
+        five_hour_reset_iso=$(echo "$usage_data" | jq -r '.five_hour.resets_at // empty')
+        five_hour_reset_epoch=$(iso_to_epoch "$five_hour_reset_iso")
+        seven_day_pct=$(echo "$usage_data" | jq -r '.seven_day.utilization // 0' | awk '{printf "%.0f", $1}')
+        seven_day_reset_iso=$(echo "$usage_data" | jq -r '.seven_day.resets_at // empty')
+        seven_day_reset_epoch=$(iso_to_epoch "$seven_day_reset_iso")
+
+        extra_enabled=$(echo "$usage_data" | jq -r '.extra_usage.is_enabled // false')
+    fi
+else
+    if [ -f "$cache_file" ]; then
+        usage_data=$(cat "$cache_file" 2>/dev/null)
+        if [ -n "$usage_data" ] && echo "$usage_data" | jq -e . >/dev/null 2>&1; then
+            extra_enabled=$(echo "$usage_data" | jq -r '.extra_usage.is_enabled // false')
+        fi
+    fi
+fi
+
+# ── Rate limit lines ────────────────────────────────────
+rate_lines=""
+bar_width=10
+
+if [ -n "$five_hour_pct" ]; then
+    five_hour_reset=$(format_epoch_time "$five_hour_reset_epoch" "time")
+    five_hour_bar=$(build_bar "$five_hour_pct" "$bar_width")
+    five_hour_pct_color=$(color_for_pct "$five_hour_pct")
+    five_hour_pct_fmt=$(printf "%3d" "$five_hour_pct")
+
+    rate_lines+="${white}current${reset} ${five_hour_bar} ${five_hour_pct_color}${five_hour_pct_fmt}%${reset}"
+    [ -n "$five_hour_reset" ] && rate_lines+=" ${dim}⟳${reset} ${white}${five_hour_reset}${reset}"
+fi
+
+if [ -n "$seven_day_pct" ]; then
+    seven_day_reset=$(format_epoch_time "$seven_day_reset_epoch" "datetime")
+    seven_day_bar=$(build_bar "$seven_day_pct" "$bar_width")
+    seven_day_pct_color=$(color_for_pct "$seven_day_pct")
+    seven_day_pct_fmt=$(printf "%3d" "$seven_day_pct")
+
+    [ -n "$rate_lines" ] && rate_lines+="\n"
+    rate_lines+="${white}weekly${reset}  ${seven_day_bar} ${seven_day_pct_color}${seven_day_pct_fmt}%${reset}"
+    [ -n "$seven_day_reset" ] && rate_lines+=" ${dim}⟳${reset} ${white}${seven_day_reset}${reset}"
+fi
+
+if [ "$extra_enabled" = "true" ] && [ -n "$usage_data" ]; then
+    extra_pct=$(echo "$usage_data" | jq -r '.extra_usage.utilization // 0' | awk '{printf "%.0f", $1}')
+    extra_used=$(echo "$usage_data" | jq -r '.extra_usage.used_credits // 0' | awk '{printf "%.2f", $1/100}')
+    extra_limit=$(echo "$usage_data" | jq -r '.extra_usage.monthly_limit // 0' | awk '{printf "%.2f", $1/100}')
+    extra_bar=$(build_bar "$extra_pct" "$bar_width")
+    extra_pct_color=$(color_for_pct "$extra_pct")
+
+    extra_reset=$(date -v+1m -v1d +"%b %-d" 2>/dev/null | tr '[:upper:]' '[:lower:]')
+    if [ -z "$extra_reset" ]; then
+        extra_reset=$(date -d "$(date +%Y-%m-01) +1 month" +"%b %-d" 2>/dev/null | tr '[:upper:]' '[:lower:]')
+    fi
+
+    [ -n "$rate_lines" ] && rate_lines+="\n"
+    rate_lines+="${white}extra${reset}   ${extra_bar} ${extra_pct_color}\$${extra_used}${dim}/${reset}${white}\$${extra_limit}${reset} ${dim}⟳${reset} ${white}${extra_reset}${reset}"
+fi
+
+# ── Output ──────────────────────────────────────────────
+printf "%b" "$line1"
+[ -n "$rate_lines" ] && printf "\n\n%b" "$rate_lines"
+
+exit 0

--- a/scripts/seed-data/sources/03-three-line-cockpit.sh
+++ b/scripts/seed-data/sources/03-three-line-cockpit.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# Claude Code statusline script (ToS-safe version)
+# Line 1: Model | Context% | +added/-removed | git branch
+# Line 2: Context window progress bar (detailed)
+# Line 3: Session cost | Version
+#
+# This version uses ONLY stdin data provided by Claude Code.
+# No external API calls, no OAuth token extraction, no keychain access.
+# Fully compliant with Anthropic Consumer Terms of Service.
+
+set -euo pipefail
+
+# ---------- Read stdin (Claude Code provides JSON) ----------
+input=$(cat)
+
+# ---------- ANSI Colors ----------
+readonly GREEN=$'\e[38;2;151;201;195m'
+readonly YELLOW=$'\e[38;2;229;192;123m'
+readonly RED=$'\e[38;2;224;108;117m'
+readonly GRAY=$'\e[38;2;74;88;92m'
+readonly RESET=$'\e[0m'
+readonly DIM=$'\e[2m'
+
+# ---------- Color by percentage ----------
+color_for_pct() {
+  local pct="${1:-0}"
+  if [[ -z "$pct" || "$pct" == "null" ]]; then
+    printf '%s' "$GRAY"
+    return
+  fi
+  local ipct
+  ipct=$(printf "%.0f" "$pct" 2>/dev/null) || ipct=0
+  if (( ipct >= 80 )); then
+    printf '%s' "$RED"
+  elif (( ipct >= 50 )); then
+    printf '%s' "$YELLOW"
+  else
+    printf '%s' "$GREEN"
+  fi
+}
+
+# ---------- Progress bar (10 segments) ----------
+progress_bar() {
+  local pct="${1:-0}"
+  local filled
+  filled=$(awk "BEGIN{v=int($pct / 10 + 0.5); if(v>10)v=10; if(v<0)v=0; printf \"%d\", v}" 2>/dev/null) || filled=0
+  local bar=""
+  local i
+  for (( i=1; i<=10; i++ )); do
+    if (( i <= filled )); then
+      bar+="▰"
+    else
+      bar+="▱"
+    fi
+  done
+  printf '%s' "$bar"
+}
+
+# ---------- Safe JSON parsing (no eval) ----------
+parse_json() {
+  local json="$1"
+  local query="$2"
+  local default="${3:-}"
+  local result
+  result=$(printf '%s' "$json" | jq -r "$query" 2>/dev/null) || result=""
+  if [[ -z "$result" || "$result" == "null" ]]; then
+    printf '%s' "$default"
+  else
+    printf '%s' "$result"
+  fi
+}
+
+# ---------- Parse stdin fields ----------
+model_name=$(parse_json "$input" '.model.display_name // empty' 'Unknown')
+used_pct=$(parse_json "$input" '.context_window.used_percentage // 0' '0')
+remaining_pct=$(parse_json "$input" '.context_window.remaining_percentage // 100' '100')
+ctx_size=$(parse_json "$input" '.context_window.context_window_size // 0' '0')
+cwd=$(parse_json "$input" '.cwd // empty' '')
+lines_added=$(parse_json "$input" '.cost.total_lines_added // 0' '0')
+lines_removed=$(parse_json "$input" '.cost.total_lines_removed // 0' '0')
+total_cost=$(parse_json "$input" '.cost.total_cost_usd // 0' '0')
+
+# ---------- Git branch ----------
+git_branch=""
+if [[ -n "$cwd" && -d "$cwd" ]]; then
+  git_branch=$(git -C "$cwd" --no-optional-locks rev-parse --abbrev-ref HEAD 2>/dev/null) || true
+fi
+
+# ---------- Line stats ----------
+git_stats=""
+if (( ${lines_added:-0} > 0 )) 2>/dev/null || (( ${lines_removed:-0} > 0 )) 2>/dev/null; then
+  git_stats="+${lines_added}/-${lines_removed}"
+fi
+
+# ---------- Context window formatting ----------
+ctx_pct_int=$(printf "%.0f" "${used_pct:-0}" 2>/dev/null) || ctx_pct_int=0
+
+# Format context size (e.g., 200000 -> 200K)
+format_tokens() {
+  local tokens="${1:-0}"
+  if (( tokens >= 1000000 )); then
+    awk "BEGIN{printf \"%.0fM\", $tokens / 1000000}"
+  elif (( tokens >= 1000 )); then
+    awk "BEGIN{printf \"%.0fK\", $tokens / 1000}"
+  else
+    printf '%s' "$tokens"
+  fi
+}
+
+ctx_size_display=$(format_tokens "$ctx_size")
+
+# Used tokens (approximate)
+used_tokens=0
+if (( ctx_size > 0 )); then
+  used_tokens=$(awk "BEGIN{printf \"%.0f\", $ctx_size * $used_pct / 100}" 2>/dev/null) || used_tokens=0
+fi
+used_tokens_display=$(format_tokens "$used_tokens")
+
+# ---------- Cost formatting ----------
+cost_display=""
+if [[ -n "$total_cost" && "$total_cost" != "0" ]]; then
+  cost_display=$(awk "BEGIN{printf \"\$%.2f\", $total_cost}" 2>/dev/null) || cost_display=""
+fi
+
+# ---------- Separator ----------
+SEP="${GRAY} │ ${RESET}"
+
+# ========== Line 1: Model | Context% | Changes | Branch ==========
+ctx_color=$(color_for_pct "$ctx_pct_int")
+
+line1="🤖 ${model_name}${SEP}${ctx_color}📊 ${ctx_pct_int}%${RESET}"
+
+if [[ -n "$git_stats" ]]; then
+  line1+="${SEP}✏️  ${GREEN}${git_stats}${RESET}"
+fi
+
+if [[ -n "$git_branch" ]]; then
+  line1+="${SEP}🔀 ${git_branch}"
+fi
+
+# ========== Line 2: Context window progress bar ==========
+ctx_bar_color=$(color_for_pct "$ctx_pct_int")
+ctx_bar=$(progress_bar "$ctx_pct_int")
+
+line2="${ctx_bar_color}📐 CTX  ${ctx_bar}  ${ctx_pct_int}%${RESET}"
+if (( ctx_size > 0 )); then
+  line2+="  ${DIM}${used_tokens_display} / ${ctx_size_display} tokens${RESET}"
+fi
+
+# ========== Line 3: Session cost ==========
+line3=""
+if [[ -n "$cost_display" ]]; then
+  line3="${GREEN}💰 ${cost_display}${RESET}"
+else
+  line3="${DIM}💰 --${RESET}"
+fi
+
+# ---------- Output ----------
+printf '%s\n' "$line1"
+printf '%s\n' "$line2"
+printf '%s' "$line3"

--- a/scripts/seed-data/sources/04-quota-at-a-glance.py
+++ b/scripts/seed-data/sources/04-quota-at-a-glance.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+import sys
+import json
+import urllib.request
+import urllib.error
+import subprocess
+import platform
+from pathlib import Path
+
+# ANSI colors
+BLUE = "\033[34m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+RED = "\033[31m"
+CYAN = "\033[36m"
+RESET = "\033[0m"
+
+USAGE_API_URL = "https://api.anthropic.com/api/oauth/usage"
+USAGE_THRESHOLD_HIGH = 80
+USAGE_THRESHOLD_MEDIUM = 50
+CREDENTIALS_PATH = Path.home() / ".claude" / ".credentials.json"
+
+def main():
+    try:
+        raw = sys.stdin.read()
+        data = json.loads(raw)
+    except Exception:
+        print("statusline: no data")
+        return
+
+    # Extract fields
+    current_directory = data.get("cwd", "")
+    model = data.get("model", {}).get("display_name", "")
+
+    # Fetch usage from API
+    access_token = get_access_token()
+
+    if access_token:
+        usage_data = fetch_usage(access_token)
+        usage_str = format_usage(usage_data)
+    else:
+        usage_str = f"{RED}No credentials{RESET}"
+
+    line = f"{BLUE}{model}{RESET} | {usage_str} | Dir: {current_directory}"
+
+    print(line)
+
+
+def get_access_token() -> str | None:
+    """Retrieve the access token based on the platform."""
+    system = platform.system()
+
+    if system == "Darwin":  # macOS
+        return get_access_token_macos()
+    elif system == "Linux":
+        return get_access_token_linux()
+    else:
+        return None # Windows not supported
+
+
+def get_access_token_macos() -> str | None:
+    """Retrieve access token from macOS Keychain."""
+    try:
+        result = subprocess.run(
+            ["security", "find-generic-password", "-s", "Claude Code-credentials", "-w"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=True
+        )
+        credentials = result.stdout.strip()
+        if credentials:
+            creds = json.loads(credentials)
+            return creds.get("claudeAiOauth", {}).get("accessToken")
+        return None
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError, KeyError):
+        return None
+
+
+def get_access_token_linux() -> str | None:
+    """Read access token from credentials file on Linux."""
+    try:
+        with open(CREDENTIALS_PATH) as f:
+            creds = json.load(f)
+        return creds.get("claudeAiOauth", {}).get("accessToken")
+    except (FileNotFoundError, json.JSONDecodeError, KeyError):
+        return None
+
+
+def fetch_usage(access_token: str) -> dict | None:
+    """Fetch usage data from Anthropic API."""
+    try:
+        req = urllib.request.Request(
+            USAGE_API_URL,
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json",
+                "anthropic-beta": "oauth-2025-04-20",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return json.loads(resp.read().decode())
+    except (urllib.error.URLError, json.JSONDecodeError, TimeoutError):
+        return None
+
+
+def format_usage(usage_data: dict) -> str:
+    """Format usage data for statusline display."""
+    if not usage_data:
+        return f"{RED}Usage: N/A{RESET}"
+
+    # Extract 5-hour and 7-day limits
+    five_hour_usage = usage_data.get("five_hour", {})
+    weekly_usage = usage_data.get("seven_day", {})
+
+    five_hour_percentage = five_hour_usage.get("utilization", 0) or 0
+    weekly_percentage = weekly_usage.get("utilization", 0) or 0
+
+    five_hour_str = f"{get_usage_color(five_hour_percentage)}{five_hour_percentage:.0f}%{RESET}"
+    weekly_str = f"{get_usage_color(weekly_percentage)}{weekly_percentage:.0f}%{RESET}"
+
+    return f"5h: {five_hour_str} | 7d: {weekly_str}"
+
+def get_usage_color(percentage: float) -> str:
+    if percentage >= USAGE_THRESHOLD_HIGH:
+        return RED
+    elif percentage >= USAGE_THRESHOLD_MEDIUM:
+        return YELLOW
+    return GREEN
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed-data/sources/05-overage-watcher.sh
+++ b/scripts/seed-data/sources/05-overage-watcher.sh
@@ -1,0 +1,468 @@
+#!/usr/bin/env bash
+# claude-code-statusline — Enhanced status line for Claude Code
+# https://github.com/aleksander-dytko/claude-code-statusline
+# MIT License — Aleksander Dytko 2026
+#
+# Displays: model | git repo@branch | ctx | cost | 5h limit | 7d limit | extra usage
+
+set -f  # disable globbing
+export LC_NUMERIC=C  # ensure '.' is decimal separator regardless of locale
+unset LC_ALL          # LC_ALL overrides LC_NUMERIC; unset it while preserving other locale vars
+
+# Detect stat variant once (GNU vs BSD) to avoid repeated fallback forks
+if stat -c %Y /dev/null >/dev/null 2>&1; then
+    _stat_mtime() { stat -c %Y "$1" 2>/dev/null; }
+else
+    _stat_mtime() { stat -f %m "$1" 2>/dev/null; }
+fi
+
+# ─── Configuration (override via environment variables) ─────────────────────
+STATUSLINE_SHOW_GIT="${STATUSLINE_SHOW_GIT:-true}"
+STATUSLINE_SHOW_CONTEXT="${STATUSLINE_SHOW_CONTEXT:-true}"
+STATUSLINE_SHOW_SESSION="${STATUSLINE_SHOW_SESSION:-true}"
+STATUSLINE_SHOW_WEEKLY="${STATUSLINE_SHOW_WEEKLY:-true}"
+STATUSLINE_SHOW_EXTRA="${STATUSLINE_SHOW_EXTRA:-true}"
+STATUSLINE_SHOW_SESSION_COST="${STATUSLINE_SHOW_SESSION_COST:-true}"
+STATUSLINE_SPLIT_LINES="${STATUSLINE_SPLIT_LINES:-false}"
+STATUSLINE_CACHE_TTL="${STATUSLINE_CACHE_TTL:-60}"           # seconds between API fetches
+STATUSLINE_CACHE_DIR="${STATUSLINE_CACHE_DIR:-/tmp/claude}"  # cache directory
+STATUSLINE_CURRENCY_SYMBOL="${STATUSLINE_CURRENCY_SYMBOL:-$}"  # set to € for Europe
+# ────────────────────────────────────────────────────────────────────────────
+
+input=$(cat)
+
+if [ -z "$input" ]; then
+    printf "Claude"
+    exit 0
+fi
+
+# Hard dependency check
+if ! command -v jq >/dev/null 2>&1; then
+    printf "Claude (install jq for full statusline — brew install jq)"
+    exit 0
+fi
+
+# ─── ANSI colors ────────────────────────────────────────────────────────────
+blue='\033[38;2;0;153;255m'
+orange='\033[38;2;255;176;85m'
+green='\033[38;2;0;160;0m'
+cyan='\033[38;2;46;149;153m'
+red='\033[38;2;255;85;85m'
+yellow='\033[38;2;230;200;0m'
+white='\033[38;2;220;220;220m'
+dim='\033[2m'
+reset='\033[0m'
+
+# ─── Helper functions ────────────────────────────────────────────────────────
+
+# ─── Color threshold reference ────────────────────────────────────────────────
+# Context window:  green < 50% | yellow 50–75% | red ≥ 75%
+# 5h session:      green < 70% | yellow 70–90% | red ≥ 90%
+# 7d weekly:       green < 70% | yellow 70–90% | red ≥ 90%
+# Extra usage:     green < 50% | yellow 50–80% | red ≥ 80%
+# Session cost:    white (informational, no threshold coloring)
+# Balance:         white (not available via OAuth API — field not returned)
+# ⚡ on 5h/7d:     utilization ≥ 100 (plan limit hit, routing to extra billing)
+# ⚡ on extra:     EITHER five_hour OR seven_day utilization ≥ 100
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Format token counts: 50000 → "50k", 1200000 → "1.2m"
+format_tokens() {
+    local num=$1
+    if [ "$num" -ge 1000000 ]; then
+        awk "BEGIN {printf \"%.1fm\", $num / 1000000}"
+    elif [ "$num" -ge 1000 ]; then
+        awk "BEGIN {printf \"%.0fk\", $num / 1000}"
+    else
+        printf "%d" "$num"
+    fi
+}
+
+# Color for plan limits (session / weekly): green < 70%, yellow 70-90%, red ≥ 90%
+plan_color() {
+    local pct=$1
+    if   [ "$pct" -ge 90 ]; then echo "$red"
+    elif [ "$pct" -ge 70 ]; then echo "$yellow"
+    else echo "$green"
+    fi
+}
+
+# Color for context window: green < 50%, yellow 50-75%, red ≥ 75%
+context_color() {
+    local pct=$1
+    if   [ "$pct" -ge 75 ]; then echo "$red"
+    elif [ "$pct" -ge 50 ]; then echo "$yellow"
+    else echo "$green"
+    fi
+}
+
+# Color for extra usage spend: green < 50%, yellow 50-80%, red ≥ 80%
+extra_color() {
+    local pct=$1
+    if   [ "$pct" -ge 80 ]; then echo "$red"
+    elif [ "$pct" -ge 50 ]; then echo "$yellow"
+    else echo "$green"
+    fi
+}
+
+# Resolve OAuth token — tries 4 sources in order
+get_oauth_token() {
+    # 1. Explicit env var override
+    if [ -n "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+        echo "$CLAUDE_CODE_OAUTH_TOKEN"
+        return 0
+    fi
+
+    # 2. macOS Keychain
+    if command -v security >/dev/null 2>&1; then
+        local blob
+        blob=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null)
+        if [ -n "$blob" ]; then
+            local token
+            token=$(echo "$blob" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
+            if [ -n "$token" ] && [ "$token" != "null" ]; then
+                echo "$token"; return 0
+            fi
+        fi
+    fi
+
+    # 3. Linux credentials file
+    local creds_file="${HOME}/.claude/.credentials.json"
+    if [ -f "$creds_file" ]; then
+        local token
+        token=$(jq -r '.claudeAiOauth.accessToken // empty' "$creds_file" 2>/dev/null)
+        if [ -n "$token" ] && [ "$token" != "null" ]; then
+            echo "$token"; return 0
+        fi
+    fi
+
+    # 4. GNOME Keyring via secret-tool
+    if command -v secret-tool >/dev/null 2>&1; then
+        local blob
+        blob=$(timeout 2 secret-tool lookup service "Claude Code-credentials" 2>/dev/null)
+        if [ -n "$blob" ]; then
+            local token
+            token=$(echo "$blob" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
+            if [ -n "$token" ] && [ "$token" != "null" ]; then
+                echo "$token"; return 0
+            fi
+        fi
+    fi
+
+    echo ""
+}
+
+# Convert ISO 8601 to Unix epoch (cross-platform: GNU date + BSD date)
+iso_to_epoch() {
+    local iso_str="$1"
+
+    # GNU date (Linux)
+    local epoch
+    epoch=$(date -d "${iso_str}" +%s 2>/dev/null)
+    [ -n "$epoch" ] && echo "$epoch" && return 0
+
+    # BSD date (macOS)
+    local stripped="${iso_str%%.*}"
+    stripped="${stripped%%Z}"
+    stripped="${stripped%%+*}"
+    stripped="${stripped%%-[0-9][0-9]:[0-9][0-9]}"
+
+    if [[ "$iso_str" == *"Z"* ]] || [[ "$iso_str" == *"+00:00"* ]] || [[ "$iso_str" == *"-00:00"* ]]; then
+        epoch=$(env TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$stripped" +%s 2>/dev/null)
+    else
+        epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$stripped" +%s 2>/dev/null)
+    fi
+
+    [ -n "$epoch" ] && echo "$epoch" && return 0
+    return 1
+}
+
+# Format ISO reset timestamp to compact local time
+# Styles: time (4:30pm) | datetime (Mar 6, 4:30pm) | date (Mar 6)
+format_reset_time() {
+    local iso_str="$1"
+    local style="$2"
+    [ -z "$iso_str" ] || [ "$iso_str" = "null" ] && return
+
+    local epoch
+    epoch=$(iso_to_epoch "$iso_str") || return
+
+    case "$style" in
+        time)
+            date -j -r "$epoch" +"%l:%M%p" 2>/dev/null | sed 's/^ //' | tr '[:upper:]' '[:lower:]' || \
+            date -d "@$epoch" +"%l:%M%P" 2>/dev/null | sed 's/^ //'
+            ;;
+        datetime)
+            date -j -r "$epoch" +"%b %-d, %l:%M%p" 2>/dev/null | sed 's/  / /g; s/^ //' | tr '[:upper:]' '[:lower:]' || \
+            date -d "@$epoch" +"%b %-d, %l:%M%P" 2>/dev/null | sed 's/  / /g; s/^ //'
+            ;;
+        *)
+            date -j -r "$epoch" +"%b %-d" 2>/dev/null | tr '[:upper:]' '[:lower:]' || \
+            date -d "@$epoch" +"%b %-d" 2>/dev/null
+            ;;
+    esac
+}
+
+# Format time remaining until reset: epoch → "in 2h 24min", "in 47min", "soon"
+format_countdown() {
+    local iso_str="$1"
+    [ -z "$iso_str" ] || [ "$iso_str" = "null" ] && return
+
+    local epoch
+    epoch=$(iso_to_epoch "$iso_str") || return
+
+    local now diff hours mins
+    now=$(date +%s)
+    diff=$(( epoch - now ))
+
+    [ "$diff" -le 0 ] && echo "soon" && return
+
+    hours=$(( diff / 3600 ))
+    mins=$(( (diff % 3600) / 60 ))
+
+    if   [ "$hours" -ge 24 ]; then echo "resets in $(( hours / 24 ))d"
+    elif [ "$hours" -ge 1 ];  then echo "resets in ${hours}h ${mins}min"
+    else echo "resets in ${mins}min"
+    fi
+}
+
+# ─── Parse stdin JSON ────────────────────────────────────────────────────────
+model_name=$(echo "$input" | jq -r '.model.display_name // "Claude"')
+cwd=$(echo "$input" | jq -r '.cwd // empty')
+
+size=$(echo "$input" | jq -r '.context_window.context_window_size // 200000')
+[ "$size" -eq 0 ] 2>/dev/null && size=200000
+
+input_tokens=$(echo "$input" | jq -r '.context_window.current_usage.input_tokens // 0')
+cache_create=$(echo "$input" | jq -r '.context_window.current_usage.cache_creation_input_tokens // 0')
+cache_read=$(echo "$input"   | jq -r '.context_window.current_usage.cache_read_input_tokens // 0')
+current=$(( input_tokens + cache_create + cache_read ))
+
+used_tokens=$(format_tokens "$current")
+total_tokens=$(format_tokens "$size")
+
+# Prefer stdin pre-calculated percentage; fall back to manual integer division
+pct_used_stdin=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+if [ -n "$pct_used_stdin" ] && [ "$pct_used_stdin" != "null" ]; then
+    pct_used=$(printf "%.0f" "$pct_used_stdin" 2>/dev/null || echo 0)
+else
+    pct_used=$(( size > 0 ? current * 100 / size : 0 ))
+fi
+
+# Session cost from stdin (no API call needed)
+session_cost=$(echo "$input" | jq -r '.cost.total_cost_usd // 0')
+
+# Worktree info from stdin (more accurate than git-dir path heuristic)
+wt_name=$(echo "$input" | jq -r '.worktree.name // empty')
+
+# ─── Fetch / cache usage API ─────────────────────────────────────────────────
+cache_file="${STATUSLINE_CACHE_DIR}/statusline-usage-cache.json"
+attempt_stamp="${STATUSLINE_CACHE_DIR}/statusline-fetch-attempt"
+ratelimit_stamp="${STATUSLINE_CACHE_DIR}/statusline-ratelimited"
+lock_dir="${STATUSLINE_CACHE_DIR}/statusline-fetch.lock"
+mkdir -p "${STATUSLINE_CACHE_DIR}"
+
+now=$(date +%s)
+usage_data=""
+
+# Always load valid cached data for display (even if stale — shown while refreshing)
+if [ -f "$cache_file" ]; then
+    cached=$(cat "$cache_file" 2>/dev/null)
+    echo "$cached" | jq -e '.five_hour' >/dev/null 2>&1 && usage_data="$cached"
+fi
+
+# Exponential backoff for rate limits: 30s → 60s → 120s → 240s → 300s (capped)
+# Count of consecutive 429s is stored in the ratelimit_stamp file content.
+rl_count=0
+ratelimited=false
+if [ -f "$ratelimit_stamp" ]; then
+    rl_count=$(cat "$ratelimit_stamp" 2>/dev/null | tr -d '[:space:]')
+    [[ "$rl_count" =~ ^[0-9]+$ ]] || rl_count=1
+    [ "$rl_count" -lt 1 ] && rl_count=1
+    rl_mtime=$(_stat_mtime "$ratelimit_stamp" || echo 0)
+    rl_backoff=$(( 30 * (1 << (rl_count - 1)) ))   # 30 * 2^(n-1)
+    [ "$rl_backoff" -gt 300 ] && rl_backoff=300     # cap at 5 min
+    [ $(( now - rl_mtime )) -lt "$rl_backoff" ] && ratelimited=true
+fi
+
+# Throttle fetches: only attempt once per TTL period regardless of success/failure
+needs_refresh=false
+if ! $ratelimited; then
+    needs_refresh=true
+    if [ -f "$attempt_stamp" ]; then
+        stamp_mtime=$(_stat_mtime "$attempt_stamp" || echo 0)
+        [ $(( now - stamp_mtime )) -lt "$STATUSLINE_CACHE_TTL" ] && needs_refresh=false
+    fi
+fi
+
+if $needs_refresh; then
+    # Atomic lock: mkdir is POSIX-atomic — only one session fetches at a time
+    # If mkdir fails, check for stale lock (crashed holder) and retry once
+    got_lock=false
+    if mkdir "$lock_dir" 2>/dev/null; then
+        got_lock=true
+    else
+        lock_mtime=$(_stat_mtime "$lock_dir" || echo 0)
+        if [ $(( now - lock_mtime )) -gt 30 ]; then
+            rmdir "$lock_dir" 2>/dev/null && mkdir "$lock_dir" 2>/dev/null && got_lock=true
+        fi
+    fi
+    if $got_lock; then
+        trap 'rmdir "$lock_dir" 2>/dev/null' INT TERM EXIT
+        touch "$attempt_stamp"
+        token=$(get_oauth_token)
+        if [ -n "$token" ] && [ "$token" != "null" ]; then
+            response=$(curl -s --max-time 8 \
+                -H "Accept: application/json" \
+                -H "Content-Type: application/json" \
+                -H "Authorization: Bearer $token" \
+                -H "anthropic-beta: oauth-2025-04-20" \
+                -H "User-Agent: claude-code-statusline/1.0.0" \
+                "https://api.anthropic.com/api/oauth/usage" 2>/dev/null)
+            if [ -n "$response" ] && echo "$response" | jq -e '.five_hour' >/dev/null 2>&1; then
+                usage_data="$response"
+                echo "$response" > "$cache_file"
+                rm -f "$ratelimit_stamp"  # success — reset backoff
+            elif echo "$response" | jq -e '.error.type == "rate_limit_error"' >/dev/null 2>&1; then
+                echo $(( rl_count + 1 )) > "$ratelimit_stamp"  # increment backoff counter
+            fi
+        fi
+        rmdir "$lock_dir" 2>/dev/null
+        trap - INT TERM EXIT
+    fi
+    # If mkdir failed, another session holds the lock — silently use cached data
+fi
+
+# ─── Build output ────────────────────────────────────────────────────────────
+sep=" ${dim}|${reset} "
+out1=""  # stdin-based: model, git, ctx, cost  (always available, per-session)
+out2=""  # API-based:   5h, 7d, extra          (cached, shared across tabs)
+
+# Append to out2 with auto-separator
+append2() { [ -n "$out2" ] && out2+="$sep"; out2+="$1"; }
+
+# Model name
+out1+="${blue}${model_name}${reset}"
+
+# Git: project[wt]@branch +adds/-dels
+if [ "${STATUSLINE_SHOW_GIT}" = "true" ] && [ -n "$cwd" ]; then
+    display_dir="${cwd##*/}"
+    git_branch=$(git -C "${cwd}" rev-parse --abbrev-ref HEAD 2>/dev/null)
+    out1+="${sep}${cyan}${display_dir}${reset}"
+    if [ -n "$git_branch" ]; then
+        # Worktree detection: prefer stdin worktree.name (accurate); fallback to git-dir path heuristic
+        if [ -n "$wt_name" ]; then
+            out1+="${dim}[wt:${wt_name}]${reset}"
+        else
+            git_dir=$(git -C "${cwd}" rev-parse --git-dir 2>/dev/null)
+            [[ "$git_dir" == *"/worktrees/"* ]] && out1+="${dim}[wt]${reset}"
+        fi
+        out1+="${dim}@${reset}${green}${git_branch}${reset}"
+        # Use HEAD diff to include both staged and unstaged changes
+        git_stat=$(git -C "${cwd}" diff HEAD --numstat 2>/dev/null | awk '{a+=$1; d+=$2} END {if (a+d>0) printf "+%d -%d", a, d}')
+        if [ -n "$git_stat" ]; then
+            adds="${git_stat%% *}"
+            dels="${git_stat##* }"
+            out1+=" ${dim}(${reset}${green}${adds}${reset} ${red}${dels}${reset}${dim})${reset}"
+        fi
+    fi
+fi
+
+# Context window
+if [ "${STATUSLINE_SHOW_CONTEXT}" = "true" ]; then
+    ctx_color=$(context_color "$pct_used")
+    out1+="${sep}${white}ctx${reset} ${orange}${used_tokens}/${total_tokens}${reset} ${dim}(${reset}${ctx_color}${pct_used}%${reset}${dim})${reset}"
+fi
+
+# Session cost (from stdin, no API call)
+if [ "${STATUSLINE_SHOW_SESSION_COST}" = "true" ]; then
+    cost_fmt=$(printf "%.2f" "$session_cost" 2>/dev/null || echo "0.00")
+    sym="${STATUSLINE_CURRENCY_SYMBOL}"
+    out1+="${sep}${white}cost ${sym}${cost_fmt}${reset}"
+fi
+
+# Usage limits from API
+if [ -n "$usage_data" ]; then
+
+    five_pct=$(echo "$usage_data" | jq -r '.five_hour.utilization // 0' | awk '{printf "%.0f", $1}')
+    five_reset_iso=$(echo "$usage_data" | jq -r '.five_hour.resets_at // empty')
+    seven_pct=$(echo "$usage_data" | jq -r '.seven_day.utilization // 0' | awk '{printf "%.0f", $1}')
+    seven_reset_iso=$(echo "$usage_data" | jq -r '.seven_day.resets_at // empty')
+
+    # ⚡ fires on whichever limit is currently causing overflow (real-time signal)
+    five_on_extra=false
+    seven_on_extra=false
+    [ "$five_pct" -ge 100 ] && five_on_extra=true
+    [ "$seven_pct" -ge 100 ] && seven_on_extra=true
+
+    # 5-hour session limit
+    if [ "${STATUSLINE_SHOW_SESSION}" = "true" ]; then
+        five_color=$(plan_color "$five_pct")
+        five_label="5h"
+        $five_on_extra && five_label="⚡ 5h"
+
+        seg="${white}${five_label}${reset} ${five_color}${five_pct}%${reset}"
+        if $five_on_extra; then
+            five_countdown=$(format_countdown "$five_reset_iso")
+            [ -n "$five_countdown" ] && seg+=" ${dim}${five_countdown}${reset}"
+        else
+            five_reset=$(format_reset_time "$five_reset_iso" "time")
+            [ -n "$five_reset" ] && seg+=" ${dim}@${five_reset}${reset}"
+        fi
+        append2 "$seg"
+    fi
+
+    # 7-day weekly limit
+    if [ "${STATUSLINE_SHOW_WEEKLY}" = "true" ]; then
+        seven_color=$(plan_color "$seven_pct")
+        seven_label="7d"
+        $seven_on_extra && seven_label="⚡ 7d"
+
+        seg="${white}${seven_label}${reset} ${seven_color}${seven_pct}%${reset}"
+        if $seven_on_extra; then
+            seven_countdown=$(format_countdown "$seven_reset_iso")
+            [ -n "$seven_countdown" ] && seg+=" ${dim}${seven_countdown}${reset}"
+        else
+            seven_reset=$(format_reset_time "$seven_reset_iso" "datetime")
+            [ -n "$seven_reset" ] && seg+=" ${dim}@${seven_reset}${reset}"
+        fi
+        append2 "$seg"
+    fi
+
+    # Extra usage — monthly billing summary (shown when extra is enabled)
+    if [ "${STATUSLINE_SHOW_EXTRA}" = "true" ]; then
+        extra_enabled=$(echo "$usage_data" | jq -r '.extra_usage.is_enabled // false')
+        if [ "$extra_enabled" = "true" ]; then
+            extra_pct=$(echo "$usage_data" | jq -r '.extra_usage.utilization // 0' | awk '{printf "%.0f", $1}')
+            extra_used=$(echo "$usage_data" | jq -r '.extra_usage.used_credits // 0' | awk '{printf "%.2f", $1/100}')
+            extra_limit=$(echo "$usage_data" | jq -r '.extra_usage.monthly_limit // 0' | awk '{printf "%.2f", $1/100}')
+            extra_clr=$(extra_color "$extra_pct")
+
+            sym="${STATUSLINE_CURRENCY_SYMBOL}"
+            extra_cap_left=$(echo "$usage_data" | jq -r '((.extra_usage.monthly_limit // 0) - (.extra_usage.used_credits // 0)) / 100' | awk '{printf "%.2f", $1}')
+
+            extra_label="extra"
+            { $five_on_extra || $seven_on_extra; } && extra_label="extra ⚡"
+            seg="${white}${extra_label}${reset} ${extra_clr}${sym}${extra_used}/${sym}${extra_limit}${reset}"
+            seg+=" ${dim}(${reset}${white}${sym}${extra_cap_left} left${reset}${dim})${reset}"
+            append2 "$seg"
+        fi
+    fi
+fi
+
+# When rate-limited with no cached data, show a dim indicator instead of silence
+# Only if at least one API section is enabled (otherwise out2 is empty by design)
+if [ -z "$out2" ] && $ratelimited; then
+    if [ "${STATUSLINE_SHOW_SESSION}" = "true" ] || [ "${STATUSLINE_SHOW_WEEKLY}" = "true" ] || [ "${STATUSLINE_SHOW_EXTRA}" = "true" ]; then
+        append2 "${dim}limits unavailable (rate limited)${reset}"
+    fi
+fi
+
+# ─── Render ──────────────────────────────────────────────────────────────────
+if [ "${STATUSLINE_SPLIT_LINES}" = "true" ] && [ -n "$out2" ]; then
+    printf "%b\n%b" "$out1" "$out2"
+else
+    [ -n "$out2" ] && out1+="${sep}${out2}"
+    printf "%b" "$out1"
+fi
+exit 0

--- a/scripts/seed-data/sources/06-gradient-dashboard.sh
+++ b/scripts/seed-data/sources/06-gradient-dashboard.sh
@@ -1,0 +1,365 @@
+#!/usr/bin/env bash
+# ~/.claude/statusline.sh — Claude Code session status line (aesthetic edition)
+#
+# 三行輸出：
+#   第一行：◆ 模型 │ 漸層進度條 百分比 │ 費用 │ 時間 │ 速率限制
+#   第二行：⎇分支* │ +增/-減 │ 目錄
+#   第三行：❯ 提示符（顏色跟上下文用量連動）
+#
+# 環境變數：
+#   CLAUDE_STATUSLINE_ASCII=1     退回純 ASCII
+#   CLAUDE_STATUSLINE_NERDFONT=1  啟用 Nerd Font 圖示
+#   CLAUDE_STATUSLINE_POWERLINE=1 啟用 Powerline 分隔符（預設跟隨 NERDFONT）
+#   COLORTERM=truecolor|24bit     系統自動設定，啟用真彩色漸層
+
+set -euo pipefail
+
+# ═══════════════════════════════════════════════════════════════
+# 環境偵測
+# ═══════════════════════════════════════════════════════════════
+
+USE_ASCII="${CLAUDE_STATUSLINE_ASCII:-0}"
+USE_NERDFONT="${CLAUDE_STATUSLINE_NERDFONT:-0}"
+USE_POWERLINE="${CLAUDE_STATUSLINE_POWERLINE:-$USE_NERDFONT}"
+USE_TRUECOLOR=0
+if [[ "${COLORTERM:-}" == "truecolor" || "${COLORTERM:-}" == "24bit" ]]; then
+  USE_TRUECOLOR=1
+fi
+
+# ═══════════════════════════════════════════════════════════════
+# 色彩與符號
+# ═══════════════════════════════════════════════════════════════
+
+RST='\033[0m'
+CYAN='\033[36m'
+BLUE='\033[34m'
+GRAY='\033[90m'
+DIM='\033[2m'
+YELLOW='\033[33m'
+GREEN='\033[32m'
+RED='\033[31m'
+MAGENTA='\033[35m'
+
+# Anthropic 品牌紫 (#7266EA)
+if (( USE_TRUECOLOR )); then
+  PURPLE='\033[38;2;114;102;234m'
+else
+  PURPLE='\033[35m'
+fi
+
+# 符號集
+if [[ "$USE_ASCII" == "1" ]]; then
+  S_BRAND="<>"
+  S_BRANCH=">"
+  S_WARN="!"
+  S_PROMPT=">"
+  S_TIME=""
+  S_COST=""
+  SEP=" | "
+elif [[ "$USE_NERDFONT" == "1" ]]; then
+  S_BRAND="◆"
+  S_BRANCH=" "
+  S_WARN=" 󰀦"
+  S_PROMPT="❯"
+  S_TIME="󰔟 "
+  S_COST=" "
+  if [[ "$USE_POWERLINE" == "1" ]]; then
+    SEP="  "
+  else
+    SEP=" │ "
+  fi
+else
+  S_BRAND="◆"
+  S_BRANCH="⎇"
+  S_WARN=" ⚠"
+  S_PROMPT="❯"
+  S_TIME=""
+  S_COST=""
+  if [[ "$USE_POWERLINE" == "1" ]]; then
+    SEP="  "
+  else
+    SEP=" │ "
+  fi
+fi
+
+# ═══════════════════════════════════════════════════════════════
+# 降級輸出
+# ═══════════════════════════════════════════════════════════════
+
+fallback_prompt() {
+  printf '%b' "${GRAY}${1:-─}${RST}"
+  exit 0
+}
+
+command -v jq &>/dev/null || fallback_prompt "─ │ jq not found"
+
+# ═══════════════════════════════════════════════════════════════
+# 讀取 JSON（單次 jq）
+# ═══════════════════════════════════════════════════════════════
+
+input=$(cat)
+
+parsed=$(echo "$input" | jq -r '
+  (.model.display_name // ""),
+  (.context_window.used_percentage // 0 | tostring),
+  (.cost.total_cost_usd // 0 | tostring),
+  (.workspace.current_dir // "." | split("/") | last),
+  (.worktree.branch // ""),
+  (.rate_limits.five_hour.used_percentage // -1 | tostring),
+  (.rate_limits.seven_day.used_percentage // -1 | tostring),
+  (.agent.name // ""),
+  (.workspace.current_dir // "."),
+  (.cost.total_lines_added // 0 | tostring),
+  (.cost.total_lines_removed // 0 | tostring),
+  (.cost.total_duration_ms // 0 | tostring),
+  (.context_window.context_window_size // 0 | tostring),
+  (.worktree.name // ""),
+  "END"
+' 2>/dev/null) || fallback_prompt "─ │ parse error"
+
+{
+  IFS= read -r model_name
+  IFS= read -r ctx_pct
+  IFS= read -r cost
+  IFS= read -r dir
+  IFS= read -r branch
+  IFS= read -r rate5h
+  IFS= read -r rate7d
+  IFS= read -r agent_name
+  IFS= read -r cwd_full
+  IFS= read -r lines_add
+  IFS= read -r lines_rm
+  IFS= read -r duration_ms
+  IFS= read -r ctx_size
+  IFS= read -r wt_name
+  IFS= read -r _sentinel
+} <<< "$parsed"
+
+# ═══════════════════════════════════════════════════════════════
+# 模型
+# ═══════════════════════════════════════════════════════════════
+
+model="${model_name:-─}"
+
+# ═══════════════════════════════════════════════════════════════
+# 上下文進度條
+# ═══════════════════════════════════════════════════════════════
+
+pct_int=${ctx_pct%.*}
+pct_int=${pct_int:-0}
+if (( pct_int < 0 )); then pct_int=0; fi
+if (( pct_int > 100 )); then pct_int=100; fi
+
+bar_filled=$(( pct_int / 10 ))
+if (( bar_filled > 10 )); then bar_filled=10; fi
+
+# 漸層色（真彩色）：綠 → 黃 → 橘 → 紅
+GRAD_R=(46 116 186 241 239 236 233 231 211 192)
+GRAD_G=(204 195 186 196 161 126 101 76 66 57)
+GRAD_B=(113 89 64 15 24 34 44 60 50 43)
+
+bar=""
+if [[ "$USE_ASCII" == "1" ]]; then
+  # ASCII 模式
+  for (( i=0; i<10; i++ )); do
+    if (( i < bar_filled )); then bar+="#"; else bar+="-"; fi
+  done
+elif (( USE_TRUECOLOR )); then
+  # 真彩色漸層：每格獨立上色
+  for (( i=0; i<10; i++ )); do
+    if (( i < bar_filled )); then
+      bar+="\\033[38;2;${GRAD_R[$i]};${GRAD_G[$i]};${GRAD_B[$i]}m█"
+    else
+      bar+="\\033[38;2;60;60;60m░"
+    fi
+  done
+  bar+="${RST}"
+else
+  # ANSI 退回：依整體百分比選色
+  if (( pct_int >= 90 )); then bar_color="$RED"
+  elif (( pct_int >= 70 )); then bar_color="$YELLOW"
+  else bar_color="$GREEN"; fi
+
+  for (( i=0; i<10; i++ )); do
+    if (( i < bar_filled )); then bar+="█"; else bar+="░"; fi
+  done
+  bar="${bar_color}${bar}${RST}"
+fi
+
+# 百分比文字顏色（跟進度條整體色一致）
+if (( pct_int >= 90 )); then pct_color="$RED"
+elif (( pct_int >= 70 )); then pct_color="$YELLOW"
+else pct_color="$GREEN"; fi
+
+# 警告符號
+ctx_warn=""
+if (( pct_int >= 90 )); then ctx_warn="${RED}${S_WARN}${RST}"; fi
+
+# 上下文視窗大小（僅在 model display_name 不包含 context 資訊時才顯示）
+ctx_size_int=${ctx_size:-0}
+ctx_label=""
+if [[ "$model" != *context* && "$model" != *Context* ]]; then
+  if (( ctx_size_int >= 1000000 )); then ctx_label=" ${GRAY}1M${RST}"
+  elif (( ctx_size_int >= 200000 )); then ctx_label=" ${GRAY}200k${RST}"
+  fi
+fi
+
+# ═══════════════════════════════════════════════════════════════
+# 費用
+# ═══════════════════════════════════════════════════════════════
+
+cost_val="${cost:-0}"
+cost_fmt=$(printf '%.2f' "$cost_val" 2>/dev/null || echo "0.00")
+cost_int=${cost_val%.*}
+cost_int=${cost_int:-0}
+
+if (( cost_int >= 10 )); then cost_color="$RED"
+elif (( cost_int >= 5 )); then cost_color="$YELLOW"
+elif [[ "$cost_fmt" == "0.00" ]]; then cost_color="$GRAY"
+else cost_color="$YELLOW"; fi
+
+# ═══════════════════════════════════════════════════════════════
+# 經過時間（零值智慧隱藏）
+# ═══════════════════════════════════════════════════════════════
+
+dur_ms=${duration_ms:-0}
+dur_section=""
+if (( dur_ms > 0 )); then
+  dur_sec=$((dur_ms / 1000))
+  dur_min=$((dur_sec / 60))
+  dur_s=$((dur_sec % 60))
+  # 格式化後仍為 0m0s 就不顯示（session 啟動初期 dur_ms 可能是幾百毫秒）
+  if (( dur_min > 0 || dur_s > 0 )); then
+    dur_section="${SEP}${GRAY}${S_TIME}${dur_min}m${dur_s}s${RST}"
+  fi
+fi
+
+# ═══════════════════════════════════════════════════════════════
+# Git 分支與髒標記（帶快取）
+# ═══════════════════════════════════════════════════════════════
+
+GIT_CACHE="/tmp/claude-statusline-git-cache"
+GIT_CACHE_MAX_AGE=5
+
+git_branch="${branch:-}"
+dirty=""
+
+git_cache_is_stale() {
+  [[ ! -f "$GIT_CACHE" ]] && return 0
+  local cache_age=$(( $(date +%s) - $(stat -f %m "$GIT_CACHE" 2>/dev/null || echo 0) ))
+  (( cache_age > GIT_CACHE_MAX_AGE ))
+}
+
+if [[ -n "${cwd_full:-}" && -d "${cwd_full:-}" ]]; then
+  if git_cache_is_stale; then
+    if git -C "$cwd_full" rev-parse --git-dir &>/dev/null; then
+      cached_branch="${git_branch}"
+      if [[ -z "$cached_branch" ]]; then
+        cached_branch=$(git -C "$cwd_full" -c core.useBuiltinFSMonitor=false branch --show-current 2>/dev/null) || true
+        if [[ -z "$cached_branch" ]]; then
+          cached_branch=$(git -C "$cwd_full" rev-parse --short HEAD 2>/dev/null) || true
+        fi
+      fi
+      cached_dirty=""
+      if ! git -C "$cwd_full" -c core.useBuiltinFSMonitor=false diff --quiet 2>/dev/null || \
+         ! git -C "$cwd_full" -c core.useBuiltinFSMonitor=false diff --cached --quiet 2>/dev/null; then
+        cached_dirty="*"
+      fi
+      echo "${cached_branch}|${cached_dirty}" > "$GIT_CACHE"
+    else
+      echo "|" > "$GIT_CACHE"
+    fi
+  fi
+
+  if [[ -f "$GIT_CACHE" ]]; then
+    IFS='|' read -r cached_br cached_dt < "$GIT_CACHE"
+    if [[ -z "$git_branch" ]]; then git_branch="${cached_br}"; fi
+    dirty="${cached_dt}"
+  fi
+fi
+
+# ═══════════════════════════════════════════════════════════════
+# 行數增減（零值智慧隱藏）
+# ═══════════════════════════════════════════════════════════════
+
+lines_add=${lines_add:-0}
+lines_rm=${lines_rm:-0}
+lines_section=""
+if (( lines_add > 0 || lines_rm > 0 )); then
+  lines_section="${GREEN}+${lines_add}${RST}/${RED}-${lines_rm}${RST}"
+fi
+
+# ═══════════════════════════════════════════════════════════════
+# 速率限制（條件顯示）
+# ═══════════════════════════════════════════════════════════════
+
+rate_section=""
+rate5h_int=${rate5h%.*}; rate5h_int=${rate5h_int:-0}
+rate7d_int=${rate7d%.*}; rate7d_int=${rate7d_int:-0}
+
+rate_parts=""
+if (( rate5h_int >= 0 )); then
+  if (( rate5h_int >= 80 )); then rate_parts+="${RED}5h:${rate5h_int}%${RST}"
+  else rate_parts+="${GRAY}5h:${rate5h_int}%${RST}"; fi
+fi
+if (( rate7d_int >= 0 )); then
+  if [[ -n "$rate_parts" ]]; then rate_parts+=" "; fi
+  if (( rate7d_int >= 80 )); then rate_parts+="${RED}7d:${rate7d_int}%${RST}"
+  else rate_parts+="${GRAY}7d:${rate7d_int}%${RST}"; fi
+fi
+if [[ -n "$rate_parts" ]]; then
+  rate_section="${SEP}${rate_parts}"
+fi
+
+# ═══════════════════════════════════════════════════════════════
+# 動態提示符（顏色跟上下文用量連動）
+# ═══════════════════════════════════════════════════════════════
+
+if (( pct_int >= 90 )); then prompt_color="$RED"
+elif (( pct_int >= 70 )); then prompt_color="$YELLOW"
+else prompt_color="$GREEN"; fi
+
+# ═══════════════════════════════════════════════════════════════
+# 組裝第一行
+# ═══════════════════════════════════════════════════════════════
+
+line1="${PURPLE}${S_BRAND}${RST} ${CYAN}${model}${RST}"
+line1+="${SEP}${bar} ${pct_color}${pct_int}%${RST}${ctx_warn}${ctx_label}"
+line1+="${SEP}${cost_color}${S_COST}\$${cost_fmt}${RST}"
+line1+="${dur_section}"
+line1+="${rate_section}"
+
+# ═══════════════════════════════════════════════════════════════
+# 組裝第二行
+# ═══════════════════════════════════════════════════════════════
+
+parts=()
+if [[ -n "$git_branch" ]]; then
+  parts+=("${GRAY}${S_BRANCH}${git_branch}${dirty}${RST}")
+fi
+if [[ -n "$lines_section" ]]; then
+  parts+=("${lines_section}")
+fi
+parts+=("${BLUE}${dir}${RST}")
+
+# Agent / Worktree 指示器（僅在非主 session 時顯示）
+if [[ -n "${wt_name:-}" ]]; then
+  parts+=("${YELLOW}⚙ worktree:${wt_name}${RST}")
+elif [[ -n "${agent_name:-}" ]]; then
+  parts+=("${YELLOW}⚙ ${agent_name}${RST}")
+fi
+
+line2=""
+for i in "${!parts[@]}"; do
+  if (( i > 0 )); then
+    line2+="${SEP}"
+  fi
+  line2+="${parts[$i]}"
+done
+
+# ═══════════════════════════════════════════════════════════════
+# 輸出
+# ═══════════════════════════════════════════════════════════════
+
+# 只輸出兩行（Claude Code 有自己的輸入提示符，不需要我們的 ❯）
+printf '%b\n%b' "$line1" "$line2"

--- a/scripts/seed-data/sources/07-todo-ticker.js
+++ b/scripts/seed-data/sources/07-todo-ticker.js
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+// Claude Code Enhanced Statusline
+// Shows: directory | model | context usage | API usage (5-hour limit) | current task
+// Auto-detects API key vs subscription usage
+// https://github.com/TahaSabir0/claude-statusline
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const https = require('https');
+const { execSync } = require('child_process');
+
+const IS_API_KEY = !!process.env.ANTHROPIC_API_KEY;
+
+// Cache configuration
+const CACHE_DIR = path.join(os.homedir(), '.claude', 'cache');
+const USAGE_CACHE_FILE = path.join(CACHE_DIR, 'usage-cache.json');
+const CACHE_TTL_MS = 30000; // Cache valid for 30 seconds
+
+// ANSI color codes
+const colors = {
+  reset: '\x1b[0m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  orange: '\x1b[38;5;208m',
+  red: '\x1b[31m',
+  blink: '\x1b[5m'
+};
+
+function getUsageColor(percentage) {
+  if (percentage < 50) return colors.green;
+  if (percentage < 75) return colors.yellow;
+  if (percentage < 90) return colors.orange;
+  return colors.red;
+}
+
+function getContextBar(remaining) {
+  const effectiveRemaining = remaining ?? 100;
+  const used = Math.max(0, Math.min(100, 100 - Math.round(effectiveRemaining)));
+
+  const filled = Math.floor(used / 10);
+  const bar = '\u2588'.repeat(filled) + '\u2591'.repeat(10 - filled);
+
+  let coloredBar;
+  if (used < 50) {
+    coloredBar = `${colors.green}${bar} ${used}%${colors.reset}`;
+  } else if (used < 65) {
+    coloredBar = `${colors.yellow}${bar} ${used}%${colors.reset}`;
+  } else if (used < 80) {
+    coloredBar = `${colors.orange}${bar} ${used}%${colors.reset}`;
+  } else {
+    coloredBar = `${colors.blink}${colors.red}\u{1F480} ${bar} ${used}%${colors.reset}`;
+  }
+
+  return coloredBar;
+}
+
+// Read cached usage data
+function getCachedUsage() {
+  try {
+    if (!fs.existsSync(USAGE_CACHE_FILE)) return null;
+
+    const cache = JSON.parse(fs.readFileSync(USAGE_CACHE_FILE, 'utf8'));
+    const age = Date.now() - cache.timestamp;
+
+    // Return cached data if fresh enough
+    if (age < CACHE_TTL_MS) {
+      return cache.data;
+    }
+
+    return null;
+  } catch (e) {
+    return null;
+  }
+}
+
+// Write usage data to cache (shared across all sessions)
+function setCachedUsage(data) {
+  try {
+    if (!fs.existsSync(CACHE_DIR)) {
+      fs.mkdirSync(CACHE_DIR, { recursive: true });
+    }
+
+    const cache = {
+      timestamp: Date.now(),
+      data: data
+    };
+
+    fs.writeFileSync(USAGE_CACHE_FILE, JSON.stringify(cache), 'utf8');
+  } catch (e) {
+    // Silently fail
+  }
+}
+
+function getCredentials() {
+  // Try file first (legacy / Linux / Windows)
+  const credsPath = path.join(os.homedir(), '.claude', '.credentials.json');
+  if (fs.existsSync(credsPath)) {
+    try {
+      return JSON.parse(fs.readFileSync(credsPath, 'utf8'));
+    } catch (e) {}
+  }
+
+  // Fallback: macOS keychain
+  if (os.platform() === 'darwin') {
+    try {
+      const raw = execSync('security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null', { encoding: 'utf8', timeout: 1000 });
+      return JSON.parse(raw.trim());
+    } catch (e) {}
+  }
+
+  return null;
+}
+
+function getApiUsage(callback) {
+  try {
+    // Read credentials (file or macOS keychain)
+    const creds = getCredentials();
+    if (!creds) {
+      return callback(null);
+    }
+
+    const accessToken = creds.claudeAiOauth?.accessToken;
+
+    if (!accessToken) {
+      return callback(null);
+    }
+
+    // Adaptive timeout: if cache exists, be faster (1200ms); if not, be patient (1500ms)
+    // API typically takes ~850ms, so 1200ms gives reasonable headroom
+    const hasCache = fs.existsSync(USAGE_CACHE_FILE);
+    const timeout = hasCache ? 1200 : 1500;
+
+    // Make API call with adaptive timeout
+    const req = https.request({
+      hostname: 'api.anthropic.com',
+      path: '/api/oauth/usage',
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+        'anthropic-beta': 'oauth-2025-04-20'
+      },
+      timeout: timeout
+    }, (res) => {
+      let data = '';
+
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => {
+        try {
+          const usage = JSON.parse(data);
+
+          // Get 5-hour session usage
+          if (usage.five_hour) {
+            const percentage = Math.round(usage.five_hour.utilization);
+            const resetsAt = usage.five_hour.resets_at;
+
+            // Parse reset time
+            let timeStr = '';
+            if (resetsAt) {
+              const resetDate = new Date(resetsAt);
+              const now = new Date();
+              const diffMs = resetDate - now;
+              const diffMins = Math.floor(diffMs / 60000);
+              const hours = Math.floor(diffMins / 60);
+              const mins = diffMins % 60;
+
+              if (hours > 0) {
+                timeStr = `${hours}h${mins}m`;
+              } else {
+                timeStr = `${mins}m`;
+              }
+            }
+
+            // Build bar
+            const barWidth = 10;
+            const filledWidth = Math.round((percentage / 100) * barWidth);
+            const filled = '\u2588'.repeat(filledWidth);
+            const empty = '\u2591'.repeat(barWidth - filledWidth);
+            const color = getUsageColor(percentage);
+
+            const bar = `${color}${filled}${empty} ${percentage}%${colors.reset}${colors.dim} (${timeStr})${colors.reset}`;
+
+            // Cache the result for other sessions
+            setCachedUsage(bar);
+
+            callback(bar);
+          } else {
+            callback(null);
+          }
+        } catch (e) {
+          callback(null);
+        }
+      });
+    });
+
+    req.on('error', () => callback(null));
+    req.on('timeout', () => {
+      req.destroy();
+      callback(null);
+    });
+
+    req.end();
+  } catch (e) {
+    callback(null);
+  }
+}
+
+// Get usage with cache fallback
+function getUsageWithCache(callback) {
+  // First, try to get fresh data from API
+  getApiUsage((freshData) => {
+    if (freshData) {
+      // Got fresh data, use it
+      callback(freshData);
+    } else {
+      // API failed or timed out, try cache
+      const cachedData = getCachedUsage();
+      callback(cachedData);
+    }
+  });
+}
+
+function getCurrentTask(sessionId) {
+  if (!sessionId) return '';
+
+  const homeDir = os.homedir();
+  const todosDir = path.join(homeDir, '.claude', 'todos');
+
+  if (!fs.existsSync(todosDir)) return '';
+
+  try {
+    const files = fs.readdirSync(todosDir)
+      .filter(f => f.startsWith(sessionId) && f.includes('-agent-') && f.endsWith('.json'))
+      .map(f => ({ name: f, mtime: fs.statSync(path.join(todosDir, f)).mtime }))
+      .sort((a, b) => b.mtime - a.mtime);
+
+    if (files.length > 0) {
+      const todos = JSON.parse(fs.readFileSync(path.join(todosDir, files[0].name), 'utf8'));
+      const inProgress = todos.find(t => t.status === 'in_progress');
+      if (inProgress) return inProgress.activeForm || '';
+    }
+  } catch (e) {}
+
+  return '';
+}
+
+// Main
+function outputStatus(data, usageBar) {
+  try {
+    const model = data?.model?.display_name || 'Claude';
+    const dir = data?.workspace?.current_dir || process.cwd();
+    const dirname = path.basename(dir);
+    const sessionId = data?.session_id || '';
+    const remaining = data?.context_window?.remaining_percentage;
+
+    const contextBar = getContextBar(remaining);
+    const task = getCurrentTask(sessionId);
+    const parts = [];
+    parts.push(dirname);
+    parts.push(model);
+    parts.push(`context: ${contextBar}`);
+
+    if (usageBar) {
+      parts.push(`usage: ${usageBar}`);
+    }
+
+    if (task) parts.push(`${colors.dim}${task}${colors.reset}`);
+    process.stdout.write(parts.join(' \u2502 '));
+  } catch (e) {
+    process.stdout.write('Status unavailable');
+  }
+}
+
+function outputFallback(usageBar) {
+  const contextBar = getContextBar(undefined);
+  const parts = ['~', 'Claude', `context: ${contextBar}`];
+  if (usageBar) parts.push(`usage: ${usageBar}`);
+  process.stdout.write(parts.join(' \u2502 '));
+}
+
+// Wrapper that skips usage fetch for API key users
+function getUsage(callback) {
+  if (IS_API_KEY) {
+    callback(null);
+  } else {
+    getUsageWithCache(callback);
+  }
+}
+
+// Process with timeout
+if (process.stdin.isTTY) {
+  getUsage((usageBar) => {
+    outputFallback(usageBar);
+    process.exit(0);
+  });
+} else {
+  let input = '';
+  let timeoutReached = false;
+
+  const overallTimeout = IS_API_KEY ? 500 : (fs.existsSync(USAGE_CACHE_FILE) ? 1300 : 1600);
+
+  const timeout = setTimeout(() => {
+    timeoutReached = true;
+    getUsage((usageBar) => {
+      if (input.length > 0) {
+        try {
+          const data = JSON.parse(input);
+          outputStatus(data, usageBar);
+        } catch (e) {
+          outputFallback(usageBar);
+        }
+      } else {
+        outputFallback(usageBar);
+      }
+      process.exit(0);
+    });
+  }, overallTimeout);
+
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => input += chunk);
+  process.stdin.on('end', () => {
+    if (timeoutReached) return;
+    clearTimeout(timeout);
+
+    getUsage((usageBar) => {
+      try {
+        const data = JSON.parse(input);
+        outputStatus(data, usageBar);
+      } catch (e) {
+        outputFallback(usageBar);
+      }
+      process.exit(0);
+    });
+  });
+}

--- a/scripts/seed-data/sources/08-pace-bars.sh
+++ b/scripts/seed-data/sources/08-pace-bars.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# Claude Code statusline plugin
+# Line1: model (ctx) effort | project (branch) Nf +A -D
+# Line2: bar PCT% CL | 5h used% [⇡⇣pace] countdown  7d used% [⇡⇣pace] countdown
+
+# Disable glob expansion so unquoted vars with wildcards (e.g. DIR paths)
+# are never accidentally expanded into filename lists.
+set -f
+input=$(cat)
+[ -z "$input" ] && {
+  echo "Claude"
+  exit 0
+}
+command -v jq >/dev/null || {
+  echo "Claude [needs jq]"
+  exit 0
+}
+
+# ── Colors & Utilities ──
+# C=Cyan G=Green Y=Yellow R=Red D=Dim N=Normal (reset)
+# Store real escape bytes so final output does not need echo -e interpretation.
+C=$'\033[36m' G=$'\033[32m' Y=$'\033[33m' R=$'\033[31m' D=$'\033[2m' N=$'\033[0m'
+# Cache records use ASCII Unit Separator so legal Git ref names cannot split
+# serialized fields and empty values survive round-trips through read.
+SEP=$'\037'
+NOW=$(date +%s)
+# Returns true when the candidate cache dir is a real directory owned by the
+# current user, writable, and not a symlink into a foreign-controlled path.
+_cache_dir_ok() { [ -d "$1" ] && [ ! -L "$1" ] && [ -O "$1" ] && [ -w "$1" ]; }
+# Reads one cache record into CACHE_FIELDS, supporting the current separator
+# and the legacy pipe format used by older cache files.
+_read_cache_record() {
+  local line="$1" delim rest field
+  CACHE_FIELDS=()
+  if [[ "$line" == *"$SEP"* ]]; then
+    delim="$SEP"
+  else
+    delim='|'
+  fi
+  rest="$line"
+  while [[ "$rest" == *"$delim"* ]]; do
+    field=${rest%%"$delim"*}
+    CACHE_FIELDS+=("$field")
+    rest=${rest#*"$delim"}
+  done
+  CACHE_FIELDS+=("$rest")
+}
+# Loads and parses one cache file into CACHE_FIELDS.
+_load_cache_record_file() {
+  local path="$1" line=""
+  [ -f "$path" ] || return 1
+  IFS= read -r line <"$path" || line=""
+  _read_cache_record "$line"
+}
+# Writes one cache record atomically. If mktemp fails, the caller skips the
+# cache update and keeps serving live data for this run.
+_write_cache_record() {
+  local path="$1" tmp dir
+  shift
+  dir=${path%/*}
+  tmp=$(mktemp "${dir}/claude-sl-tmp-XXXXXX" 2>/dev/null || true)
+  [ -n "$tmp" ] || return 1
+  (
+    IFS="$SEP"
+    printf '%s\n' "$*"
+  ) >"$tmp" && mv "$tmp" "$path"
+}
+# Computes remaining whole minutes until a future epoch. Missing or expired
+# timestamps return an empty string so callers can skip countdown formatting.
+_minutes_until() {
+  local epoch="$1" mins
+  [[ "$epoch" =~ ^[0-9]+$ ]] && ((epoch > 0)) || return
+  mins=$(((epoch - NOW) / 60))
+  ((mins < 0)) && mins=0
+  printf '%s\n' "$mins"
+}
+# Collects live Git metadata for DIR. On non-repos, leaves defaults in place
+# and returns non-zero so callers can decide whether to cache the empty result.
+_collect_git_info() {
+  BR="" FC=0 AD=0 DL=0
+  git -C "$DIR" rev-parse --git-dir >/dev/null 2>&1 || return 1
+  BR=$(git -C "$DIR" --no-optional-locks branch --show-current 2>/dev/null)
+  while IFS=$'\t' read -r a d _; do
+    # Skip binary files (reported as "-" instead of a number).
+    [[ "$a" =~ ^[0-9]+$ ]] || continue
+    FC=$((FC + 1))
+    AD=$((AD + a))
+    DL=$((DL + d))
+  done < <(git -C "$DIR" --no-optional-locks diff HEAD --numstat 2>/dev/null)
+}
+# Cache only inside a user-owned, non-symlinked directory. If no safe root is
+# available, disable caching for this run instead of falling back to shared /tmp.
+_CD="" CACHE_OK=0
+for _BASE in "${XDG_RUNTIME_DIR:-}" "${HOME}/.cache"; do
+  [ -n "$_BASE" ] || continue
+  _CAND="${_BASE%/}/claude-pace"
+  # shellcheck disable=SC2174  # -p only creates leaf here; parent already exists
+  [ -e "$_CAND" ] || mkdir -p -m 700 "$_CAND" 2>/dev/null || continue
+  _cache_dir_ok "$_CAND" || continue
+  _CD="$_CAND"
+  CACHE_OK=1
+  break
+done
+# Returns true (exit 0) when file is missing or older than $2 seconds.
+_stale() { [ ! -f "$1" ] || [ $((NOW - $(stat -f%m "$1" 2>/dev/null || stat -c%Y "$1" 2>/dev/null || echo 0))) -gt "$2" ]; }
+
+# ── Parse stdin + settings in one jq call ──
+# Fields: MODEL DIR PCT CTX COST EFF HAS_RL U5 U7 R5 R7 TIN
+# Read settings into a shell var rather than process substitution so the jq
+# --argjson path works on Windows Git Bash (where /proc/<pid>/fd/N used by
+# <(...) is unavailable and --slurpfile silently fails, yielding empty fields).
+HAS_RL=0
+_SETTINGS=$(cat "$HOME/.claude/settings.json" 2>/dev/null)
+echo "$_SETTINGS" | jq -e . >/dev/null 2>&1 || _SETTINGS='{}'
+IFS=$'\t' read -r MODEL DIR PCT CTX COST EFF HAS_RL U5 U7 R5 R7 TIN < <(
+  jq -r --argjson cfg "$_SETTINGS" \
+    '[(.model.display_name//"?"),(.workspace.project_dir//"."),
+    (.context_window.used_percentage//0|floor),(.context_window.context_window_size//0),
+    (.cost.total_cost_usd//0),
+    (.effort.level//$cfg.effortLevel//"default"),
+    (if .rate_limits then 1 else 0 end),
+    (.rate_limits.five_hour.used_percentage//null|if type=="number" then floor else "--" end),
+    (.rate_limits.seven_day.used_percentage//null|if type=="number" then floor else "--" end),
+    (.rate_limits.five_hour.resets_at//0),
+    (.rate_limits.seven_day.resets_at//0),
+    (if (.context_window.total_input_tokens|type)=="number" then (.context_window.total_input_tokens|floor) else -1 end)]|@tsv' <<<"$input"
+)
+case "${EFF:-default}" in low) EF='low' ;; high) EF='high' ;; xhigh) EF='xhigh' ;; max) EF='max' ;; *) EF='medium' ;; esac
+
+# ── Auto-compact window: track usage against the compaction threshold ──
+# When CLAUDE_CODE_AUTO_COMPACT_WINDOW is set, compaction fires at that token
+# count, not the model's full window. Recompute PCT against it and relabel CTX
+# so the bar measures "distance to compaction", matching the desktop app's bar
+# (e.g. 49.8k / 400.0k). The jq above emits TIN=-1 only when CC omits
+# total_input_tokens entirely (old CC); the ^[0-9]+$ test rejects that and falls
+# back to the full window. A present zero (fresh-session first frame, before the
+# first API response) passes, so the bar measures against the cap from the start
+# instead of flashing the full window while the env var is set.
+ACW="${CLAUDE_CODE_AUTO_COMPACT_WINDOW:-0}"
+if [[ "$ACW" =~ ^[0-9]+$ ]] && ((ACW > 0)) && [[ "$TIN" =~ ^[0-9]+$ ]]; then
+  # Compaction can't exceed the real window; clamp so the label stays honest.
+  ((CTX > 0 && ACW > CTX)) && ACW=$CTX
+  PCT=$((TIN * 100 / ACW))
+  ((PCT > 100)) && PCT=100
+  CTX=$ACW
+fi
+
+# ── Context label (needed by MODEL_SHORT and line 2) ──
+if ((CTX >= 1000000)); then
+  CL="$((CTX / 1000000))M"
+elif ((CTX > 0)); then
+  CL="$((CTX / 1000))K"
+else CL=""; fi
+
+# ── MODEL_SHORT: strip redundant context label ──
+MODEL=${MODEL/ context)/)}
+[[ "$CTX" -gt 0 && "$MODEL" != *"("* ]] && MODEL="${MODEL} (${CL})"
+# Cap "MODEL EF" at 28 chars; 28 fits the longest effort word ('medium', 6 chars)
+# plus a typical "Sonnet 4.6 (200K)" without ellipsis.
+_ML="${MODEL} ${EF}"
+((${#_ML} > 28)) && MODEL="${MODEL:0:$((28 - 2 - ${#EF}))}…"
+
+# ── Progress Bar ──
+F=$((PCT / 10))
+((F < 0)) && F=0
+((F > 10)) && F=10
+if ((PCT >= 90)); then BC=$R; elif ((PCT >= 70)); then BC=$Y; else BC=$G; fi
+BAR=""
+for ((i = 0; i < F; i++)); do BAR+='█'; done
+for ((i = F; i < 10; i++)); do BAR+='░'; done
+
+# ── Git Info (5s cache, atomic write) ──
+# Cache key encodes DIR so concurrent sessions in different repos don't clash.
+# Atomic write: write to a temp file first, then mv to avoid partial reads.
+BR="" FC=0 AD=0 DL=0
+if [[ "$CACHE_OK" == "1" ]]; then
+  GC="${_CD}/claude-sl-git-$(printf '%s' "$DIR" | { shasum 2>/dev/null || sha1sum; } | cut -c1-16)"
+  if _stale "$GC" 5; then
+    if _collect_git_info; then
+      _write_cache_record "$GC" "$BR" "$FC" "$AD" "$DL"
+    else
+      _write_cache_record "$GC" "" "" "" ""
+    fi
+  elif _load_cache_record_file "$GC"; then
+    BR=${CACHE_FIELDS[0]:-}
+    FC=${CACHE_FIELDS[1]:-}
+    AD=${CACHE_FIELDS[2]:-}
+    DL=${CACHE_FIELDS[3]:-}
+  fi
+  # Reject cache corruption before arithmetic or terminal output formatting.
+  [[ "$FC" =~ ^[0-9]+$ ]] || FC=0
+  [[ "$AD" =~ ^[0-9]+$ ]] || AD=0
+  [[ "$DL" =~ ^[0-9]+$ ]] || DL=0
+else
+  _collect_git_info || true
+fi
+
+# ── Project Name + Line 1 Right Section ──
+# Extract project name. Worktree: save repo name explicitly.
+PN="${DIR##*/}"
+IS_WT=0 _REPO=""
+if [[ "${DIR/#$HOME/\~}" =~ /([^/]+)/\.claude/worktrees/([^/]+) ]]; then
+  IS_WT=1
+  _REPO="${BASH_REMATCH[1]}"
+  _WT_NAME="${BASH_REMATCH[2]}"
+  PN="$_REPO"
+fi
+((${#PN} > 25)) && PN="${PN:0:25}…"
+
+# Format: project (branch) [git stats]
+L1R="$PN"
+if [ -n "$BR" ]; then
+  ((${#BR} > 35)) && BR="${BR:0:35}…"
+  L1R+=" (${BR})"
+  ((FC > 0)) 2>/dev/null && L1R+=" ${FC}f ${G}+${AD}${N} ${R}-${DL}${N}"
+elif [[ "$IS_WT" == "1" ]]; then
+  # Detached HEAD in worktree: show repo/worktree to preserve identity
+  L1R="${_REPO}/${_WT_NAME}"
+  ((${#L1R} > 25)) && L1R="${L1R:0:25}…"
+fi
+
+# Usage data: read stdin rate_limits when available. When absent we show
+# placeholders and the session cost instead of falling back to a possibly stale
+# (or wrong-account) cached snapshot. See docs/decisions/2026-05-20-quota-cache-removal.md.
+SHOW_COST=0
+if [[ "$HAS_RL" == "1" ]]; then
+  # Stdin path: real-time, no network. U5/U7 already set by jq read above.
+  # Guard: resets_at=0 means field missing, leave RM empty so _usage skips it.
+  RM5=$(_minutes_until "$R5")
+  RM7=$(_minutes_until "$R7")
+else
+  U5="--" U7="--" RM5="" RM7=""
+  SHOW_COST=1
+fi
+
+# Combined usage formatter: used% [pace delta] (countdown)
+_usage() {
+  local u="${1:---}" rm="$2" w="$3"
+  if [[ ! "$u" =~ ^[0-9]+$ ]]; then
+    printf "%s" "$u"
+  else
+    if ((u >= 90)); then printf "${R}%d%%${N}" "$u"; elif ((u >= 70)); then printf "${Y}%d%%${N}" "$u"; else printf "${G}%d%%${N}" "$u"; fi
+    if [[ "$rm" =~ ^[0-9]+$ ]] && ((rm <= w)); then
+      # Pace delta: positive = over pace (overspend), negative = under pace (surplus).
+      local d=$((u - (w - rm) * 100 / w))
+      ((d > 0)) && printf " ${R}⇡%d%%${N}" "$d"
+      ((d < 0)) && printf " ${G}⇣%d%%${N}" "${d#-}"
+    fi
+  fi
+  [[ "$rm" =~ ^[0-9]+$ ]] || return
+  ((rm >= 1440)) && {
+    printf " ${D}%dd${N}" $((rm / 1440))
+    return
+  }
+  ((rm >= 60)) && {
+    printf " ${D}%dh${N}" $((rm / 60))
+    return
+  }
+  printf " ${D}%dm${N}" "$rm"
+}
+
+# ── Output Assembly (symmetric single-pipe alignment) ──
+
+# Build plain-text left sections for width measurement (no ANSI codes).
+L1_PLAIN="${MODEL} ${EF}"
+L2_PLAIN="${BAR} ${PCT}% ${CL}"
+# Pad shorter side so | aligns on both lines.
+W1=${#L1_PLAIN} W2=${#L2_PLAIN}
+PAD1="" PAD2=""
+if ((W1 > W2)); then
+  printf -v PAD2 "%*s" $((W1 - W2)) ""
+elif ((W2 > W1)); then
+  printf -v PAD1 "%*s" $((W2 - W1)) ""
+fi
+
+# Line 1: model (context) effort | project (branch) git-stats
+L1="${C}${MODEL} ${EF}${N}${PAD1} ${D}|${N}  ${L1R}"
+
+# Line 2: bar pct% CL | 5h used% ...  7d used% ...
+L2="${BC}${BAR}${N} ${PCT}% ${CL}${PAD2} ${D}|${N}  5h $(_usage "$U5" "$RM5" 300)  7d $(_usage "$U7" "$RM7" 10080)"
+# Session cost: only when usage data is unavailable in stdin.
+if [[ "$SHOW_COST" == "1" ]]; then
+  printf -v _CS "\$%.2f" "$COST" 2>/dev/null
+  [[ "$_CS" != "\$0.00" ]] && L2+="  $_CS"
+fi
+
+printf '%s\n' "$L1"
+printf '%s\n' "$L2"

--- a/scripts/seed-data/sources/09-git-detective.js
+++ b/scripts/seed-data/sources/09-git-detective.js
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+// Claude Code Statusline
+// Shows: model | directory | git sync | context usage
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execFileSync } = require('child_process');
+
+let input = '';
+const stdinTimeout = setTimeout(() => process.exit(0), 3000);
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('end', () => {
+  clearTimeout(stdinTimeout);
+  try {
+    const data = JSON.parse(input);
+    const shortModel = (name) => {
+      const m = name.match(/^(?:claude-)?(Opus|Sonnet|Haiku|Mythos)[\s-]+(\d+(?:[.-]\d+)?)(?:\s*\(([^)]+)\))?/i);
+      if (!m) return name;
+      const family = m[1].charAt(0).toUpperCase() + m[1].charAt(1).toLowerCase();
+      const version = m[2].replace('-', '.');
+      const ctx = m[3];
+      let suffix = `${family} ${version}`;
+      if (ctx) {
+        const ctxMatch = ctx.match(/(\d+)\s*([KMG])/i);
+        if (ctxMatch) suffix += ` (${ctxMatch[1]}${ctxMatch[2].toLowerCase()})`;
+      }
+      return suffix;
+    };
+    const model = shortModel(data.model?.display_name || 'Claude');
+    const dir = data.workspace?.current_dir || process.cwd();
+    const session = data.session_id || '';
+    const rawRemaining = data.context_window?.remaining_percentage;
+    const remaining = (rawRemaining == null || rawRemaining === '') ? NaN : Number(rawRemaining);
+    const homeDir = os.homedir();
+    const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(homeDir, '.claude');
+
+    const fmt = (n) => {
+      if (n < 1000) return String(n);
+      if (n < 10000) return (n / 1000).toFixed(1).replace(/\.0$/, '') + 'k';
+      if (n < 1000000) return Math.round(n / 1000) + 'k';
+      return (n / 1000000).toFixed(1).replace(/\.0$/, '') + 'M';
+    };
+
+    // --- Context window ---
+    let ctx = '';
+    if (Number.isFinite(remaining)) {
+      // Absolute token counts (e.g. "480k/1M"). Numerator is total_input_tokens
+      // (input + cache_creation + cache_read); denominator is context_window_size.
+      // When both are present we drive the bar from them directly \u2014 more honest
+      // than remapping `remaining_percentage` through a hardcoded compact buffer
+      // that doesn't scale across context window sizes.
+      const totalInput = Number(data.context_window?.total_input_tokens) || 0;
+      const ctxSize = Number(data.context_window?.context_window_size) || 0;
+      const haveAbs = totalInput > 0 && ctxSize > 0;
+      const used = haveAbs
+        ? Math.max(0, Math.min(100, Math.round((totalInput / ctxSize) * 100)))
+        : Math.max(0, Math.min(100, Math.round(100 - remaining)));
+
+      // Bridge file for context-monitor PostToolUse hook
+      if (session) {
+        try {
+          const bridgePath = path.join(os.tmpdir(), `claude-ctx-${session}.json`);
+          fs.writeFileSync(bridgePath, JSON.stringify({
+            session_id: session,
+            remaining_percentage: remaining,
+            used_pct: used,
+            timestamp: Math.floor(Date.now() / 1000)
+          }));
+        } catch (e) {}
+      }
+
+      const steps = Math.max(0, Math.min(10, Math.floor(used / 10)));
+      let bar = '';
+      for (let i = 0; i < 5; i++) {
+        const cell = Math.max(0, Math.min(2, steps - i * 2));
+        bar += cell === 2 ? '\u2588' : cell === 1 ? '\u258c' : '\u2591';
+      }
+
+      const abs = haveAbs ? ` ${fmt(totalInput)}/${fmt(ctxSize)}` : '';
+
+      let color, prefix = '';
+      if (used < 50) color = '\x1b[38;2;255;125;218m';
+      else if (used < 65) color = '\x1b[33m';
+      else if (used < 80) color = '\x1b[38;2;255;140;0m';
+      else { color = '\x1b[31m'; prefix = '\uD83D\uDC80 '; }
+
+      // Absolute token cap: 250k is the pricing/quality cliff regardless of how
+      // wide the context window is. Bump pink \u2192 yellow once we cross it, so a
+      // 1M session at 250k/1M (25% used) doesn't render as "still cozy pink".
+      if (haveAbs && totalInput >= 250000 && color === '\x1b[38;2;255;125;218m') {
+        color = '\x1b[33m';
+      }
+
+      ctx = ` ${color}${prefix}${bar}${abs}\x1b[0m`;
+    }
+
+    // --- Git status (live, local, no network) ---
+    let gitInfo = '';
+    let branch = '';
+    let detachedSha = '';
+    try {
+      const gitExec = (args) => {
+        try {
+          return execFileSync('git', args, { encoding: 'utf8', cwd: dir, windowsHide: true, timeout: 1000, stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+        } catch (e) { return null; }
+      };
+      const parts = [];
+
+      // Uncommitted changes — bucketed by VS Code-style status codes
+      const status = gitExec(['status', '--porcelain']);
+      if (status) {
+        const buckets = { M: 0, A: 0, D: 0, R: 0, '?': 0, '!': 0 };
+        for (const line of status.split('\n')) {
+          if (!line) continue;
+          const X = line.charAt(0);
+          const Y = line.charAt(1);
+          if (X === '?' && Y === '?') buckets['?']++;
+          else if (X === 'U' || Y === 'U' || (X === 'D' && Y === 'D') || (X === 'A' && Y === 'A')) buckets['!']++;
+          else if (Y === 'D' || X === 'D') buckets.D++;
+          else if (X === 'R') buckets.R++;
+          else if (X === 'A' || X === 'C') buckets.A++;
+          else buckets.M++;
+        }
+        const dimBuckets = [];
+        for (const k of ['M', 'A', 'D', 'R', '?']) {
+          if (buckets[k] > 0) dimBuckets.push(`${buckets[k]}${k}`);
+        }
+        if (dimBuckets.length > 0) parts.push(`\x1b[2m${dimBuckets.join(' ')}\x1b[0m`);
+        if (buckets['!'] > 0) parts.push(`\x1b[31m${buckets['!']}!\x1b[0m`);
+      }
+
+      // Behind/ahead origin
+      branch = gitExec(['branch', '--show-current']) || '';
+      if (!branch) {
+        detachedSha = gitExec(['rev-parse', '--short', 'HEAD']) || '';
+      }
+      if (branch) {
+        const remoteRef = `refs/remotes/origin/${branch}`;
+        const behind = parseInt(gitExec(['rev-list', '--count', `HEAD..${remoteRef}`]) || '0', 10);
+        const ahead = parseInt(gitExec(['rev-list', '--count', `${remoteRef}..HEAD`]) || '0', 10);
+        if (behind > 0) parts.push(`\x1b[31m\u2193${behind} pull\x1b[0m`);
+        if (ahead > 0) parts.push(`\x1b[33m\u2191${ahead} push\x1b[0m`);
+      }
+
+      // MD sync check: drift between CLAUDE.md ↔ AGENTS.md ↔ GEMINI.md
+      try {
+        const claudeMd = path.join(dir, 'CLAUDE.md');
+        const agentsMd = path.join(dir, 'AGENTS.md');
+        const geminiMd = path.join(dir, 'GEMINI.md');
+        if (fs.existsSync(claudeMd) && fs.existsSync(agentsMd) && fs.existsSync(geminiMd)) {
+          const SYNC_LINE_RE = /^> \*\*(?:Синхронизация|Sync):\*\*.*$/m;
+          const norm = (p) => fs.readFileSync(p, 'utf8').replace(/\r\n/g, '\n');
+          const cs = norm(claudeMd).replace(SYNC_LINE_RE, '');
+          const as = norm(agentsMd).replace(SYNC_LINE_RE, '');
+          const gs = norm(geminiMd).replace(SYNC_LINE_RE, '');
+          if (cs !== as || cs !== gs) {
+            parts.push('\x1b[31m\u26A0 md drift\x1b[0m');
+          }
+        }
+      } catch (e) {}
+
+      if (parts.length > 0) {
+        gitInfo = ' ' + parts.join(' ');
+      }
+    } catch (e) {}
+
+    // --- Prompt cache state ---
+    // Counters come from stdin (current_usage of the latest API call).
+    // TTL bucket and last-touch timestamp come from the transcript — stdin
+    // exposes neither ephemeral_1h vs ephemeral_5m nor a per-message timestamp.
+    let cacheSegment = '';
+    try {
+      const usage = data.context_window?.current_usage;
+      const usageNull = usage === null || usage === undefined;
+      const read = (usage && Number(usage.cache_read_input_tokens)) || 0;
+      const write = (usage && Number(usage.cache_creation_input_tokens)) || 0;
+      const freshInput = (usage && Number(usage.input_tokens)) || 0;
+
+      let lastTouchTs = null;
+      let lastWriteTtl = null;
+      let hadCacheBefore = false;
+
+      // Parse transcript when we need TTL/timestamp OR want to detect a /compact
+      // reset (current_usage is null but earlier messages had cache activity).
+      if (session && (read > 0 || write > 0 || usageNull)) {
+        try {
+          // Claude Code slug encoding: drive colon, separators, AND dots → '-'
+          // (e.g. C:\Users\ilyap\.openclaw → C--Users-ilyap--openclaw).
+          // Without the dot replacement, transcripts inside hidden dirs aren't
+          // found and the cache TTL/timestamp segment silently drops.
+          const slug = dir.replace(/[:\\\/.]/g, '-');
+          const transcriptPath = path.join(claudeDir, 'projects', slug, `${session}.jsonl`);
+          if (fs.existsSync(transcriptPath)) {
+            const stat = fs.statSync(transcriptPath);
+            // Read 1 extra byte before the window so the first \n distinguishes
+            // a partial line from a clean line boundary.
+            const desired = Math.min(stat.size, 16384);
+            const startOffset = Math.max(0, stat.size - desired - 1);
+            const readBytes = stat.size - startOffset;
+            const buf = Buffer.alloc(readBytes);
+            const fd = fs.openSync(transcriptPath, 'r');
+            fs.readSync(fd, buf, 0, readBytes, startOffset);
+            fs.closeSync(fd);
+            let content = buf.toString('utf8');
+            if (startOffset > 0) {
+              const nl = content.indexOf('\n');
+              if (nl >= 0) content = content.slice(nl + 1);
+            }
+            const lines = content.split('\n').filter(Boolean);
+
+            for (let i = lines.length - 1; i >= 0; i--) {
+              try {
+                const rec = JSON.parse(lines[i]);
+                const u = rec && rec.type === 'assistant' && rec.message ? rec.message.usage : null;
+                if (!u || !rec.timestamp) continue;
+                const r = u.cache_read_input_tokens || 0;
+                const w = u.cache_creation_input_tokens || 0;
+                if (r === 0 && w === 0) continue;
+
+                hadCacheBefore = true;
+                if (!lastTouchTs) {
+                  const ts = new Date(rec.timestamp).getTime();
+                  lastTouchTs = Number.isFinite(ts) ? ts : 0;
+                }
+                if (!lastWriteTtl && w > 0 && u.cache_creation) {
+                  if (u.cache_creation.ephemeral_1h_input_tokens > 0) lastWriteTtl = '1h';
+                  else if (u.cache_creation.ephemeral_5m_input_tokens > 0) lastWriteTtl = '5m';
+                }
+                if (lastTouchTs && lastWriteTtl) break;
+              } catch (e) {}
+            }
+          }
+        } catch (e) {}
+      }
+
+      if (read > 0 || write > 0) {
+        const parts = ['\x1b[2mcache\x1b[0m'];
+
+        // Hit ratio: read / (input + cache_creation + cache_read).
+        // Matches the input-only formula used for used_percentage.
+        // ratio === 0 means a full cache miss / invalidation — surface it loudly
+        // instead of hiding the segment, since it's a costly event worth noticing.
+        const denom = read + write + freshInput;
+        if (denom > 0) {
+          const ratio = read > 0 ? Math.round(read / denom * 100) : 0;
+          let ratioColor;
+          if (ratio === 0) ratioColor = '\x1b[1;31m';
+          else if (ratio >= 90) ratioColor = '\x1b[1;32m';
+          else if (ratio >= 75) ratioColor = '\x1b[32m';
+          else if (ratio >= 50) ratioColor = '\x1b[33m';
+          else ratioColor = '\x1b[38;2;255;140;0m';
+          parts.push(`${ratioColor}${ratio}%\x1b[0m`);
+        }
+
+        if (read > 0) {
+          parts.push(`\x1b[1;32m↓${fmt(read)}\x1b[0m`);
+        }
+        if (write > 0) {
+          const sym = read > 0 ? '+' : '↑';
+          parts.push(`\x1b[33m${sym}${fmt(write)}\x1b[0m`);
+        }
+        if (lastWriteTtl && lastTouchTs) {
+          const ttlMs = lastWriteTtl === '5m' ? 300000 : 3600000;
+          const remainingSec = (ttlMs - (Date.now() - lastTouchTs)) / 1000;
+          const bucketColor = lastWriteTtl === '5m' ? '\x1b[33m' : '\x1b[2;36m';
+          let suffix = `${bucketColor}${lastWriteTtl}\x1b[0m`;
+          let timeStr;
+          if (remainingSec <= 0) timeStr = '0m';
+          else if (remainingSec < 60) timeStr = Math.ceil(remainingSec) + 's';
+          else if (remainingSec < 3600) timeStr = Math.ceil(remainingSec / 60) + 'm';
+          else {
+            const h = Math.floor(remainingSec / 3600);
+            const m = Math.floor((remainingSec % 3600) / 60);
+            timeStr = h + 'h' + (m > 0 ? m + 'm' : '');
+          }
+          const pct = remainingSec > 0 ? (remainingSec * 1000) / ttlMs : 0;
+          let countColor;
+          if (pct <= 0) countColor = '\x1b[31m';
+          else if (pct < 0.1) countColor = '\x1b[38;2;255;140;0m';
+          else if (pct < 0.25) countColor = '\x1b[33m';
+          else countColor = '\x1b[2m';
+          suffix += `${countColor}:${timeStr}\x1b[0m`;
+          parts.push(suffix);
+        }
+        cacheSegment = parts.join(' ');
+      } else if (usageNull && hadCacheBefore) {
+        // current_usage is null after /compact until the next API call repopulates it.
+        // Show that the live cache view is reset, not just absent.
+        cacheSegment = '\x1b[2mcache:\x1b[0m\x1b[33mreset\x1b[0m';
+      }
+    } catch (e) {}
+
+    // --- Rate limits (subscription) ---
+    const limitParts = [];
+    const rl = data.rate_limits;
+    if (rl) {
+      const colorPct = (pct) => {
+        if (pct < 50) return `\x1b[38;2;255;125;218m${pct}%\x1b[0m`;
+        if (pct < 65) return `\x1b[33m${pct}%\x1b[0m`;
+        if (pct < 80) return `\x1b[38;2;255;140;0m${pct}%\x1b[0m`;
+        return `\x1b[31m${pct}%\x1b[0m`;
+      };
+      const formatReset = (resetTs, opts) => {
+        if (!Number.isFinite(resetTs)) return null;
+        const coarse = !!(opts && opts.coarse);
+        const resetMin = Math.max(0, Math.ceil((resetTs * 1000 - Date.now()) / 60000));
+        if (resetMin >= 1440) {
+          const d = Math.floor(resetMin / 1440);
+          const h = Math.floor((resetMin % 1440) / 60);
+          if (coarse && d >= 2) return `${d}d`;
+          if (d === 1 && h === 0) return '24h';
+          return `${d}d${h}h`;
+        }
+        if (resetMin >= 60) {
+          const h = Math.floor(resetMin / 60);
+          const m = resetMin % 60;
+          return m > 0 ? `${h}h${m}m` : `${h}h`;
+        }
+        return `${resetMin}m`;
+      };
+      const withReset = (label, bucket, opts) => {
+        const rawUsedPct = bucket.used_percentage;
+        const usedPct = (rawUsedPct == null || rawUsedPct === '') ? NaN : Number(rawUsedPct);
+        if (!Number.isFinite(usedPct)) return null;
+        const pct = Math.round(usedPct);
+        const reset = formatReset(bucket.resets_at, opts);
+        const main = `${label}:${colorPct(pct)}`;
+        return reset ? `${main}\x1b[2m(${reset})\x1b[0m` : main;
+      };
+      const parts = [];
+      if (rl.five_hour) {
+        const p = withReset('5h', rl.five_hour);
+        if (p) parts.push(p);
+      }
+      if (rl.seven_day) {
+        const p = withReset('7d', rl.seven_day, { coarse: true });
+        if (p) parts.push(p);
+      }
+      for (const p of parts) limitParts.push(p);
+    }
+
+    // --- Output ---
+    const dirRaw = path.basename(dir);
+    const dirShort = dirRaw.length > 15
+      ? dirRaw.slice(0, 7) + '…' + dirRaw.slice(-7)
+      : dirRaw;
+    const buildDirSegment = (name) => {
+      let s = `\x1b[2m${name}\x1b[0m`;
+      if (branch) s += ` \x1b[36m(${branch})\x1b[0m`;
+      else if (detachedSha) s += ` \x1b[31m(HEAD@${detachedSha})\x1b[0m`;
+      return s;
+    };
+    const segments = [`\x1b[2m${model}\x1b[0m`];
+    const dirIndex = segments.length;
+    segments.push(buildDirSegment(dirRaw));
+    if (gitInfo) segments.push(gitInfo.trim());
+    if (ctx) segments.push(ctx.trim());
+    if (cacheSegment) segments.push(cacheSegment);
+    for (const lp of limitParts) segments.push(lp);
+
+    // Truncate dirname only if the line crosses 100 visible columns.
+    if (dirRaw !== dirShort) {
+      const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, '');
+      let visible = -3; // " \u2502 " separator is 3 chars; pre-subtract one to undo over-counting.
+      for (const seg of segments) visible += 3 + stripAnsi(seg).length;
+      if (visible > 100) segments[dirIndex] = buildDirSegment(dirShort);
+    }
+
+    process.stdout.write(segments.join(' \u2502 '));
+  } catch (e) {}
+});

--- a/scripts/seed-data/sources/10-quota-fallback.sh
+++ b/scripts/seed-data/sources/10-quota-fallback.sh
@@ -1,0 +1,353 @@
+#!/bin/bash
+# ════════════════════════════════════════════════════════════════════════════
+# Claude Code — Status Line with real-time usage tracking
+#
+# Dependencies: bash, jq, curl
+# License: MIT
+#
+# Default: 🌿 main★ │ Snt 4.6 │ 🟢 Ctx ▓▓▓░░░ 42% │ ⏳ 🟡 ▓▓░░░░ 35% ↻ 2h30m │ $0.12 ⏱ 1h4m
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── Configuration (override via environment variables) ────────────────────────
+TIMEZONE="${TIMEZONE:-}"                            # e.g. "America/New_York", empty = system default
+REFRESH_INTERVAL="${REFRESH_INTERVAL:-300}"           # seconds between API calls (0 = every render, risks rate limiting)
+SHOW_WEEKLY="${SHOW_WEEKLY:-0}"                      # set to 1 to show weekly + sonnet quotas
+USAGE_FILE="${USAGE_FILE:-$HOME/.claude/usage-exact.json}"
+CREDENTIALS_FILE="${CREDENTIALS_FILE:-$HOME/.claude/.credentials.json}"
+SETTINGS_FILE="${SETTINGS_FILE:-$HOME/.claude/settings.json}"
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+tz_date() {
+    local tz="$1"; shift
+    if [ -n "$tz" ]; then TZ="$tz" date "$@"; else date "$@"; fi
+}
+
+format_remaining() {
+    local secs="$1"
+    [ "$secs" -le 0 ] 2>/dev/null && return
+    local h=$(( secs / 3600 )) m=$(( (secs % 3600) / 60 ))
+    if [ $h -gt 0 ]; then echo "${h}h${m}m"
+    elif [ $m -gt 0 ]; then echo "${m}m"
+    else echo "<1m"
+    fi
+}
+
+# Cross-platform ISO 8601 → epoch (GNU date -d || BSD date -j)
+iso_to_epoch() {
+    local iso="$1"
+    date -d "$iso" +%s 2>/dev/null && return
+    # macOS/BSD fallback: strip the offset/Z and fractional seconds, then parse the
+    # core as UTC (-u). The API always sends +00:00, so the stripped wall-clock IS
+    # UTC; without -u, date -j would read it as local time and skew the countdown.
+    local core="${iso%[+-][0-9][0-9]:*}"  # strip +HH:MM / -HH:MM suffix
+    core="${core%Z}"                       # strip trailing Z
+    core="${core%%.*}"                     # strip .fractional
+    date -juf "%Y-%m-%dT%H:%M:%S" "$core" +%s 2>/dev/null
+}
+
+file_mtime() {
+    if stat --version &>/dev/null; then
+        stat -c %Y "$1" 2>/dev/null || echo 0
+    else
+        stat -f %m "$1" 2>/dev/null || echo 0
+    fi
+}
+
+cache_age_sec() {
+    [ ! -f "$USAGE_FILE" ] && echo 999999 && return
+    local age=$(( $(date +%s) - $(file_mtime "$USAGE_FILE") ))
+    [ "$age" -lt 0 ] && age=0
+    echo "$age"
+}
+
+# Coerce to a bare non-negative integer. Drops the decimal part then strips any
+# non-digit. Critical: percentages/resets flow into $(( )), where a value like
+# "x[$(cmd)]" would execute cmd via arithmetic array-subscript evaluation.
+num() {
+    local v="${1%%.*}"
+    v="${v//[^0-9]/}"
+    echo "$(( 10#${v:-0} ))"   # 10# forces base 10 — a leading zero would be read as octal
+}
+
+# make_bar <percent> → sets BAR_COLOR and BAR_STR (6-block bar)
+make_bar() {
+    local pct; pct="$(num "$1")"
+    [ "$pct" -gt 100 ] && pct=100
+    local filled=$(( (pct + 16) / 17 )); [ $filled -gt 6 ] && filled=6   # 17 = ceil(100/6): round onto 6 blocks
+    local empty=$(( 6 - filled ))
+    BAR_STR=""
+    local i
+    for ((i=0; i<filled; i++)); do BAR_STR+="▓"; done
+    for ((i=0; i<empty;  i++)); do BAR_STR+="░"; done
+    if   [ "$pct" -lt 50 ]; then BAR_COLOR="🟢"
+    elif [ "$pct" -lt 80 ]; then BAR_COLOR="🟡"
+    else                         BAR_COLOR="🔴"
+    fi
+}
+
+# render_quota <emoji> <percent> <reset_epoch> → "emoji color bar pct% [↻ remain]".
+# A reset moment already in the past means the window rolled over → usage back to 0%.
+# Needs NOW set by the caller.
+render_quota() {
+    local emoji="$1" reset="$3" remain="" pct
+    pct="$(num "$2")"
+    if [ -n "$reset" ] && [ "$reset" -gt "$NOW" ] 2>/dev/null; then
+        remain=$(format_remaining $(( reset - NOW )))
+    elif [ -n "$reset" ] && [ "$reset" -le "$NOW" ] 2>/dev/null; then
+        pct=0
+    fi
+    make_bar "$pct"
+    local out="${emoji} ${BAR_COLOR} ${BAR_STR} ${pct}%"
+    [ -n "$remain" ] && out="${out} ↻ ${remain}"
+    echo "$out"
+}
+
+# ── Read JSON input from stdin ────────────────────────────────────────────────
+JSON=$(cat)
+
+# ── Parse all stdin fields in a single jq call ───────────────────────────────
+# Joined on US (0x1f), not "|": a "|" in a branch path or model name would shift
+# every field. US is non-whitespace so read preserves empty fields (absent
+# rate_limits). rate_limits.* is native since Claude Code 2.1.x (Pro/Max) —
+# preferred over the API call when present.
+IFS=$'\x1f' read -r J_MODEL_DISPLAY J_MODEL_RAW J_CTX_PCT J_CTX_SIZE J_COST J_DURATION J_CWD \
+    J_RL_5H_PCT J_RL_5H_RESET J_RL_7D_PCT J_RL_7D_RESET \
+    < <(echo "$JSON" | jq -r '[
+        (if .model | type == "object" then .model.display_name // "" else "" end),
+        (if .model | type == "string" then .model else "" end),
+        (.context_window.used_percentage // 0 | tostring | split(".")[0]),
+        (.context_window.context_window_size // 0),
+        (.cost.total_cost_usd // ""),
+        (.cost.total_duration_ms // ""),
+        (.workspace.current_dir // ""),
+        (.rate_limits.five_hour.used_percentage // ""),
+        (.rate_limits.five_hour.resets_at // ""),
+        (.rate_limits.seven_day.used_percentage // ""),
+        (.rate_limits.seven_day.resets_at // "")
+    ] | join("\u001f")' 2>/dev/null)
+
+# ── Model ─────────────────────────────────────────────────────────────────────
+MODEL="$J_MODEL_DISPLAY"
+MODEL=$(echo "$MODEL" | sed 's/Default (\(.*\))/\1/' | sed 's/Claude //' | sed 's/ (.*//')
+[ -z "$MODEL" ] && MODEL="$J_MODEL_RAW"
+case "$MODEL" in
+  claude-sonnet-4-6*|Sonnet\ 4.6*) MODEL="Snt 4.6" ;;
+  claude-sonnet-4-5*|Sonnet\ 4.5*) MODEL="Snt 4.5" ;;
+  claude-opus-4-6*|Opus\ 4.6*)     MODEL="Opus 4.6" ;;
+  claude-opus-4-5*|Opus\ 4.5*)     MODEL="Opus 4.5" ;;
+  claude-haiku-4*|Haiku\ 4*)       MODEL="Haiku 4"  ;;
+esac
+# strip control bytes — model name comes from untrusted JSON (terminal OSC injection)
+MODEL="${MODEL//[$'\x01'-$'\x1f'$'\x7f']/}"
+
+# ── Effort level (from settings.json — not yet in stdin JSON) ────────────────
+EFFORT_LABEL=""
+if [ -f "$SETTINGS_FILE" ]; then
+    case "$(jq -r '.effortLevel // empty' "$SETTINGS_FILE" 2>/dev/null)" in
+        low)    EFFORT_LABEL="lo" ;;
+        medium) EFFORT_LABEL="md" ;;
+        high)   EFFORT_LABEL="hi" ;;
+        max)    EFFORT_LABEL="mx" ;;
+    esac
+fi
+
+# ── Context window ────────────────────────────────────────────────────────────
+CTX_PERCENT="$(num "${J_CTX_PCT:-0}")"
+CTX_LABEL="Ctx"
+[ "$J_CTX_SIZE" -ge 900000 ] 2>/dev/null && CTX_LABEL="1M"   # ≥900k → extended 1M context
+
+make_bar "$CTX_PERCENT"
+CTX_COLOR="$BAR_COLOR" CTX_BAR="$BAR_STR"
+
+# ── Session cost + duration ───────────────────────────────────────────────────
+COST_STR="" DURATION_STR=""
+if [[ "$J_COST" =~ ^[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?$ ]] && [ "$J_COST" != "0" ]; then
+    COST_STR=$(printf '$%.2f' "$J_COST" 2>/dev/null)
+fi
+if [ -n "$J_DURATION" ] && [ "$J_DURATION" != "0" ] && [ "$J_DURATION" != "null" ]; then
+    DURATION_STR=$(format_remaining $(( $(num "$J_DURATION") / 1000 )))
+fi
+
+# ── Git branch ────────────────────────────────────────────────────────────────
+CWD="$J_CWD"
+BRANCH="" DIRTY=""
+if [ -n "$CWD" ] && [ -d "$CWD" ]; then
+    BRANCH=$(git -C "$CWD" --no-optional-locks symbolic-ref --short HEAD 2>/dev/null)
+    if [ -n "$BRANCH" ] && git -C "$CWD" --no-optional-locks diff --quiet HEAD 2>/dev/null; then
+        [ -n "$(git -C "$CWD" --no-optional-locks ls-files --others --exclude-standard 2>/dev/null)" ] && DIRTY="★"
+    else
+        [ -n "$BRANCH" ] && DIRTY="★"
+    fi
+fi
+[ -z "$BRANCH" ] && BRANCH="(no git)"
+[ "${#BRANCH}" -gt 30 ] && BRANCH="${BRANCH:0:27}..."
+
+# ── Refresh usage via Anthropic OAuth API ────────────────────────────────────
+refresh_usage_api() {
+    [ ! -f "$CREDENTIALS_FILE" ] && return 1
+    local token
+    token=$(jq -r '.claudeAiOauth.accessToken // empty' "$CREDENTIALS_FILE" 2>/dev/null)
+    [ -z "$token" ] && return 1
+    local resp
+    resp=$(curl -s --max-time 3 \
+        "https://api.anthropic.com/api/oauth/usage" \
+        -H "Authorization: Bearer $token" \
+        -H "anthropic-beta: oauth-2025-04-20" \
+        -H "Content-Type: application/json" 2>/dev/null)
+    echo "$resp" | jq -e '.five_hour.utilization' >/dev/null 2>&1 || return 1
+    local tmp
+    tmp=$(mktemp "${USAGE_FILE}.XXXXXX") || return 1
+    if echo "$resp" | jq '{
+        timestamp: (now | todate),
+        source: "api",
+        metrics: {
+            session: {
+                percent_used: .five_hour.utilization,
+                percent_remaining: (100 - .five_hour.utilization),
+                resets_at: .five_hour.resets_at
+            },
+            week_all: {
+                percent_used: .seven_day.utilization,
+                percent_remaining: (100 - .seven_day.utilization),
+                resets_at: .seven_day.resets_at
+            },
+            week_sonnet: (if .seven_day_sonnet then {
+                percent_used: .seven_day_sonnet.utilization,
+                percent_remaining: (100 - .seven_day_sonnet.utilization),
+                resets_at: .seven_day_sonnet.resets_at
+            } else null end)
+        }
+    }' > "$tmp"; then
+        mv "$tmp" "$USAGE_FILE"
+    else
+        rm -f "$tmp"; return 1
+    fi
+}
+
+# Native stdin rate_limits (Pro/Max, CC ≥2.1.x) cover session + weekly-all. The
+# API is only needed for the Sonnet quota (SHOW_WEEKLY) or as a fallback when the
+# stdin field is absent — so most renders make no network call at all.
+HAVE_STDIN_SESSION=0
+[ -n "$J_RL_5H_PCT" ] && [ "$J_RL_5H_PCT" != "null" ] && HAVE_STDIN_SESSION=1
+NEED_API=1
+[ "$HAVE_STDIN_SESSION" = 1 ] && [ "$SHOW_WEEKLY" != "1" ] && NEED_API=0
+
+[[ "$REFRESH_INTERVAL" =~ ^[0-9]+$ ]] || REFRESH_INTERVAL=300
+
+# Lock outside world-writable /tmp to avoid a symlink/clobber on shared hosts.
+LOCK_FILE="${XDG_RUNTIME_DIR:-$HOME/.claude}/statusline-refresh.lock"
+if [ "$NEED_API" = 1 ] && [ "$(cache_age_sec)" -gt "$REFRESH_INTERVAL" ]; then
+    # 2>/dev/null: if the lock dir is missing, skip the refresh quietly (no stderr noise)
+    ( flock -n 9 || exit 0; refresh_usage_api ) 9>"$LOCK_FILE" 2>/dev/null
+fi
+
+# ── Resolve usage metrics: native stdin (preferred) → API cache (fallback) ────
+BLOCK_DISPLAY="" WEEK_SONNET_DISPLAY=""
+NOW=$(date +%s)
+
+SESS_PCT="" SESS_EPOCH="" SESS_FROM_CACHE=0
+WEEK_PCT="" WEEK_EPOCH="" SONNET_PCT=""
+
+# Leave the epoch empty when no reset is sent — num("") is "0", which render_quota
+# would read as a past reset and wrongly zero the live percentage.
+if [ "$HAVE_STDIN_SESSION" = 1 ]; then
+    SESS_PCT="$J_RL_5H_PCT"
+    [ -n "$J_RL_5H_RESET" ] && [ "$J_RL_5H_RESET" != "null" ] && SESS_EPOCH="$(num "$J_RL_5H_RESET")"
+fi
+if [ "$SHOW_WEEKLY" = "1" ] && [ -n "$J_RL_7D_PCT" ] && [ "$J_RL_7D_PCT" != "null" ]; then
+    WEEK_PCT="$J_RL_7D_PCT"
+    [ -n "$J_RL_7D_RESET" ] && [ "$J_RL_7D_RESET" != "null" ] && WEEK_EPOCH="$(num "$J_RL_7D_RESET")"
+fi
+
+# Cache only fills metrics stdin didn't provide. resets_at parsed as ISO 8601
+# (API format); the Sonnet weekly quota is API-only (absent from stdin).
+if [ -f "$USAGE_FILE" ]; then
+    IFS=$'\x1f' read -r CACHE_SOURCE U_SESS_PCT U_SESS_RESETS U_WEEK_PCT U_WEEK_RESETS U_SONNET_PCT \
+        < <(jq -r '[
+            (.source // "legacy"),
+            (.metrics.session.percent_used     // ""),
+            (.metrics.session.resets_at        // ""),
+            (.metrics.week_all.percent_used    // ""),
+            (.metrics.week_all.resets_at       // ""),
+            (.metrics.week_sonnet.percent_used // "")
+        ] | join("\u001f")' "$USAGE_FILE" 2>/dev/null)
+
+    if [ -z "$SESS_PCT" ] && [ -n "$U_SESS_PCT" ] && [ "$U_SESS_PCT" != "null" ]; then
+        SESS_PCT="$U_SESS_PCT"; SESS_FROM_CACHE=1
+        [ "$CACHE_SOURCE" = "api" ] && [ -n "$U_SESS_RESETS" ] && SESS_EPOCH="$(iso_to_epoch "$U_SESS_RESETS")"
+    fi
+    if [ "$SHOW_WEEKLY" = "1" ]; then
+        if [ -z "$WEEK_PCT" ] && [ -n "$U_WEEK_PCT" ] && [ "$U_WEEK_PCT" != "null" ]; then
+            WEEK_PCT="$U_WEEK_PCT"
+            [ "$CACHE_SOURCE" = "api" ] && [ -n "$U_WEEK_RESETS" ] && WEEK_EPOCH="$(iso_to_epoch "$U_WEEK_RESETS")"
+        fi
+        [ -n "$U_SONNET_PCT" ] && [ "$U_SONNET_PCT" != "null" ] && SONNET_PCT="$U_SONNET_PCT"
+    fi
+fi
+
+# ── Render ────────────────────────────────────────────────────────────────────
+[ -n "$SESS_PCT" ] && [ "$SESS_PCT" != "null" ] && \
+    BLOCK_DISPLAY="$(render_quota "⏳" "$SESS_PCT" "$SESS_EPOCH")"
+
+if [ "$SHOW_WEEKLY" = "1" ]; then
+    WEEK_INT="" WEEK_COLOR="" WEEK_RESET_LABEL="" SONNET_INT="" SONNET_COLOR=""
+    if [ -n "$WEEK_PCT" ] && [ "$WEEK_PCT" != "null" ]; then
+        WEEK_INT="$(num "$WEEK_PCT")"; make_bar "$WEEK_INT"; WEEK_COLOR="$BAR_COLOR"
+        if [ -n "$WEEK_EPOCH" ]; then
+            # GNU date -d @epoch || BSD date -r epoch
+            WEEK_RESET_LABEL=$(tz_date "${TIMEZONE}" -d "@$WEEK_EPOCH" +"%a %Hh" 2>/dev/null \
+                || tz_date "${TIMEZONE}" -r "$WEEK_EPOCH" +"%a %Hh" 2>/dev/null)
+            WEEK_RESET_LABEL=$(echo "$WEEK_RESET_LABEL" | tr '[:upper:]' '[:lower:]')
+        fi
+    fi
+    if [ -n "$SONNET_PCT" ] && [ "$SONNET_PCT" != "null" ]; then
+        SONNET_INT="$(num "$SONNET_PCT")"; make_bar "$SONNET_INT"; SONNET_COLOR="$BAR_COLOR"
+    fi
+    if [ -n "$WEEK_INT" ] && [ -n "$SONNET_INT" ]; then
+        WEEK_SONNET_DISPLAY="📅 ${WEEK_COLOR} ${WEEK_INT}% / Snt ${SONNET_COLOR} ${SONNET_INT}%"
+        [ -n "$WEEK_RESET_LABEL" ] && WEEK_SONNET_DISPLAY+=" ↻ ${WEEK_RESET_LABEL}"
+    elif [ -n "$WEEK_INT" ]; then
+        WEEK_SONNET_DISPLAY="📅 ${WEEK_COLOR} ${WEEK_INT}%"
+        [ -n "$WEEK_RESET_LABEL" ] && WEEK_SONNET_DISPLAY+=" ↻ ${WEEK_RESET_LABEL}"
+    elif [ -n "$SONNET_INT" ]; then
+        WEEK_SONNET_DISPLAY="Snt ${SONNET_COLOR} ${SONNET_INT}%"
+    fi
+fi
+
+# ── Stale indicator — ⚠ in place of color dot. Only when session came from the
+# cache: stdin rate_limits are always fresh, so cache age is irrelevant there.
+IS_STALE=0
+if [ "$SESS_FROM_CACHE" = 1 ] && [ -f "$USAGE_FILE" ] && [ "$REFRESH_INTERVAL" -gt 0 ] 2>/dev/null; then
+    [ "$(cache_age_sec)" -gt $(( REFRESH_INTERVAL * 3 )) ] && IS_STALE=1   # 3 missed refresh windows
+fi
+if [ "$IS_STALE" = 1 ] && [ -n "$BLOCK_DISPLAY" ]; then
+    # Exactly one color dot is present; the other two replacements are no-ops.
+    BLOCK_DISPLAY="${BLOCK_DISPLAY/🟢/⚠}"
+    BLOCK_DISPLAY="${BLOCK_DISPLAY/🟡/⚠}"
+    BLOCK_DISPLAY="${BLOCK_DISPLAY/🔴/⚠}"
+fi
+
+# ── Assemble ──────────────────────────────────────────────────────────────────
+PARTS=()
+[ -n "$BRANCH" ] && PARTS+=("🌿 $BRANCH$DIRTY")
+if [ -n "$MODEL" ] && [ -n "$EFFORT_LABEL" ]; then
+    PARTS+=("$MODEL/$EFFORT_LABEL")
+elif [ -n "$MODEL" ]; then
+    PARTS+=("$MODEL")
+fi
+[ -n "$CTX_PERCENT" ]         && PARTS+=("$CTX_COLOR $CTX_LABEL $CTX_BAR ${CTX_PERCENT}%")
+[ -n "$BLOCK_DISPLAY" ]       && PARTS+=("$BLOCK_DISPLAY")
+[ -n "$WEEK_SONNET_DISPLAY" ] && PARTS+=("$WEEK_SONNET_DISPLAY")
+# Cost + duration (only if non-zero)
+if [ -n "$COST_STR" ] && [ -n "$DURATION_STR" ]; then
+    PARTS+=("$COST_STR ⏱ $DURATION_STR")
+elif [ -n "$COST_STR" ]; then
+    PARTS+=("$COST_STR")
+fi
+
+RESULT=""
+for part in "${PARTS[@]}"; do
+    [ -z "$RESULT" ] && RESULT="$part" || RESULT="$RESULT │ $part"
+done
+
+echo "${RESULT}"

--- a/scripts/seed-data/sources/11-width-aware-monitor.py
+++ b/scripts/seed-data/sources/11-width-aware-monitor.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""
+Claude Code statusline with 5h/7d quota tracking.
+
+Shows: model, context gauge, tokens, git branch, 5h remaining%, 7d remaining%,
+pace indicator, and reset countdown.
+
+Designed for Claude Code on Windows, macOS, and Linux. Caches API responses to
+the system temp directory for 5 minutes.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import threading
+from pathlib import Path
+
+# Force UTF-8 output on Windows
+if sys.stdout.encoding != "utf-8":
+    sys.stdout.reconfigure(encoding="utf-8")
+
+# ── Configuration (env vars) ─────────────────────────────────────
+# Set these in your shell profile or in Claude Code's settings.json env block.
+# Values: "1" = show, "0" = hide
+SHOW_CONTEXT_SIZE = os.environ.get("CQB_CONTEXT_SIZE", "0") == "1"
+SHOW_TOKENS = os.environ.get("CQB_TOKENS", "1") == "1"
+SHOW_PACE = os.environ.get("CQB_PACE", "0") == "1"
+SHOW_RESET = os.environ.get("CQB_RESET", "1") == "1"
+SHOW_DURATION = os.environ.get("CQB_DURATION", "1") == "1"
+SHOW_BRANCH = os.environ.get("CQB_BRANCH", "1") == "1"
+SHOW_COST = os.environ.get("CQB_COST", "0") == "1"
+SHOW_REMAINING = os.environ.get("CQB_REMAINING", "1") == "1"
+SHOW_BAR = os.environ.get("CQB_BAR", "1") == "1"
+MAX_WIDTH = int(os.environ.get("CQB_MAX_WIDTH", "80"))
+
+# ── Read stdin ──────────────────────────────────────────────────
+raw = sys.stdin.read().strip()
+if not raw:
+    print("Claude")
+    sys.exit(0)
+
+try:
+    d = json.loads(raw)
+except json.JSONDecodeError:
+    print("Claude")
+    sys.exit(0)
+
+# ── ANSI colors ─────────────────────────────────────────────────
+C = "\033[36m"   # cyan
+G = "\033[32m"   # green
+Y = "\033[33m"   # yellow
+R = "\033[31m"   # red
+D = "\033[2m"    # dim
+N = "\033[0m"    # reset
+
+_ANSI_RE = re.compile(r"\033\[[0-9;]*m")
+
+
+def strip_ansi(text):
+    """Remove ANSI escape sequences to measure visible width."""
+    return _ANSI_RE.sub("", text)
+
+
+def color_pct(used_pct):
+    """Color based on how much quota is USED (high = bad)."""
+    if used_pct >= 90:
+        return R
+    if used_pct >= 70:
+        return Y
+    return G
+
+
+# ── Parse session data ──────────────────────────────────────────
+model = "Opus"
+try:
+    model = d["model"]["display_name"]
+except (KeyError, TypeError):
+    pass
+
+ctx_pct_used = 0
+ctx_size = 0
+try:
+    ctx_pct_used = int(d["context_window"]["used_percentage"] or 0)
+    ctx_size = int(d["context_window"]["context_window_size"] or 0)
+except (KeyError, TypeError, ValueError):
+    pass
+
+in_tok = 0
+out_tok = 0
+try:
+    in_tok = d["context_window"]["total_input_tokens"] or 0
+except (KeyError, TypeError):
+    pass
+try:
+    out_tok = d["context_window"]["total_output_tokens"] or 0
+except (KeyError, TypeError):
+    pass
+
+cost_usd = 0.0
+duration_ms = 0
+try:
+    cost_usd = float(d["cost"]["total_cost_usd"] or 0)
+except (KeyError, TypeError, ValueError):
+    pass
+try:
+    duration_ms = int(d["cost"]["total_duration_ms"] or 0)
+except (KeyError, TypeError, ValueError):
+    pass
+
+proj_dir = ""
+proj_name = ""
+try:
+    proj_dir = d["workspace"]["project_dir"] or ""
+    proj_name = os.path.basename(proj_dir)
+except (KeyError, TypeError):
+    pass
+
+# ── Git branch ──────────────────────────────────────────────────
+branch = ""
+cwd = os.getcwd()
+candidate_dirs = []
+if proj_dir:
+    candidate_dirs.append(proj_dir)
+if cwd and cwd not in candidate_dirs:
+    candidate_dirs.append(cwd)
+
+for try_dir in candidate_dirs:
+    if not try_dir:
+        continue
+    try:
+        r = subprocess.run(
+            ["git", "-C", try_dir, "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, timeout=2,
+        )
+        if r.returncode == 0:
+            branch = r.stdout.strip()
+            if not proj_name:
+                proj_name = os.path.basename(try_dir)
+            break
+    except Exception:
+        pass
+
+# ── Helpers ─────────────────────────────────────────────────────
+def compact(n):
+    n = float(n)
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}m".replace(".0m", "m")
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k".replace(".0k", "k")
+    return str(int(n))
+
+
+def format_duration(ms):
+    if ms >= 3_600_000:
+        return f"{ms // 3_600_000}h{(ms // 60_000) % 60}m"
+    if ms >= 60_000:
+        return f"{ms // 60_000}m{(ms // 1000) % 60}s"
+    return f"{ms // 1000}s"
+
+
+def format_reset(minutes):
+    """Format reset countdown."""
+    if minutes is None:
+        return ""
+    m = int(minutes)
+    if m >= 1440:
+        return f" {D}({m // 1440}d){N}"
+    if m >= 60:
+        return f" {D}({m // 60}h){N}"
+    return f" {D}({m}m){N}"
+
+
+
+def used_pct_str(used_pct):
+    """Format used or remaining % with color."""
+    if used_pct is None or used_pct == "--":
+        return "--"
+    used = int(used_pct)
+    c = color_pct(used)
+    val = 100 - used if SHOW_REMAINING else used
+    if SHOW_BAR:
+        filled = round(min(100, max(0, val)) / 100.0 * 5)
+        filled_chars = "\u25b0" * filled
+        empty_chars = "\u25b1" * (5 - filled)
+        bar = f"{c}{filled_chars}{empty_chars}{N} "
+    else:
+        bar = ""
+    return f"{bar}{c}{val}%{N}"
+
+
+def pace_indicator(used_pct, remain_min, window_min):
+    """Show pace: positive = ahead (green), negative = over pace (red). Suppress within +/-10%."""
+    if used_pct is None or remain_min is None:
+        return ""
+    try:
+        used = int(used_pct)
+        rmin = int(remain_min)
+    except (ValueError, TypeError):
+        return ""
+    if rmin > window_min:
+        return ""
+    elapsed = window_min - rmin
+    if elapsed <= 0:
+        return ""
+    expected = (elapsed * 100) // window_min
+    delta = expected - used
+    if delta > 10:
+        return f" {G}+{delta}%{N}"
+    if delta < -10:
+        return f" {R}{delta}%{N}"
+    return ""
+
+
+# ── Quota API ───────────────────────────────────────────────────
+CACHE_FILE = os.environ.get(
+    "CQB_CACHE_PATH",
+    os.path.join(tempfile.gettempdir(), "claude-sl-usage.json"),
+)
+CACHE_TTL = 300  # 5 minutes
+LOCK_FILE = CACHE_FILE + ".lock"
+
+
+def get_oauth_token():
+    """Read OAuth token from Claude Code's credential store."""
+    # Env var override
+    tok = os.environ.get("CLAUDE_CODE_OAUTH_TOKEN")
+    if tok:
+        return tok
+    # Credentials file
+    cred_path = Path.home() / ".claude" / ".credentials.json"
+    if cred_path.exists():
+        try:
+            creds = json.loads(cred_path.read_text(encoding="utf-8"))
+            return creds.get("claudeAiOauth", {}).get("accessToken")
+        except Exception:
+            pass
+    return None
+
+
+def fetch_usage_sync():
+    """Call Anthropic usage API and write cache. Run in background thread."""
+    try:
+        token = get_oauth_token()
+        if not token:
+            return
+
+        import urllib.request
+
+        req = urllib.request.Request(
+            "https://api.anthropic.com/api/oauth/usage",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "anthropic-beta": "oauth-2025-04-20",
+                "Content-Type": "application/json",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read().decode())
+
+        def parse_reset_minutes(iso_str):
+            if not iso_str:
+                return None
+            try:
+                from datetime import datetime, timezone
+                # Handle various ISO formats
+                iso_str = iso_str.replace("+00:00", "+0000").replace("Z", "+0000")
+                # Strip fractional seconds
+                if "." in iso_str:
+                    base, rest = iso_str.split(".", 1)
+                    tz_part = ""
+                    for sep in ["+", "-"]:
+                        if sep in rest:
+                            idx = rest.index(sep)
+                            tz_part = rest[idx:]
+                            break
+                    iso_str = base + tz_part
+                dt = datetime.strptime(iso_str, "%Y-%m-%dT%H:%M:%S%z")
+                now = datetime.now(timezone.utc)
+                diff = (dt - now).total_seconds() / 60
+                return max(0, int(diff))
+            except Exception:
+                return None
+
+        cache_data = {
+            "five_hour_used": data.get("five_hour", {}).get("utilization", 0),
+            "seven_day_used": data.get("seven_day", {}).get("utilization", 0),
+            "five_hour_reset_min": parse_reset_minutes(data.get("five_hour", {}).get("resets_at")),
+            "seven_day_reset_min": parse_reset_minutes(data.get("seven_day", {}).get("resets_at")),
+            "extra_enabled": data.get("extra_usage", {}).get("is_enabled", False),
+            "extra_used": data.get("extra_usage", {}).get("used_credits", 0),
+            "extra_limit": data.get("extra_usage", {}).get("monthly_limit", 0),
+            "fetched_at": time.time(),
+        }
+
+        tmp = CACHE_FILE + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump(cache_data, f)
+        os.replace(tmp, CACHE_FILE)
+
+    except Exception:
+        pass  # Intentional: statusline must never fail visibly
+    finally:
+        try:
+            os.unlink(LOCK_FILE)
+        except OSError:
+            pass
+
+
+_fetch_thread = None
+
+def read_cached_usage():
+    """Read cached usage data, trigger background refresh if stale."""
+    global _fetch_thread
+    cache = None
+    if os.path.exists(CACHE_FILE):
+        try:
+            with open(CACHE_FILE) as f:
+                cache = json.load(f)
+        except Exception:
+            pass
+
+    # Check if cache is stale
+    now = time.time()
+    fetched_at = (cache or {}).get("fetched_at", 0)
+    is_stale = (now - fetched_at) > CACHE_TTL
+
+    if is_stale:
+        # Try to acquire lock (non-blocking)
+        try:
+            fd = os.open(LOCK_FILE, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.write(fd, str(os.getpid()).encode())
+            os.close(fd)
+            # Fetch in background thread; joined at end of script
+            t = threading.Thread(target=fetch_usage_sync)
+            t.start()
+            _fetch_thread = t
+        except FileExistsError:
+            # Another process is fetching; check if lock is stale (>30s)
+            try:
+                lock_age = now - os.path.getmtime(LOCK_FILE)
+                if lock_age > 30:
+                    os.unlink(LOCK_FILE)
+            except OSError:
+                pass
+
+    if cache:
+        # Adjust reset minutes for time elapsed since fetch
+        elapsed_min = (now - cache.get("fetched_at", now)) / 60
+        r5 = cache.get("five_hour_reset_min")
+        r7 = cache.get("seven_day_reset_min")
+        if r5 is not None:
+            r5 = max(0, int(r5 - elapsed_min))
+        if r7 is not None:
+            r7 = max(0, int(r7 - elapsed_min))
+        return {
+            "u5": cache.get("five_hour_used"),
+            "u7": cache.get("seven_day_used"),
+            "r5": r5,
+            "r7": r7,
+            "extra_enabled": cache.get("extra_enabled", False),
+            "extra_used": cache.get("extra_used", 0),
+            "extra_limit": cache.get("extra_limit", 0),
+        }
+
+    return None
+
+
+# ── Build output ────────────────────────────────────────────────
+SEP = " \u2502 "  # │
+DIAMOND = "\u25c6"  # ◆
+
+# Context gauge (5 blocks)
+ctx_remaining = 100 - ctx_pct_used
+filled = round(min(100, max(0, ctx_remaining)) / 100.0 * 5)
+gauge = "\u25b0" * filled + "\u25b1" * (5 - filled)  # ▰▱
+
+# Context size label
+if ctx_size >= 1_000_000:
+    ctx_label = f"{ctx_size // 1_000_000}M"
+else:
+    ctx_label = f"{ctx_size // 1000}K"
+
+# Line 1: model, project, branch
+line1_parts = [f"{C}{DIAMOND} {model}{N}"]
+
+if proj_name:
+    loc = f"{proj_name}/{branch}" if (branch and SHOW_BRANCH) else proj_name
+    if len(loc) > 40:
+        loc = loc[:39] + "\u2026"
+    line1_parts.append(loc)
+
+line1 = SEP.join(line1_parts)
+
+# Line 2: context gauge, quota, duration
+# Each segment is (text, priority) - lower priority number = more important (dropped last).
+# When the joined line exceeds MAX_WIDTH, the highest-numbered priorities are dropped first.
+ctx_color = color_pct(ctx_pct_used)
+ctx_str = f"{ctx_color}{gauge}{N} {ctx_remaining}%"
+if SHOW_CONTEXT_SIZE:
+    ctx_str += f" of {ctx_label}"
+
+line2_segments = []  # list of (text, priority)
+line2_segments.append((ctx_str, 2))
+
+# Token counts
+if SHOW_TOKENS and (in_tok or out_tok):
+    line2_segments.append((f"\u2191{compact(in_tok)} \u2193{compact(out_tok)}", 4))
+
+# Quota
+usage = read_cached_usage()
+if usage:
+    u5 = usage["u5"]
+    u7 = usage["u7"]
+    r5 = usage["r5"]
+    r7 = usage["r7"]
+
+    pace5 = pace_indicator(u5, r5, 300) if SHOW_PACE else ""
+    pace7 = pace_indicator(u7, r7, 10080) if SHOW_PACE else ""
+    reset5 = format_reset(r5) if SHOW_RESET else ""
+    reset7 = format_reset(r7) if SHOW_RESET else ""
+
+    line2_segments.append((f"5h: {used_pct_str(u5)}{pace5}{reset5}", 1))
+    line2_segments.append((f"7d: {used_pct_str(u7)}{pace7}{reset7}", 1))
+else:
+    if not get_oauth_token():
+        line2_segments.append((f"5h: {D}no token{N}", 1))
+        line2_segments.append((f"7d: {D}no token{N}", 1))
+    else:
+        line2_segments.append((f"5h: {D}--{N}", 1))
+        line2_segments.append((f"7d: {D}--{N}", 1))
+
+# Cost
+if SHOW_COST and cost_usd > 0:
+    line2_segments.append((f"{D}${cost_usd:.2f}{N}", 4))
+
+# Duration
+if SHOW_DURATION:
+    line2_segments.append((f"{D}{format_duration(duration_ms)}{N}", 3))
+
+# Drop lowest-priority segments until line fits within MAX_WIDTH
+def build_line(segments):
+    return SEP.join(text for text, _ in segments)
+
+line2 = build_line(line2_segments)
+while len(strip_ansi(line2)) > MAX_WIDTH and line2_segments:
+    worst = max(range(len(line2_segments)), key=lambda i: line2_segments[i][1])
+    line2_segments.pop(worst)
+    line2 = build_line(line2_segments)
+
+print(line1)
+print(line2)
+
+# Wait for background fetch to finish (max 8s) so cache gets written
+if _fetch_thread is not None:
+    _fetch_thread.join(timeout=8)

--- a/scripts/seed-data/sources/12-activity-feed.sh
+++ b/scripts/seed-data/sources/12-activity-feed.sh
@@ -1,0 +1,644 @@
+#!/bin/bash
+# [statuslin.es] trimmed: removed the ccusage-cache.sh sibling-script call and its daily-cost table; everything else is unmodified from the pinned source.
+# Claude Code Custom Statusline
+# https://github.com/JungHoonGhae/claude-statusline
+#
+# A rich statusline for Claude Code that shows context usage, rate limits,
+# tool/agent activity, and daily token costs — all in pure bash.
+#
+# Dependencies: jq, curl
+# Optional: ccusage (npm) for token cost tracking
+
+# ── Platform Detection ────────────────────────────────────────────────────────
+OS_TYPE="$(uname -s)"
+
+get_mtime() {
+  case "$OS_TYPE" in
+    Darwin) stat -f %m "$1" 2>/dev/null || echo 0 ;;
+    MINGW*|MSYS*|CYGWIN*) stat -c %Y "$1" 2>/dev/null || echo 0 ;;
+    *) stat -c %Y "$1" 2>/dev/null || echo 0 ;;
+  esac
+}
+
+parse_iso_to_epoch() {
+  local ts=$1
+  case "$OS_TYPE" in
+    Darwin) TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$ts" "+%s" 2>/dev/null ;;
+    *) TZ=UTC date -d "${ts}" "+%s" 2>/dev/null ;;
+  esac
+}
+
+get_oauth_token() {
+  local cred_file
+  case "$OS_TYPE" in
+    Darwin)
+      security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null \
+        | jq -r '.claudeAiOauth.accessToken // empty'
+      return
+      ;;
+    MINGW*|MSYS*|CYGWIN*)
+      # Windows (Git Bash / MSYS2 / Cygwin): ~/.claude/.credentials.json
+      cred_file="$HOME/.claude/.credentials.json"
+      if [ ! -f "$cred_file" ] && [ -n "$APPDATA" ]; then
+        cred_file="$APPDATA/Claude/credentials.json"
+      fi
+      if [ -f "$cred_file" ]; then
+        jq -r '.claudeAiOauth.accessToken // empty' "$cred_file" 2>/dev/null
+      fi
+      return
+      ;;
+  esac
+  # Linux: try credentials file, then secret-tool (GNOME Keyring)
+  cred_file="$HOME/.claude/.credentials.json"
+  if [ -f "$cred_file" ]; then
+    jq -r '.claudeAiOauth.accessToken // empty' "$cred_file" 2>/dev/null
+  elif command -v secret-tool >/dev/null 2>&1; then
+    secret-tool lookup service "Claude Code-credentials" 2>/dev/null \
+      | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null
+  fi
+}
+
+# ── Dependency Check ──────────────────────────────────────────────────────────
+# Without this, a missing jq makes the statusline silently blank (common in
+# Docker containers after restart — only the mounted ~/.claude survives)
+if ! command -v jq >/dev/null 2>&1; then
+  cat > /dev/null
+  printf '\n  \033[1;31mclaude-statusline: jq not found\033[0m \033[2m— install it: apt-get install -y jq / apk add jq / brew install jq\033[0m\n\n'
+  exit 0
+fi
+
+# ── Cache ─────────────────────────────────────────────────────────────────────
+# Per-user dir — a shared /tmp path collides (and leaks data) between users
+CACHE_DIR="${TMPDIR:-/tmp}/claude-statusline-$(id -u)"
+mkdir -p "$CACHE_DIR" 2>/dev/null
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+# Defaults; overridable by environment, then by the conf file (conf wins).
+SHOW_RATE_LIMITS=${SHOW_RATE_LIMITS:-true}
+SHOW_TOOLS=${SHOW_TOOLS:-true}
+SHOW_AGENTS=${SHOW_AGENTS:-true}
+SHOW_CCUSAGE=${SHOW_CCUSAGE:-true}
+SHOW_CONTEXT_BAR=${SHOW_CONTEXT_BAR:-true}
+SHOW_BURN_RATE=${SHOW_BURN_RATE:-true}
+SHOW_GIT_AHEAD=${SHOW_GIT_AHEAD:-true}
+SHOW_LINKS=${SHOW_LINKS:-true}
+SHOW_SESSION_NAME=${SHOW_SESSION_NAME:-false}
+CONTEXT_WARN_PCT=${CONTEXT_WARN_PCT:-30}
+CONTEXT_CRIT_PCT=${CONTEXT_CRIT_PCT:-70}
+DAILY_BUDGET=${DAILY_BUDGET:-0}
+
+STATUSLINE_CONF="${STATUSLINE_CONF:-$HOME/.claude/statusline.conf}"
+if [ -f "$STATUSLINE_CONF" ]; then
+  while IFS='=' read -r key val; do
+    key=$(echo "$key" | tr -d '[:space:]')
+    val=$(echo "$val" | tr -d '[:space:]')
+    case "$key" in
+      SHOW_RATE_LIMITS|SHOW_TOOLS|SHOW_AGENTS|SHOW_CCUSAGE) eval "$key=$val" ;;
+      SHOW_CONTEXT_BAR|SHOW_BURN_RATE|SHOW_GIT_AHEAD|SHOW_LINKS|SHOW_SESSION_NAME) eval "$key=$val" ;;
+      CONTEXT_WARN_PCT|CONTEXT_CRIT_PCT|DAILY_BUDGET) eval "$key=$val" ;;
+    esac
+  done < <(grep -v '^\s*#' "$STATUSLINE_CONF" | grep -v '^\s*$')
+fi
+
+# Terminal width — Claude Code exports $COLUMNS. The header and the rate-limit
+# lines compact at *independent* thresholds (the header is far longer, so it
+# needs to shrink well before the rate-limit lines do — otherwise the gauges get
+# packed together while there's still plenty of room).
+#   WIDE      (>= WIDE_COLS):     full header incl. ctx bar, token detail, burn rate
+#   medium:                       standard header, no extras
+#   COMPACT   (<  COMPACT_COLS):  minimal header (model | ctx% | project | cost)
+#   RL_COMPACT(<  RLCOMPACT_COLS):tight rate-limit lines (5 spaced dots, no labels)
+# COLUMNS unset (0) → assume wide so piped/test use keeps the full layout.
+COLS=${COLUMNS:-0}
+COMPACT_COLS=100   # minimal header below this (standard header needs ~96 cols)
+WIDE_COLS=132      # ctx bar + tokens + burn rate above this (full header ~129 cols)
+RLCOMPACT_COLS=64  # tighten rate-limit lines only below this (normal line ~56 cols)
+COMPACT=0
+WIDE=1
+RL_COMPACT=0
+if [ "$COLS" -gt 0 ] 2>/dev/null; then
+  [ "$COLS" -lt "$COMPACT_COLS" ] && COMPACT=1
+  [ "$COLS" -lt "$WIDE_COLS" ] && WIDE=0
+  [ "$COLS" -lt "$RLCOMPACT_COLS" ] && RL_COMPACT=1
+fi
+# Links can leak escape codes through tmux without passthrough — disable there
+[ -n "$TMUX" ] && SHOW_LINKS=false
+
+# ── Parse stdin from Claude Code ──────────────────────────────────────────────
+input=$(cat)
+
+eval "$(jq -r '
+  @sh "model=\(.model.display_name // "Unknown")",
+  @sh "used=\(.context_window.used_percentage // 0 | floor)",
+  @sh "ctx_size=\(.context_window.context_window_size // 0)",
+  @sh "ctx_tokens=\(if .context_window.current_usage then ((.context_window.current_usage.input_tokens // 0) + (.context_window.current_usage.cache_creation_input_tokens // 0) + (.context_window.current_usage.cache_read_input_tokens // 0)) else "" end)",
+  @sh "cwd=\(.workspace.current_dir // .cwd // "")",
+  @sh "cost=\(.cost.total_cost_usd // 0)",
+  @sh "duration_ms=\(.cost.total_duration_ms // 0)",
+  @sh "lines_added=\(.cost.total_lines_added // 0)",
+  @sh "lines_removed=\(.cost.total_lines_removed // 0)",
+  @sh "git_branch=\(.git.branch // "")",
+  @sh "git_dirty=\(.git.dirty // false)",
+  @sh "worktree=\(.worktree.name // .workspace.git_worktree // "")",
+  @sh "fast_mode=\(.fast_mode // false)",
+  @sh "effort=\(.effort.level // "")",
+  @sh "thinking=\(.thinking.enabled // false)",
+  @sh "pr_number=\(.pr.number // "")",
+  @sh "pr_state=\(.pr.review_state // "")",
+  @sh "pr_url=\(.pr.url // "")",
+  @sh "session_name=\(.session_name // "")",
+  @sh "transcript_path=\(.transcript_path // "")",
+  @sh "stdin_5h_used=\(.rate_limits.five_hour.used_percentage // "")",
+  @sh "stdin_5h_reset=\(.rate_limits.five_hour.resets_at // "")",
+  @sh "stdin_7d_used=\(.rate_limits.seven_day.used_percentage // "")",
+  @sh "stdin_7d_reset=\(.rate_limits.seven_day.resets_at // "")"
+' <<< "$input")"
+
+# ── Project & Branch ──────────────────────────────────────────────────────────
+project=$(basename "$cwd" 2>/dev/null)
+
+# Claude Code no longer sends .git in stdin (v2.1.x) — read from the repo directly
+if [ -z "$git_branch" ] && [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  git_branch=$(git -C "$cwd" branch --show-current 2>/dev/null)
+  [ -z "$git_branch" ] && git_branch=$(git -C "$cwd" rev-parse --short HEAD 2>/dev/null)
+  if [ -n "$git_branch" ] && [ "$git_dirty" != "true" ]; then
+    [ -n "$(git -C "$cwd" status --porcelain --untracked-files=no 2>/dev/null | head -1)" ] && git_dirty=true
+  fi
+fi
+
+# Ahead/behind vs upstream (one cheap git call; skipped if no upstream)
+ahead_behind=""
+if [ "$SHOW_GIT_AHEAD" = "true" ] && [ -n "$git_branch" ] && [ -n "$cwd" ] && [ -d "$cwd" ]; then
+  ab=$(git -C "$cwd" rev-list --left-right --count '@{upstream}...HEAD' 2>/dev/null)
+  if [ -n "$ab" ]; then
+    behind=${ab%%[	 ]*}
+    ahead=${ab##*[	 ]}
+    [ "$ahead" -gt 0 ] 2>/dev/null && ahead_behind="${ahead_behind} \033[32m↑${ahead}\033[0m"
+    [ "$behind" -gt 0 ] 2>/dev/null && ahead_behind="${ahead_behind} \033[31m↓${behind}\033[0m"
+  fi
+fi
+
+dirty_mark=""
+if [ "$git_dirty" = "true" ]; then
+  dirty_mark="\033[31m*\033[0m"
+fi
+
+location_str=""
+if [ -n "$worktree" ]; then
+  location_str=" \033[35m⎇ ${worktree}\033[0m${dirty_mark}${ahead_behind}"
+elif [ -n "$git_branch" ]; then
+  location_str=" \033[35m(${git_branch})\033[0m${dirty_mark}${ahead_behind}"
+fi
+
+# ── Format Duration ───────────────────────────────────────────────────────────
+if [ "$duration_ms" -gt 0 ] 2>/dev/null; then
+  total_sec=$((duration_ms / 1000))
+  hours=$((total_sec / 3600))
+  mins=$(( (total_sec % 3600) / 60 ))
+  if [ "$hours" -gt 0 ]; then
+    duration_str="${hours}h ${mins}m"
+  elif [ "$mins" -gt 0 ]; then
+    duration_str="${mins}m"
+  else
+    duration_str="${total_sec}s"
+  fi
+else
+  duration_str="0s"
+fi
+
+# ── Format Cost ───────────────────────────────────────────────────────────────
+if [ "$cost" != "0" ] && [ -n "$cost" ]; then
+  cost_str=$(printf '$%.2f' "$cost")
+else
+  cost_str='$0.00'
+fi
+
+# ── Burn Rate ($/hr) ──────────────────────────────────────────────────────────
+# Only meaningful past the first minute; integer-cents math, no bc/awk
+burn_str=""
+if [ "$SHOW_BURN_RATE" = "true" ] && [ "$duration_ms" -ge 60000 ] 2>/dev/null; then
+  cstr=${cost_str#\$}                      # "24.32"
+  cfrac=${cstr#*.}00                        # decimals, padded
+  cents=$(( ${cstr%%.*} * 100 + 10#${cfrac:0:2} ))
+  if [ "$cents" -gt 0 ] 2>/dev/null; then
+    rate_cents=$(( cents * 3600000 / duration_ms ))
+    burn_str=$(printf ' \033[2m· ~$%d.%02d/hr\033[0m' $((rate_cents / 100)) $((rate_cents % 100)))
+  fi
+fi
+
+# ── OSC 8 Hyperlink ───────────────────────────────────────────────────────────
+# Wraps text in a clickable link; unsupported terminals just show the text.
+# Returns *literal* escape sequences so it survives the header's printf '%b'.
+osc_link() {
+  local url=$1 text=$2
+  if [ "$SHOW_LINKS" = "true" ] && [ -n "$url" ]; then
+    printf '%s' '\033]8;;'"$url"'\033\\'"$text"'\033]8;;\033\\'
+  else
+    printf '%s' "$text"
+  fi
+}
+
+# Session name (opt-in; truncated, since long /rename labels blow up line 1)
+session_str=""
+if [ "$SHOW_SESSION_NAME" = "true" ] && [ -n "$session_name" ]; then
+  sn=$session_name
+  [ "${#sn}" -gt 24 ] && sn="${sn:0:23}…"
+  session_str=" \033[2m· ${sn}\033[0m"
+fi
+
+# ── Color Helpers ─────────────────────────────────────────────────────────────
+
+ctx_color() {
+  local pct=$1
+  if [ "$pct" -lt "$CONTEXT_WARN_PCT" ]; then
+    printf "\033[32m"
+  elif [ "$pct" -lt "$CONTEXT_CRIT_PCT" ]; then
+    printf "\033[33m"
+  else
+    printf "\033[31m"
+  fi
+}
+
+make_bar() {
+  local pct=$1 count=${2:-10}
+  local filled=$(( pct * count / 100 ))
+  [ "$filled" -gt "$count" ] && filled=$count
+
+  local color
+  if [ "$pct" -gt 50 ]; then
+    color="\033[32m"
+  elif [ "$pct" -gt 20 ]; then
+    color="\033[33m"
+  else
+    color="\033[31m"
+  fi
+
+  local bar="" i=0
+  while [ "$i" -lt "$count" ]; do
+    [ "$i" -gt 0 ] && bar="${bar} "   # always spaced for legibility
+    if [ "$i" -lt "$filled" ]; then
+      bar="${bar}${color}●\033[0m"
+    else
+      bar="${bar}\033[2m○\033[0m"
+    fi
+    i=$((i + 1))
+  done
+  printf '%b' "$bar"
+}
+
+# Small 5-segment context gauge for the header (spaced, like the rate-limit bars)
+ctx_bar() {
+  local pct=$1 c
+  c=$(ctx_color "$pct")
+  local filled=$(( (pct + 19) / 20 ))   # round up so any usage shows ≥1 dot
+  [ "$filled" -gt 5 ] && filled=5
+  [ "$filled" -lt 0 ] && filled=0
+  local bar="" i=0
+  while [ "$i" -lt 5 ]; do
+    [ "$i" -gt 0 ] && bar="${bar} "
+    if [ "$i" -lt "$filled" ]; then
+      bar="${bar}${c}●\033[0m"
+    else
+      bar="${bar}\033[2m○\033[0m"
+    fi
+    i=$((i + 1))
+  done
+  printf '%b' "$bar"
+}
+
+status_dot() {
+  local pct=$1
+  if [ "$pct" -gt 50 ]; then
+    printf "\033[32m●\033[0m"
+  elif [ "$pct" -gt 20 ]; then
+    printf "\033[33m●\033[0m"
+  else
+    printf "\033[31m●\033[0m"
+  fi
+}
+
+# ── Rate Limit Helpers ────────────────────────────────────────────────────────
+
+format_remaining_epoch() {
+  local reset_epoch=$1
+  # null/empty reset = bucket idle (0% used) — the window hasn't started yet
+  if [ -z "$reset_epoch" ] || [ "$reset_epoch" = "" ] || [ "$reset_epoch" = "null" ]; then
+    echo "idle"
+    return
+  fi
+  if echo "$reset_epoch" | grep -qE '^[0-9]+\.?[0-9]*$'; then
+    reset_epoch=${reset_epoch%%.*}
+  else
+    local utc_ts=${reset_epoch%%+*}
+    utc_ts=${utc_ts%%.*}
+    reset_epoch=$(parse_iso_to_epoch "$utc_ts")
+  fi
+  local now_epoch remaining rd rh rm
+  now_epoch=$(date +%s)
+  if [ -n "$reset_epoch" ] && [ "$reset_epoch" -gt "$now_epoch" ] 2>/dev/null; then
+    remaining=$(( reset_epoch - now_epoch ))
+    rd=$((remaining / 86400))
+    rh=$(( (remaining % 86400) / 3600 ))
+    rm=$(( (remaining % 3600) / 60 ))
+    if [ "$rd" -gt 0 ]; then
+      echo "Resets in ${rd}d ${rh}h"
+    elif [ "$rh" -gt 0 ]; then
+      echo "Resets in ${rh}h ${rm}m"
+    else
+      echo "Resets in ${rm}m"
+    fi
+  else
+    echo "Resetting"
+  fi
+}
+
+print_limit_line() {
+  local label=$1 used_val=$2 reset_val=$3
+  [ -n "$used_val" ] || return
+  local left=$((100 - used_val))
+  if [ "$RL_COMPACT" -eq 1 ]; then
+    # Very narrow: 5 spaced dots, short reset, no "left"/"Resets in"
+    local rem; rem=$(format_remaining_epoch "$reset_val"); rem=${rem#Resets in }; rem=${rem// /}
+    printf "  \033[2m%-7.7s\033[0m %b \033[36m%s%%\033[0m \033[2m%s\033[0m\n" \
+      "$label" "$(make_bar "$left" 5)" "$left" "$rem"
+  else
+    printf "  \033[2m%-7.7s\033[0m %b %s  \033[36m%s%% left\033[0m  \033[2m%s\033[0m\n" \
+      "$label" "$(status_dot "$left")" "$(make_bar "$left")" "$left" "$(format_remaining_epoch "$reset_val")"
+  fi
+}
+
+# Bucket key → display label (works on bash 3.2 — no ${var^})
+pretty_bucket() {
+  case "$1" in
+    oauth_apps) echo "Apps" ;;
+    *) echo "$1" | awk -F_ '{ print toupper(substr($1,1,1)) substr($1,2) }' ;;
+  esac
+}
+
+fmt_tokens() {
+  local t=$1 div unit
+  if [ "$t" -ge 1000000000 ] 2>/dev/null; then
+    div=1000000000; unit=B
+  elif [ "$t" -ge 1000000 ] 2>/dev/null; then
+    div=1000000; unit=M
+  elif [ "$t" -ge 1000 ] 2>/dev/null; then
+    div=1000; unit=K
+  else
+    printf "%d" "$t"
+    return
+  fi
+  local whole=$((t / div)) dec=$(( (t % div) * 10 / div ))
+  if [ "$dec" -eq 0 ]; then
+    printf "%d%s" "$whole" "$unit"
+  else
+    printf "%d.%d%s" "$whole" "$dec" "$unit"
+  fi
+}
+
+# ── Rate Limits: stdin first, API fallback ────────────────────────────────────
+
+# Try stdin rate_limits first (Claude Code v2.1.6+)
+if [ -n "$stdin_5h_used" ] && [ "$stdin_5h_used" != "null" ]; then
+  five_hour_used=$(printf '%.0f' "$stdin_5h_used" 2>/dev/null || echo 0)
+  five_hour_reset="$stdin_5h_reset"
+else
+  five_hour_used=""
+fi
+
+if [ -n "$stdin_7d_used" ] && [ "$stdin_7d_used" != "null" ]; then
+  seven_day_used=$(printf '%.0f' "$stdin_7d_used" 2>/dev/null || echo 0)
+  seven_day_reset="$stdin_7d_reset"
+else
+  seven_day_used=""
+fi
+
+# API fallback: model-specific buckets (auto-detected) + Session/Weekly if stdin missing
+api_buckets=""
+extra_enabled=""; extra_used_pct=""
+
+if [ "$SHOW_RATE_LIMITS" = "true" ]; then
+  CACHE_FILE="$CACHE_DIR/usage.json"
+  CACHE_TTL=120
+
+  fetch_usage() {
+    local TOKEN
+    command -v curl >/dev/null 2>&1 || return 0
+    TOKEN=$(get_oauth_token)
+    if [ -n "$TOKEN" ]; then
+      curl -s --max-time 3 "https://api.anthropic.com/api/oauth/usage" \
+        -H "Authorization: Bearer $TOKEN" \
+        -H "anthropic-beta: oauth-2025-04-20" 2>/dev/null
+    fi
+  }
+
+  need_refresh=1
+  if [ -f "$CACHE_FILE" ]; then
+    cache_age=$(( $(date +%s) - $(get_mtime "$CACHE_FILE") ))
+    if [ "$cache_age" -lt "$CACHE_TTL" ]; then
+      need_refresh=0
+    fi
+  fi
+
+  if [ "$need_refresh" -eq 1 ]; then
+    usage_data=$(fetch_usage)
+    if [ -n "$usage_data" ] && echo "$usage_data" | jq -e '.five_hour' >/dev/null 2>&1; then
+      echo "$usage_data" > "$CACHE_FILE"
+    fi
+  fi
+
+  if [ -s "$CACHE_FILE" ]; then
+    eval "$(jq -r '
+      @sh "api_5h_used=\(.five_hour.utilization // "" | if . != "" then (. | floor | tostring) else "" end)",
+      @sh "api_5h_reset=\(.five_hour.resets_at // "")",
+      @sh "api_7d_used=\(.seven_day.utilization // "" | if . != "" then (. | floor | tostring) else "" end)",
+      @sh "api_7d_reset=\(.seven_day.resets_at // "")",
+      @sh "extra_enabled=\(.extra_usage.is_enabled // false)",
+      @sh "extra_used_pct=\(if .extra_usage.utilization then (.extra_usage.utilization | floor | tostring) else "" end)"
+    ' "$CACHE_FILE")"
+
+    # Any seven_day_<bucket> with data (Opus/Sonnet/Fable/... — keys change over time).
+    # Order by model capability (best first); unknown buckets keep API order after.
+    api_buckets=$(jq -r '
+      ["fable","opus","sonnet","haiku"] as $rank
+      | [ to_entries[]
+          | select(.key | startswith("seven_day_"))
+          | select((.value | type) == "object" and .value.utilization != null)
+          | (.key | sub("^seven_day_"; "")) as $n
+          | {name: $n, used: (.value.utilization | floor), reset: (.value.resets_at // ""), rank: (($rank | index($n)) // 99)} ]
+      | sort_by(.rank, .name)
+      | .[] | "\(.name)\t\(.used)\t\(.reset)"
+    ' "$CACHE_FILE" 2>/dev/null)
+
+    [ -z "$five_hour_used" ] && five_hour_used="$api_5h_used" && five_hour_reset="$api_5h_reset"
+    [ -z "$seven_day_used" ] && seven_day_used="$api_7d_used" && seven_day_reset="$api_7d_reset"
+  fi
+fi
+
+ctx_c=$(ctx_color "$used")
+
+# ══════════════════════════════════════════════════════════════════════════════
+# OUTPUT
+# ══════════════════════════════════════════════════════════════════════════════
+echo ""
+
+# Model badges: fast mode / effort level / extended thinking
+model_badges=""
+[ "$fast_mode" = "true" ] && model_badges="${model_badges} \033[36m⚡fast\033[0m"
+[ -n "$effort" ] && model_badges="${model_badges} \033[2m${effort}\033[0m"
+[ "$thinking" = "true" ] && model_badges="${model_badges} \033[2m✦\033[0m"
+
+# Context mini-bar (low usage = good = green) + used/total tokens — wide only
+ctx_bar_str=""
+if [ "$SHOW_CONTEXT_BAR" = "true" ] && [ "$WIDE" -eq 1 ]; then
+  ctx_bar_str=" $(ctx_bar "$used")"
+fi
+ctx_detail=""
+if [ -n "$ctx_tokens" ] && [ "$ctx_size" -gt 0 ] 2>/dev/null && [ "$WIDE" -eq 1 ]; then
+  ctx_detail=" \033[2m$(fmt_tokens "$ctx_tokens")/$(fmt_tokens "$ctx_size")\033[0m"
+fi
+
+# PR badge with review state (clickable when a URL is present)
+pr_str=""
+if [ -n "$pr_number" ]; then
+  case "$pr_state" in
+    approved)          pr_mark=" \033[32m✓\033[0m" ;;
+    changes_requested) pr_mark=" \033[31m✗\033[0m" ;;
+    draft)             pr_mark=" \033[2m◌\033[0m" ;;
+    *)                 pr_mark=" \033[33m●\033[0m" ;;
+  esac
+  pr_label=$(osc_link "$pr_url" "PR #${pr_number}")
+  pr_str=" \033[2m│\033[0m \033[36m${pr_label}\033[0m${pr_mark}"
+fi
+
+# Lines added/removed this session
+lines_str=""
+if [ "$lines_added" -gt 0 ] 2>/dev/null || [ "$lines_removed" -gt 0 ] 2>/dev/null; then
+  lines_str=" \033[32m+${lines_added}\033[0m \033[31m-${lines_removed}\033[0m"
+fi
+
+# Burn rate is a wide-only extra; session name drops on the narrowest tier
+[ "$WIDE" -ne 1 ] && burn_str=""
+[ "$COMPACT" -eq 1 ] && session_str=""
+
+if [ "$COMPACT" -eq 1 ]; then
+  # Minimal header for narrow terminals: model | ctx% | project (branch) | cost
+  printf "  \033[1;37m%s\033[0m \033[2m│\033[0m %bctx %s%%\033[0m \033[2m│\033[0m \033[33m%s\033[0m%b \033[2m│\033[0m \033[2m%s\033[0m\n" \
+    "$model" "$ctx_c" "$used" "$project" "$location_str" "$cost_str"
+else
+  # Full / medium: extras (bar, tokens, burn) are pre-blanked unless WIDE
+  printf "  \033[1;37m%s\033[0m%b \033[2m│\033[0m %bctx %s%%\033[0m%b%b \033[2m│\033[0m \033[33m%s\033[0m%b%b \033[2m│\033[0m \033[2m%s · %s\033[0m%b%b%b\n" \
+    "$model" "$model_badges" "$ctx_c" "$used" "$ctx_bar_str" "$ctx_detail" "$project" "$location_str" "$pr_str" "$cost_str" "$duration_str" "$burn_str" "$lines_str" "$session_str"
+fi
+
+# Compaction warning
+if [ "$used" -ge "$CONTEXT_CRIT_PCT" ]; then
+  printf "  \033[1;31m⚠ Context %s%% — compaction imminent\033[0m\n" "$used"
+fi
+
+# Rate limit lines
+if [ "$SHOW_RATE_LIMITS" = "true" ]; then
+  if [ -z "$five_hour_used" ] && [ -z "$seven_day_used" ] && ! command -v curl >/dev/null 2>&1; then
+    printf "  \033[2m✗ rate limits unavailable — curl not found\033[0m\n"
+  fi
+  print_limit_line "Session" "$five_hour_used" "$five_hour_reset"
+  print_limit_line "Weekly"  "$seven_day_used" "$seven_day_reset"
+  if [ -n "$api_buckets" ]; then
+    while IFS=$'\t' read -r bkt_name bkt_used bkt_reset; do
+      [ -z "$bkt_name" ] && continue
+      print_limit_line "$(pretty_bucket "$bkt_name")" "$bkt_used" "$bkt_reset"
+    done <<< "$api_buckets"
+  fi
+  if [ "$extra_enabled" = "true" ] && [ -n "$extra_used_pct" ]; then
+    print_limit_line "Extra" "$extra_used_pct" ""
+  fi
+fi
+
+# Tool / Agent Activity (from transcript)
+if [ "$SHOW_TOOLS" = "true" ] || [ "$SHOW_AGENTS" = "true" ]; then
+  if [ -n "$transcript_path" ] && [ -s "$transcript_path" ]; then
+    transcript_data=$(tail -500 "$transcript_path" | jq -c -s '
+      [.[] |
+        if .type == "assistant" and (.message.content | type) == "array" then
+          (.message.content)[] | select(.type == "tool_use") |
+          {action: "use", id: .id, name: .name, target: (
+            if .name == "Read" or .name == "Write" or .name == "Edit" then (.input.file_path // .input.path // "" | split("/") | .[-1:] | join(""))
+            elif .name == "Glob" or .name == "Grep" then (.input.pattern // "")
+            elif .name == "Bash" then (.input.command // "" | .[0:30])
+            elif .name == "Agent" then (.input.description // .input.subagent_type // "")
+            else ""
+            end
+          ), subagent_type: (.input.subagent_type // ""), agent_desc: (.input.description // "")}
+        elif .type == "user" and (.message.content | type) == "array" then
+          (.message.content)[] | select(.type == "tool_result") |
+          {action: "result", id: .tool_use_id, is_error: (.is_error // false)}
+        else empty
+        end
+      ] |
+      (reduce .[] as $item (
+        {tools: {}, agents: {}, completed: {}};
+        if $item.action == "use" then
+          if $item.name == "Agent" then
+            .agents[$item.id] = {type: $item.subagent_type, desc: $item.agent_desc, status: "running"}
+          elif $item.name != "TodoWrite" and $item.name != "TaskCreate" and $item.name != "TaskUpdate" then
+            .tools[$item.id] = {name: $item.name, target: $item.target, status: "running"}
+          else .
+          end
+        elif $item.action == "result" then
+          if .agents[$item.id] then
+            .agents[$item.id].status = "done"
+          elif .tools[$item.id] then
+            .tools[$item.id] as $t |
+            .tools[$item.id].status = "done" |
+            .completed[$t.name] = ((.completed[$t.name] // 0) + 1)
+          else .
+          end
+        else .
+        end
+      )) |
+      {
+        running_tools: [.tools | to_entries[] | select(.value.status == "running") | {name: .value.name, target: .value.target}] | .[-3:],
+        completed: .completed,
+        running_agents: [.agents | to_entries[] | select(.value.status == "running") | {type: .value.type, desc: .value.desc}] | .[-3:],
+        done_agents: [.agents | to_entries[] | select(.value.status != "running")] | length
+      }
+    ' 2>/dev/null)
+
+    if [ -n "$transcript_data" ] && [ "$transcript_data" != "null" ]; then
+      IFS=$'\x1e' read -r running_tools completed_tools running_agents done_agent_count <<< "$(
+        jq -r '[
+          (.running_tools | if length > 0 then [.[] | "◐ \(.name)" + (if .target != "" then ":\(.target)" else "" end)] | join("  ") else "" end),
+          (.completed | to_entries | sort_by(-.value) | if length > 0 then [.[:5][] | "✓ \(.key)×\(.value)"] | join("  ") else "" end),
+          (.running_agents | if length > 0 then [.[] | "◐ \(.type)" + (if .desc != "" then " \(.desc)" else "" end)] | join("  ") else "" end),
+          (.done_agents | tostring)
+        ] | join("\u001e")' <<< "$transcript_data"
+      )"
+
+      # Tools line
+      if [ "$SHOW_TOOLS" = "true" ]; then
+        if [ -n "$running_tools" ] || [ -n "$completed_tools" ]; then
+          tool_line="  "
+          if [ -n "$running_tools" ]; then
+            tool_line="${tool_line}\033[33m${running_tools}\033[0m"
+            [ -n "$completed_tools" ] && tool_line="${tool_line}  \033[2m${completed_tools}\033[0m"
+          else
+            tool_line="${tool_line}\033[2m${completed_tools}\033[0m"
+          fi
+          printf '%b\n' "$tool_line"
+        fi
+      fi
+
+      # Agents line
+      if [ "$SHOW_AGENTS" = "true" ]; then
+        if [ -n "$running_agents" ]; then
+          agent_line="  \033[35m${running_agents}\033[0m"
+          [ "$done_agent_count" -gt 0 ] 2>/dev/null && agent_line="${agent_line}  \033[2m(${done_agent_count} done)\033[0m"
+          printf '%b\n' "$agent_line"
+        elif [ "$done_agent_count" -gt 0 ] 2>/dev/null; then
+          printf '  \033[2m✓ %s agents done\033[0m\n' "$done_agent_count"
+        fi
+      fi
+    fi
+  fi
+fi
+
+echo ""

--- a/scripts/seed-data/sources/13-nerd-font-duo.sh
+++ b/scripts/seed-data/sources/13-nerd-font-duo.sh
@@ -1,0 +1,247 @@
+#!/bin/bash
+
+# Claude Code Status Line — Two-line layout with Nerd Font icons (MD range)
+# Line 1: Model │ Context Bar (16 segs) │ Cost │ 5h usage │ 7d usage
+# Line 2: Directory │ Git Branch & Status │ Venv │ Vim
+
+input=$(< /dev/stdin)
+now=$(date +%s)
+
+# --- Extract all values in a single jq call ---
+eval "$(jq -r '
+    @sh "model=\(.model.display_name // "?")",
+    @sh "cwd=\(.workspace.current_dir // ".")",
+    @sh "used_pct=\(.context_window.used_percentage // 0)",
+    @sh "cost=\(.cost.total_cost_usd // 0)",
+    @sh "vim_mode=\(.vim.mode // "")"
+' <<< "$input")"
+
+dir_name="${cwd##*/}"
+
+# --- Theme detection ---
+# Override with STATUSLINE_THEME=dark|light|auto (default: auto)
+detect_theme() {
+    local theme="${STATUSLINE_THEME:-auto}"
+    if [ "$theme" != "auto" ]; then echo "$theme"; return; fi
+
+    # macOS system appearance
+    if defaults read -g AppleInterfaceStyle &>/dev/null; then
+        echo "dark"; return
+    fi
+
+    # COLORFGBG env var (e.g. "15;0" → bg=0 is dark)
+    if [ -n "$COLORFGBG" ]; then
+        local bg="${COLORFGBG##*;}"
+        if [ "$bg" -lt 8 ] 2>/dev/null; then
+            echo "dark"
+        else
+            echo "light"
+        fi
+        return
+    fi
+
+    echo "dark"
+}
+
+THEME=$(detect_theme)
+
+# --- Colors ---
+RST=$'\033[0m'
+BOLD=$'\033[1m'
+
+if [ "$THEME" = "light" ]; then
+    DIM=$'\033[90m'              # bright black (gray) — visible on light bg
+    CYAN=$'\033[36m'
+    GREEN=$'\033[32m'
+    YELLOW=$'\033[33m'
+    RED=$'\033[31m'
+    MAGENTA=$'\033[35m'
+    BLUE=$'\033[34m'
+    BG_RED=$'\033[41m'
+    WHITE_BOLD=$'\033[1;30m'     # bold black — for alert badge text on light bg
+else
+    DIM=$'\033[2m'
+    CYAN=$'\033[36m'
+    GREEN=$'\033[32m'
+    YELLOW=$'\033[33m'
+    RED=$'\033[31m'
+    MAGENTA=$'\033[35m'
+    BLUE=$'\033[34m'
+    BG_RED=$'\033[41m'
+    WHITE_BOLD=$'\033[1;37m'
+fi
+
+# --- Nerd Font Icons (all MD range, U+F0000+) ---
+ICON_MODEL="󰚩"     # nf-md-robot
+ICON_CTX="󰍛"       # nf-md-memory
+ICON_DIR="󰝰"       # nf-md-folder_outline
+ICON_GIT="󰘬"       # nf-md-source_branch
+ICON_COST="󰄉"      # nf-md-cash
+ICON_WARN=""       # nf-fa-warning
+ICON_VIM="󰕷"       # nf-md-vim
+ICON_VENV="󰌠"      # nf-md-language_python
+
+SEP="${DIM} │ ${RST}"
+BAR_SEGMENTS=16
+
+# --- Color helper for utilization percentage ---
+# Thresholds: green < 50, yellow 50-79, red >= 80
+pct_color() {
+    local pct=$1
+    if [ "$pct" -lt 50 ]; then echo "$GREEN"
+    elif [ "$pct" -lt 80 ]; then echo "$YELLOW"
+    else echo "$RED"
+    fi
+}
+
+# --- Context percentage ---
+pct_int=${used_pct%.*}
+pct_int=${pct_int:-0}
+CTX_COLOR=$(pct_color "$pct_int")
+
+# --- Progress bar ---
+filled=$(( (pct_int * BAR_SEGMENTS + 50) / 100 ))
+[ "$filled" -gt "$BAR_SEGMENTS" ] && filled=$BAR_SEGMENTS
+empty=$((BAR_SEGMENTS - filled))
+bar=""
+for ((i = 0; i < filled; i++)); do bar="${bar}▰"; done
+for ((i = 0; i < empty; i++)); do bar="${bar}▱"; done
+
+# --- Cost ---
+printf -v cost_str '$%.2f' "$cost"
+
+# --- Git info (single git status --porcelain call) ---
+git_info=""
+if git -C "$cwd" rev-parse --git-dir > /dev/null 2>&1; then
+    branch=$(git -C "$cwd" branch --show-current 2>/dev/null)
+    [ -z "$branch" ] && branch="detached"
+
+    staged=0 unstaged=0 untracked=0
+    while IFS= read -r line; do
+        x=${line:0:1}
+        y=${line:1:1}
+        if [ "$x$y" = "??" ]; then
+            ((untracked++))
+        else
+            [ "$x" != " " ] && [ "$x" != "?" ] && ((staged++))
+            [ "$y" != " " ] && ((unstaged++))
+        fi
+    done < <(git -C "$cwd" status --porcelain 2>/dev/null)
+
+    status=""
+    [ "$staged" -gt 0 ] && status="${status} ${GREEN}+${staged}${RST}"
+    [ "$unstaged" -gt 0 ] && status="${status} ${YELLOW}~${unstaged}${RST}"
+    [ "$untracked" -gt 0 ] && status="${status} ${DIM}?${untracked}${RST}"
+
+    git_info="${SEP}${MAGENTA}${ICON_GIT} ${branch}${RST}${status}"
+fi
+
+# --- Python venv detection ---
+venv_str=""
+venv_name="" py_ver=""
+if [ -n "$VIRTUAL_ENV" ]; then
+    venv_name="${VIRTUAL_ENV##*/}"
+else
+    for venv_dir in "$cwd/.venv" "$cwd/venv" "$cwd/.env"; do
+        if [ -f "${venv_dir}/bin/python" ]; then
+            venv_name="${venv_dir##*/}"
+            py_ver=$("${venv_dir}/bin/python" --version 2>/dev/null | awk '{print $2}' | cut -d. -f1-2)
+            break
+        fi
+    done
+fi
+if [ -n "$venv_name" ]; then
+    venv_str="${SEP}${YELLOW}${ICON_VENV} ${venv_name}${py_ver:+ ($py_ver)}${RST}"
+fi
+
+# --- Vim mode ---
+vim_str=""
+if [ -n "$vim_mode" ]; then
+    [[ "$vim_mode" == "NORMAL" ]] && vim_color=$BLUE || vim_color=$GREEN
+    vim_str="${SEP}${vim_color}${BOLD}${ICON_VIM} ${vim_mode}${RST}"
+fi
+
+# --- Anthropic OAuth usage API (cached, background refresh) ---
+CACHE_DIR="$HOME/.claude/statusline-cache"
+USAGE_CACHE="$CACHE_DIR/usage.dat"
+LOCK_FILE="$CACHE_DIR/usage-update.lock"
+CACHE_TTL=60
+
+refresh_usage_cache() {
+    if ! mkdir "$LOCK_FILE" 2>/dev/null; then
+        lock_age=$(( now - $(stat -f%m "$LOCK_FILE" 2>/dev/null || echo 0) ))
+        [ "$lock_age" -gt 60 ] && rm -r "$LOCK_FILE" 2>/dev/null || return
+        mkdir "$LOCK_FILE" 2>/dev/null || return
+    fi
+    (
+        # Try macOS Keychain first, then fall back to credentials file
+        token=$(security find-generic-password -s "Claude Code-credentials" -a "$(whoami)" -w 2>/dev/null | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
+        [ -z "$token" ] && token=$(jq -r '.claudeAiOauth.accessToken // empty' "$HOME/.claude/.credentials.json" 2>/dev/null)
+        if [ -n "$token" ]; then
+            resp=$(curl -s --max-time 5 \
+                -H "Authorization: Bearer $token" \
+                -H "anthropic-beta: oauth-2025-04-20" \
+                https://api.anthropic.com/api/oauth/usage 2>/dev/null)
+            if echo "$resp" | jq -e '.five_hour' > /dev/null 2>&1; then
+                echo "$resp" | jq -r '
+                    def to_epoch: split(".")[0] + "Z" | fromdateiso8601;
+                    "\(.five_hour.utilization | floor) \(.five_hour.resets_at | to_epoch) \(.seven_day.utilization | floor) \(.seven_day.resets_at | to_epoch)"
+                ' > "$USAGE_CACHE.tmp" 2>/dev/null && mv "$USAGE_CACHE.tmp" "$USAGE_CACHE"
+            fi
+        fi
+        rm -r "$LOCK_FILE" 2>/dev/null
+    ) &
+    disown 2>/dev/null
+}
+
+format_countdown() {
+    local diff=$(( $1 - now ))
+    [ "$diff" -le 0 ] && echo "soon" && return
+    if [ "$diff" -ge 86400 ]; then
+        echo "$((diff / 86400))d$((diff % 86400 / 3600))h"
+    elif [ "$diff" -ge 3600 ]; then
+        echo "$((diff / 3600))h$((diff % 3600 / 60))m"
+    else
+        echo "$((diff / 60))m"
+    fi
+}
+
+usage_segment() {
+    local label=$1 pct=$2 reset_epoch=$3
+    local color reset_str
+    color=$(pct_color "$pct")
+    reset_str=$(format_countdown "$reset_epoch")
+    echo "${SEP}${DIM}${label}${RST} ${color}${pct}%${RST} ${DIM}↺ ${reset_str}${RST}"
+}
+
+if [ ! -f "$USAGE_CACHE" ]; then
+    [ -d "$CACHE_DIR" ] || mkdir -p "$CACHE_DIR" 2>/dev/null
+    refresh_usage_cache
+else
+    cache_age=$(( now - $(stat -f%m "$USAGE_CACHE" 2>/dev/null || echo 0) ))
+    [ "$cache_age" -gt "$CACHE_TTL" ] && refresh_usage_cache
+fi
+
+usage_5h="" usage_7d=""
+if [ -f "$USAGE_CACHE" ]; then
+    read -r pct5h epoch5h pct7d epoch7d < "$USAGE_CACHE" 2>/dev/null
+    if [ -n "$pct5h" ] && [ "$pct5h" != "-1" ]; then
+        usage_5h=$(usage_segment "5h" "$pct5h" "$epoch5h")
+    fi
+    if [ -n "$pct7d" ] && [ "$pct7d" != "-1" ]; then
+        usage_7d=$(usage_segment "7d" "$pct7d" "$epoch7d")
+    fi
+fi
+
+# --- Build output ---
+line1_tail="${SEP}${DIM}${ICON_COST} ${cost_str}${RST}${usage_5h}${usage_7d}"
+
+if [ "$pct_int" -ge 90 ]; then
+    line1="${BG_RED}${WHITE_BOLD} ${ICON_WARN} CTX ${pct_int}% ${RST} ${CYAN}${BOLD}${ICON_MODEL} ${model}${RST}${SEP}${CTX_COLOR}${bar}${RST}${line1_tail}"
+else
+    line1="${CYAN}${BOLD}${ICON_MODEL} ${model}${RST}${SEP}${DIM}${ICON_CTX}${RST} ${CTX_COLOR}${bar} ${pct_int}%${RST}${line1_tail}"
+fi
+
+line2="${BLUE}${ICON_DIR} ${dir_name}${RST}${git_info}${venv_str}${vim_str}"
+
+printf '%s\n%s' "$line1" "$line2"

--- a/scripts/seed-data/sources/14-traffic-light-context.sh
+++ b/scripts/seed-data/sources/14-traffic-light-context.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Claude Code status line script
+
+input=$(cat)
+
+# Model
+model=$(echo "$input" | jq -r '.model.display_name // "Unknown"')
+
+# Git branch (skip locks)
+branch=$(GIT_OPTIONAL_LOCKS=0 git -C "$(echo "$input" | jq -r '.workspace.current_dir // "."')" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "no-git")
+
+# Token data
+used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+window_size=$(echo "$input" | jq -r '.context_window.context_window_size // 0')
+# Derive the absolute token count from used_percentage * window_size so that
+# the bar, percentage, and token count are always consistent with each other.
+# (current_usage.input_tokens is only the last-turn input, not total context fill.)
+current_input=""
+if [ -n "$used_pct" ] && [ "$window_size" -gt 0 ] 2>/dev/null; then
+  current_input=$(echo "$used_pct $window_size" | awk '{printf "%d", ($1/100)*$2}')
+fi
+
+# Rate limit data
+five_hour_pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
+five_hour_resets=$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')
+seven_day_pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
+seven_day_resets=$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')
+
+# ANSI colors (dimmed-friendly)
+RESET='\033[0m'
+BOLD='\033[1m'
+DIM='\033[2m'
+CYAN='\033[36m'
+YELLOW='\033[33m'
+GREEN='\033[32m'
+RED='\033[31m'
+ORANGE='\033[38;5;214m'
+MAGENTA='\033[35m'
+BLUE='\033[34m'
+WHITE='\033[37m'
+
+# Build progress bar (10 chars wide)
+build_bar() {
+  local pct="${1:-0}"
+  local width=10
+  local filled=$(echo "$pct $width" | awk '{printf "%d", ($1/100)*$2}')
+  local empty=$((width - filled))
+
+  # 0-40%: green (smart zone — full quality)
+  # 40-60%: orange (time to /compact)
+  # 60%+: red (quality degrading, auto-compact approaching)
+  local bar_color="$GREEN"
+  if [ "$(echo "$pct" | awk '{print ($1 >= 60)}')" = "1" ]; then
+    bar_color="$RED"
+  elif [ "$(echo "$pct" | awk '{print ($1 >= 40)}')" = "1" ]; then
+    bar_color="$ORANGE"
+  fi
+
+  local bar=""
+  local i=0
+  while [ $i -lt $filled ]; do
+    bar="${bar}█"
+    i=$((i+1))
+  done
+  i=0
+  while [ $i -lt $empty ]; do
+    bar="${bar}░"
+    i=$((i+1))
+  done
+
+  printf "${bar_color}${bar}${RESET}"
+}
+
+# Color for context window percentage (matches build_bar thresholds)
+ctx_color() {
+  local pct="${1:-0}"
+  if [ "$(echo "$pct" | awk '{print ($1 >= 60)}')" = "1" ]; then
+    echo "$RED"
+  elif [ "$(echo "$pct" | awk '{print ($1 >= 40)}')" = "1" ]; then
+    echo "$ORANGE"
+  else
+    echo "$GREEN"
+  fi
+}
+
+# Color for rate-limit percentages: green <50%, orange <80%, red >=80%
+rate_color() {
+  local pct="${1:-0}"
+  if [ "$(echo "$pct" | awk '{print ($1 >= 80)}')" = "1" ]; then
+    echo "$RED"
+  elif [ "$(echo "$pct" | awk '{print ($1 >= 50)}')" = "1" ]; then
+    echo "$ORANGE"
+  else
+    echo "$GREEN"
+  fi
+}
+
+# Format seconds-until-reset as HH:MM
+fmt_countdown() {
+  local resets_at="$1"
+  local now
+  now=$(date +%s)
+  local diff=$((resets_at - now))
+  if [ "$diff" -le 0 ]; then
+    echo "00:00"
+    return
+  fi
+  local hh=$((diff / 3600))
+  local mm=$(( (diff % 3600) / 60 ))
+  printf "%02d:%02d" "$hh" "$mm"
+}
+
+# Format large numbers with k/M suffix
+fmt_num() {
+  local n="$1"
+  echo "$n" | awk '{
+    if ($1 >= 1000000) printf "%gM", $1/1000000
+    else if ($1 >= 1000) printf "%gk", $1/1000
+    else printf "%d", $1
+  }'
+}
+
+# Format the current context window token count and total window size
+window_fmt=$(fmt_num "$window_size")
+
+# Build output
+printf "${CYAN}${BOLD}%s${RESET}" "$model"
+printf " ${DIM}|${RESET} "
+printf "${MAGENTA}%s${RESET}" "$branch"
+printf " ${DIM}|${RESET} "
+
+if [ -n "$used_pct" ]; then
+  bar=$(build_bar "$used_pct")
+  pct_fmt=$(printf "%.1f" "$used_pct")
+  current_fmt=$(fmt_num "$current_input")
+  pct_color=$(ctx_color "$used_pct")
+  printf "%s ${pct_color}%s%%${RESET}" "$bar" "$pct_fmt"
+  printf " ${DIM}|${RESET} "
+  printf "${BLUE}%s / %s${RESET}" "$current_fmt" "$window_fmt"
+else
+  printf "${DIM}no messages yet${RESET}"
+fi
+
+# 5-hour window: HH:MM countdown + percentage consumed
+if [ -n "$five_hour_pct" ] && [ -n "$five_hour_resets" ]; then
+  countdown=$(fmt_countdown "$five_hour_resets")
+  color=$(rate_color "$five_hour_pct")
+  pct_fmt=$(printf "%.0f" "$five_hour_pct")
+  printf " ${DIM}|${RESET} "
+  printf "${DIM}%s${RESET} ${color}%s%%${RESET}" "$countdown" "$pct_fmt"
+fi
+
+# 7-day window: day abbreviation + percentage consumed
+if [ -n "$seven_day_pct" ] && [ -n "$seven_day_resets" ]; then
+  day_abbr=$(date -d "@${seven_day_resets}" +%a 2>/dev/null || date -r "$seven_day_resets" +%a 2>/dev/null)
+  color=$(rate_color "$seven_day_pct")
+  pct_fmt=$(printf "%.0f" "$seven_day_pct")
+  printf " ${DIM}|${RESET} "
+  printf "${DIM}%s${RESET} ${color}%s%%${RESET}" "$day_abbr" "$pct_fmt"
+fi
+
+printf "\n"

--- a/scripts/seed-data/sources/15-cost-thresholds.sh
+++ b/scripts/seed-data/sources/15-cost-thresholds.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+export TERM=xterm-256color
+input=$(cat)
+cwd=$(echo "$input" | jq -r '.workspace.current_dir')
+model=$(echo "$input" | jq -r '.model.display_name // empty')
+
+# Token usage
+input_tokens=$(echo "$input" | jq -r '.context_window.total_input_tokens // 0')
+output_tokens=$(echo "$input" | jq -r '.context_window.total_output_tokens // 0')
+context_limit=$(echo "$input" | jq -r '.context_window.context_window_size // 0')
+total_tokens=$((input_tokens + output_tokens))
+
+# Cost & stats
+cost=$(echo "$input" | jq -r '.cost.total_cost_usd // empty')
+duration_ms=$(echo "$input" | jq -r '.cost.total_duration_ms // 0')
+lines_added=$(echo "$input" | jq -r '.cost.total_lines_added // 0')
+lines_removed=$(echo "$input" | jq -r '.cost.total_lines_removed // 0')
+
+# Colors - basic ANSI codes compatible with most terminals
+RED=$'\033[31m'
+GREEN=$'\033[32m'
+YELLOW=$'\033[33m'
+BLUE=$'\033[34m'
+MAGENTA=$'\033[35m'
+CYAN=$'\033[36m'
+GRAY=$'\033[90m'
+RESET=$'\033[0m'
+
+SEP="${GRAY}${RESET}"
+short_dir=$(basename "$cwd")
+
+# Node version (only if package.json exists)
+node_info=""
+if [ -f "$cwd/package.json" ] 2>/dev/null; then
+  node_ver=$(node -v 2>/dev/null | sed 's/v//')
+  [ -n "$node_ver" ] && node_info=" ${SEP} ${GREEN}⬢ ${node_ver}${RESET}"
+fi
+
+# Session duration
+duration_info=""
+if [ "$duration_ms" -gt 0 ] 2>/dev/null; then
+  duration_sec=$((duration_ms / 1000))
+  if [ "$duration_sec" -ge 3600 ]; then
+    hours=$((duration_sec / 3600))
+    mins=$(((duration_sec % 3600) / 60))
+    duration_fmt="${hours}h${mins}m"
+  elif [ "$duration_sec" -ge 60 ]; then
+    mins=$((duration_sec / 60))
+    duration_fmt="${mins}m"
+  else
+    duration_fmt="${duration_sec}s"
+  fi
+  duration_info=" ${SEP} ${CYAN}⏱ ${duration_fmt}${RESET}"
+fi
+
+# Lines changed
+lines_info=""
+if [ "$lines_added" -gt 0 ] || [ "$lines_removed" -gt 0 ] 2>/dev/null; then
+  net=$((lines_added - lines_removed))
+  if [ "$net" -gt 0 ]; then
+    net_symbol="${GREEN}▲${RESET}"
+  elif [ "$net" -lt 0 ]; then
+    net_symbol="${RED}▼${RESET}"
+  else
+    net_symbol="${GRAY}=${RESET}"
+  fi
+  lines_info=" ${SEP} ${net_symbol} ${GREEN}+${lines_added}${RESET} ${RED}-${lines_removed}${RESET}"
+fi
+
+# Token usage with progress bar
+token_info=""
+if [ "$total_tokens" -gt 0 ] 2>/dev/null; then
+  if [ "$total_tokens" -ge 1000 ]; then
+    tokens_fmt="$((total_tokens / 1000))k"
+  else
+    tokens_fmt="$total_tokens"
+  fi
+
+  if [ "$context_limit" -gt 0 ] 2>/dev/null; then
+    pct=$((total_tokens * 100 / context_limit))
+
+    # Color based on usage
+    if [ "$pct" -ge 75 ]; then
+      bar_color="$RED"
+    elif [ "$pct" -ge 50 ]; then
+      bar_color="$YELLOW"
+    else
+      bar_color="$GREEN"
+    fi
+
+    # Build progress bar using simple chars: ▓ filled, ░ empty
+    bar_width=8
+    filled=$((pct * bar_width / 100))
+    [ "$filled" -gt "$bar_width" ] && filled=$bar_width
+    [ "$filled" -lt 1 ] && [ "$pct" -gt 0 ] && filled=1
+    empty=$((bar_width - filled))
+
+    bar="${bar_color}"
+    for ((i=0; i<filled; i++)); do bar+="▓"; done
+    bar+="${GRAY}"
+    for ((i=0; i<empty; i++)); do bar+="░"; done
+    bar+="${RESET}"
+
+    token_info=" ${SEP} ${bar} ${GRAY}${pct}%${RESET}"
+  fi
+fi
+
+# Cost with meaningful colors
+cost_info=""
+if [ -n "$cost" ] && [ "$cost" != "null" ]; then
+  cost_fmt=$(printf "%.2f" "$cost")
+  cost_cents=$(printf "%.0f" "$(echo "$cost * 100" | bc)")
+
+  if [ "$cost_cents" -ge 1000 ] 2>/dev/null; then
+    cost_color="$RED"
+  elif [ "$cost_cents" -ge 200 ] 2>/dev/null; then
+    cost_color="$YELLOW"
+  else
+    cost_color="$GREEN"
+  fi
+  cost_info=" ${SEP} ${cost_color}\$${cost_fmt}${RESET}"
+fi
+
+# Model with tier colors
+model_info=""
+if [ -n "$model" ]; then
+  case "$model" in
+    *Opus*) model_color="$MAGENTA"; model_symbol="◆"; short_model="Opus" ;;
+    *Sonnet*) model_color="$BLUE"; model_symbol="◇"; short_model="Sonnet" ;;
+    *Haiku*) model_color="$GREEN"; model_symbol="○"; short_model="Haiku" ;;
+    *) model_color="$GRAY"; model_symbol="●"; short_model="$model" ;;
+  esac
+  model_info=" ${SEP} ${model_color}${model_symbol} ${short_model}${RESET}"
+fi
+
+printf "${BLUE}${short_dir}${RESET}%s%s%s%s%s%s" "$node_info" "$duration_info" "$lines_info" "$token_info" "$cost_info" "$model_info"

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -81,6 +81,10 @@ export const configVersions = pgTable(
     sourceHtml: text('source_html'),
     networkHosts: jsonb('network_hosts').$type<string[]>().notNull().default(sql`'[]'::jsonb`),
     readsClaudeToken: boolean('reads_claude_token').notNull().default(false),
+    /** SPDX license of third-party (seeded) source, e.g. 'MIT'. Null = submitter's own work (CC0 per terms). */
+    license: text('license'),
+    /** Permanent link to the upstream source at the pinned revision (seeded configs only). */
+    sourceUrl: text('source_url'),
     // Auto-generated page copy (what it shows / requirements / behavior notes), written by
     // scripts/generate-content.ts via claude -p. Nullable: versions without it simply render
     // no content sections. Describes THIS version's script — regenerate when the script changes.

--- a/src/gallery/license-line.tsx
+++ b/src/gallery/license-line.tsx
@@ -1,0 +1,27 @@
+import { Text, TextLink } from '@/ui/text'
+
+/**
+ * The license note shown under the Source card for seeded third-party configs: the SPDX
+ * license and, when known, a link back to the pinned upstream source. Renders nothing for
+ * submitter-authored configs (license is null — those are CC0 per the terms page).
+ */
+export function LicenseLine({
+  license,
+  sourceUrl,
+}: {
+  license: string | null
+  sourceUrl: string | null
+}) {
+  if (!license) return null
+  return (
+    <Text muted size="sm">
+      {license} licensed
+      {sourceUrl && (
+        <>
+          {' '}
+          · <TextLink href={sourceUrl}>original source</TextLink>
+        </>
+      )}
+    </Text>
+  )
+}

--- a/src/gallery/queries.ts
+++ b/src/gallery/queries.ts
@@ -186,6 +186,10 @@ export interface ConfigDetail {
   /** Auto-generated page copy, or null when scripts/generate-content.ts hasn't run for this version. */
   generatedContent: GeneratedContent | null
   previews: RenderedPreview[]
+  /** SPDX license of third-party (seeded) source, e.g. 'MIT'. Null = submitter's own work (CC0 per terms). */
+  license: string | null
+  /** Permanent link to the upstream source at the pinned revision (seeded configs only). */
+  sourceUrl: string | null
 }
 
 export async function getConfigBySlug(
@@ -226,6 +230,8 @@ export async function getConfigBySlug(
     readsClaudeToken: row.version.readsClaudeToken ?? false,
     generatedContent: row.version.generatedContent ?? null,
     previews,
+    license: row.version.license ?? null,
+    sourceUrl: row.version.sourceUrl ?? null,
   }
 }
 

--- a/src/legal/terms.tsx
+++ b/src/legal/terms.tsx
@@ -27,7 +27,9 @@ export function TermsContent() {
           Configs submitted to the gallery are released under{' '}
           <TextLink href={CONTENT_LICENSE.url}>{CONTENT_LICENSE.name}</TextLink> (public domain) —
           copy, change, and use them freely, no attribution required. By submitting, you confirm you
-          have the right to share the script and agree to release it this way.
+          have the right to share the script and agree to release it this way. A few gallery entries
+          are seeded from open-source projects; those keep their original license (shown on the
+          config page with a link to the source) instead of CC0.
         </Text>
       </Stack>
 

--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -47,6 +47,7 @@ export function configJsonLd(
     description: string
     interpreter: string
     authorName: string | null
+    license: string | null
   },
 ): object[] {
   const url = `${origin}/c/${config.slug}`
@@ -58,7 +59,7 @@ export function configJsonLd(
       description: config.description,
       url,
       programmingLanguage: config.interpreter,
-      license: CONTENT_LICENSE.url,
+      license: config.license ?? CONTENT_LICENSE.url,
       ...(config.authorName ? { author: { '@type': 'Person', name: config.authorName } } : {}),
     },
     {

--- a/src/routes/c.$slug.tsx
+++ b/src/routes/c.$slug.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 import { AdoptPrompt, CopyScriptButton } from '@/adopt/adopt-actions'
 import { getConfigDetail } from '@/gallery/functions'
 import { GeneratedContentSections } from '@/gallery/generated-content'
+import { LicenseLine } from '@/gallery/license-line'
 import { getSession } from '@/lib/auth-functions'
 import { canonicalLink } from '@/lib/canonical'
 import { configJsonLd, jsonLdScript } from '@/lib/json-ld'
@@ -62,6 +63,7 @@ export const Route = createFileRoute('/c/$slug')({
             description: detail.description,
             interpreter: detail.interpreter,
             authorName: detail.author?.name ?? null,
+            license: detail.license,
           }).map(jsonLdScript)
         : [],
     }
@@ -169,6 +171,7 @@ function ConfigDetail() {
         >
           <HighlightedCode html={detail.sourceHtml} />
         </SectionCard>
+        <LicenseLine license={detail.license} sourceUrl={detail.sourceUrl} />
 
         {/* Auto-generated copy — the SEO answer to "what does this status line do?" */}
         {detail.generatedContent && <GeneratedContentSections content={detail.generatedContent} />}

--- a/src/submit/submit.ts
+++ b/src/submit/submit.ts
@@ -64,6 +64,8 @@ export interface SubmitInput {
   interpreter: Interpreter
   source: string
   networkHosts?: string[]
+  license?: string | null
+  sourceUrl?: string | null
 }
 export interface SubmitResult {
   configId: string
@@ -153,6 +155,8 @@ export async function submitConfig(db: Db, input: SubmitInput): Promise<SubmitRe
         status: 'pending',
         networkHosts,
         readsClaudeToken: readsToken,
+        license: input.license ?? null,
+        sourceUrl: input.sourceUrl ?? null,
       })
       .returning()
     const ver = verRows[0]

--- a/test/gallery/detail.test.ts
+++ b/test/gallery/detail.test.ts
@@ -216,4 +216,23 @@ describe('getConfigBySlug', () => {
     const detail = await getConfigBySlug(db, 'detail-nonetwork')
     expect(detail?.networkHosts).toEqual([])
   })
+
+  it('returns the stored license and sourceUrl when the version has them', async () => {
+    const cfg = await seed('published', 'detail-licensed', 'aabb'.repeat(16))
+    await db
+      .update(schema.configVersions)
+      .set({ license: 'MIT', sourceUrl: 'https://example.com/x' })
+      .where(eq(schema.configVersions.configId, cfg.id))
+
+    const detail = await getConfigBySlug(db, 'detail-licensed')
+    expect(detail?.license).toBe('MIT')
+    expect(detail?.sourceUrl).toBe('https://example.com/x')
+  })
+
+  it('license and sourceUrl are null when the version has neither', async () => {
+    await seed('published', 'detail-unlicensed', 'ccdd'.repeat(16))
+    const detail = await getConfigBySlug(db, 'detail-unlicensed')
+    expect(detail?.license).toBeNull()
+    expect(detail?.sourceUrl).toBeNull()
+  })
 })

--- a/test/gallery/license-line.test.tsx
+++ b/test/gallery/license-line.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { LicenseLine } from '@/gallery/license-line'
+
+describe('LicenseLine', () => {
+  it('renders nothing when there is no license', () => {
+    const { container } = render(<LicenseLine license={null} sourceUrl={null} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders the license and a link to the source when both are present', () => {
+    render(<LicenseLine license="MIT" sourceUrl="https://example.com/x" />)
+    expect(screen.getByText(/MIT licensed/)).toBeTruthy()
+    const link = screen.getByRole('link', { name: /original source/i })
+    expect(link.getAttribute('href')).toBe('https://example.com/x')
+  })
+
+  it('renders the license without a source link when sourceUrl is absent', () => {
+    render(<LicenseLine license="MIT" sourceUrl={null} />)
+    expect(screen.getByText(/MIT licensed/)).toBeTruthy()
+    expect(screen.queryByRole('link', { name: /original source/i })).toBeNull()
+  })
+})

--- a/test/legal/terms.test.tsx
+++ b/test/legal/terms.test.tsx
@@ -22,4 +22,9 @@ describe('TermsContent', () => {
     render(<TermsContent />)
     expect(screen.getByText(/remove/i)).toBeTruthy()
   })
+
+  it('notes seeded configs keep their original license instead of CC0', () => {
+    render(<TermsContent />)
+    expect(screen.getByText(/original license/i)).toBeTruthy()
+  })
 })

--- a/test/lib/json-ld.test.ts
+++ b/test/lib/json-ld.test.ts
@@ -40,6 +40,7 @@ describe('configJsonLd', () => {
       description: 'A Powerline-style status line.',
       interpreter: 'bash',
       authorName: 'LindseyB',
+      license: null,
     }) as Array<Record<string, unknown>>
     expect(code).toMatchObject({
       '@type': 'SoftwareSourceCode',
@@ -59,8 +60,33 @@ describe('configJsonLd', () => {
       description: 'd',
       interpreter: 'bash',
       authorName: null,
+      license: null,
     }) as Array<Record<string, unknown>>
     expect(code).not.toHaveProperty('author')
+  })
+
+  it('emits the per-config license when present', () => {
+    const [code] = configJsonLd('https://statuslin.es', {
+      slug: 's',
+      title: 'T',
+      description: 'd',
+      interpreter: 'bash',
+      authorName: null,
+      license: 'MIT',
+    }) as Array<Record<string, unknown>>
+    expect(code!.license).toBe('MIT')
+  })
+
+  it('falls back to the CC0 url when license is null', () => {
+    const [code] = configJsonLd('https://statuslin.es', {
+      slug: 's',
+      title: 'T',
+      description: 'd',
+      interpreter: 'bash',
+      authorName: null,
+      license: null,
+    }) as Array<Record<string, unknown>>
+    expect(code!.license).toContain('creativecommons.org')
   })
 })
 

--- a/test/scripts/community-configs.test.ts
+++ b/test/scripts/community-configs.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { validateSubmitInput } from '@/submit/submit'
+import { COMMUNITY_CONFIGS } from '../../scripts/seed-data/community-configs'
+
+describe('community seed data', () => {
+  it('has 15 entries, each passing submit validation', () => {
+    expect(COMMUNITY_CONFIGS.length).toBe(15)
+    for (const e of COMMUNITY_CONFIGS) {
+      expect(() =>
+        validateSubmitInput({
+          title: e.title,
+          description: e.description,
+          interpreter: e.interpreter,
+          source: e.source,
+          // exactOptionalPropertyTypes forbids passing an explicit `undefined` into an optional
+          // prop; `?? []` matches the conditional-spread pattern in scripts/seed-community.ts.
+          networkHosts: e.networkHosts ?? [],
+        }),
+      ).not.toThrow()
+    }
+  })
+  it('every entry carries MIT license + a pinned source url + numeric github id', () => {
+    for (const e of COMMUNITY_CONFIGS) {
+      expect(e.license).toBe('MIT')
+      expect(e.sourceUrl).toMatch(
+        /^https:\/\/(github\.com\/.+\/blob\/[0-9a-f]{40}\/|gist\.github\.com\/)/,
+      )
+      expect(e.githubId).toMatch(/^\d+$/)
+    }
+  })
+  it('descriptions keep the two-word convention and stay concise', () => {
+    for (const e of COMMUNITY_CONFIGS) {
+      expect(e.description.toLowerCase()).not.toMatch(/(?<![a-z/.-])statusline(?![a-z.-])/)
+      expect(e.description.length).toBeLessThan(400)
+    }
+  })
+})

--- a/test/scripts/community-configs.test.ts
+++ b/test/scripts/community-configs.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest'
+import { detectForeignCredentialAccess, readsClaudeToken } from '@/submit/credential-access'
+import { detectObfuscation } from '@/submit/obfuscation'
 import { validateSubmitInput } from '@/submit/submit'
 import { COMMUNITY_CONFIGS } from '../../scripts/seed-data/community-configs'
 
@@ -18,6 +20,16 @@ describe('community seed data', () => {
         }),
       ).not.toThrow()
     }
+  })
+  it('every entry passes the real seed-time rejection gates (obfuscation, foreign credentials)', () => {
+    for (const e of COMMUNITY_CONFIGS) {
+      expect(detectObfuscation(e.source)).toEqual([])
+      expect(detectForeignCredentialAccess(e.source)).toEqual([])
+    }
+  })
+  it('locks in the Claude-token disclosure badge count across the wave', () => {
+    const count = COMMUNITY_CONFIGS.filter((e) => readsClaudeToken(e.source)).length
+    expect(count).toBe(9)
   })
   it('every entry carries MIT license + a pinned source url + numeric github id', () => {
     for (const e of COMMUNITY_CONFIGS) {

--- a/test/scripts/seed-community.test.ts
+++ b/test/scripts/seed-community.test.ts
@@ -498,4 +498,131 @@ describe('publishRenderedSeeds', () => {
       .where(eq(configsTable.id, notDoneOutcome.configId as string))
     expect(notDoneCfg?.status).toBe('draft')
   })
+
+  it("only approves seed-authored versions, never a real (non-seed) submitter's pending version", async () => {
+    const profile = {
+      id: '8101',
+      login: 'realauthor',
+      name: 'Real Author',
+      avatarUrl: 'https://x/real.png',
+    }
+    await ensureSeededAuthor(db, profile)
+    const seedEntry: CommunityConfig = {
+      githubLogin: 'realauthor',
+      githubId: '8101',
+      title: 'Seed Authored Config',
+      description: 'd',
+      interpreter: 'bash',
+      source: '#!/usr/bin/env bash\necho ok',
+      license: 'MIT',
+      sourceUrl: 'https://example.com/seed-authored',
+    }
+    const seedOutcome = await seedCommunityConfig(db, profile, seedEntry)
+    const [seedVer] = await db
+      .select()
+      .from(configVersionsTable)
+      .where(eq(configVersionsTable.configId, seedOutcome.configId as string))
+    await db
+      .update(renderJobsTable)
+      .set({ status: 'done', finishedAt: new Date() })
+      .where(eq(renderJobsTable.configVersionId, seedVer?.id as string))
+
+    // A real (non-seed) web submitter with a pending version + a done render job. This must NOT
+    // be auto-approved by the batch tool — it still needs the per-item human review-queue gate;
+    // only seed-authored (email seed+*) drafts are in scope for this batch action.
+    const now = new Date()
+    await db.insert(userTable).values({
+      id: 'real-publish-user',
+      name: 'Real Publish User',
+      email: 'realuser-publish@example.com',
+      emailVerified: true,
+      role: 'user',
+      createdAt: now,
+      updatedAt: now,
+    })
+    const [realConfig] = await db
+      .insert(configsTable)
+      .values({
+        slug: 'real-user-publish-config',
+        title: 'Real User Publish Config',
+        description: 'd',
+        authorId: 'real-publish-user',
+        interpreter: 'bash',
+        status: 'draft',
+      })
+      .returning()
+    const [realVersion] = await db
+      .insert(configVersionsTable)
+      .values({
+        configId: realConfig?.id as string,
+        versionNumber: 1,
+        source: '#!/usr/bin/env bash\necho ok',
+        interpreter: 'bash',
+        contentSha256: 'realdeadbeef',
+        status: 'pending',
+      })
+      .returning()
+    await db.insert(renderJobsTable).values({
+      configVersionId: realVersion?.id as string,
+      status: 'done',
+      finishedAt: now,
+    })
+
+    const result = await publishRenderedSeeds(db)
+    expect(result.published).toBe(1)
+
+    const [seedCfg] = await db
+      .select()
+      .from(configsTable)
+      .where(eq(configsTable.id, seedOutcome.configId as string))
+    expect(seedCfg?.status).toBe('published')
+
+    const [realCfg] = await db
+      .select()
+      .from(configsTable)
+      .where(eq(configsTable.id, realConfig?.id as string))
+    expect(realCfg?.status).toBe('draft')
+  })
+
+  it('never re-publishes a removed (taken-down) config even if it has a done render job', async () => {
+    const profile = {
+      id: '8301',
+      login: 'removedauthor',
+      name: 'Removed Author',
+      avatarUrl: 'https://x/removed.png',
+    }
+    await ensureSeededAuthor(db, profile)
+    const entry: CommunityConfig = {
+      githubLogin: 'removedauthor',
+      githubId: '8301',
+      title: 'Removed Config',
+      description: 'd',
+      interpreter: 'bash',
+      source: '#!/usr/bin/env bash\necho ok',
+      license: 'MIT',
+      sourceUrl: 'https://example.com/removed',
+    }
+    const outcome = await seedCommunityConfig(db, profile, entry)
+    // Simulate an admin takedown (emergency-removal script) before a re-render lands.
+    await db
+      .update(configsTable)
+      .set({ status: 'removed' })
+      .where(eq(configsTable.id, outcome.configId as string))
+    const [ver] = await db
+      .select()
+      .from(configVersionsTable)
+      .where(eq(configVersionsTable.configId, outcome.configId as string))
+    await db
+      .update(renderJobsTable)
+      .set({ status: 'done', finishedAt: new Date() })
+      .where(eq(renderJobsTable.configVersionId, ver?.id as string))
+
+    await publishRenderedSeeds(db)
+
+    const [cfg] = await db
+      .select()
+      .from(configsTable)
+      .where(eq(configsTable.id, outcome.configId as string))
+    expect(cfg?.status).toBe('removed')
+  })
 })

--- a/test/scripts/seed-community.test.ts
+++ b/test/scripts/seed-community.test.ts
@@ -2,7 +2,7 @@ import { PGlite } from '@electric-sql/pglite'
 import { and, eq } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/pglite'
 import { migrate } from 'drizzle-orm/pglite/migrator'
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 import * as schema from '@/db/schema'
 import {
   account as accountTable,
@@ -15,6 +15,8 @@ import {
   type CommunityConfig,
   ensureSeededAuthor,
   fetchGithubUser,
+  publishRenderedSeeds,
+  releaseHeldSeeds,
   seedCommunity,
   seedCommunityConfig,
 } from '../../scripts/seed-community'
@@ -154,6 +156,8 @@ describe('seedCommunityConfig', () => {
     description: 'Model and branch only.',
     interpreter: 'bash',
     source: '#!/usr/bin/env bash\necho "hi"',
+    license: 'MIT',
+    sourceUrl: 'https://github.com/seedocto/dotfiles',
   }
 
   it('submits a draft + queued render job attributed to the seeded author (no publish)', async () => {
@@ -204,6 +208,69 @@ describe('seedCommunityConfig', () => {
     const second = await seedCommunityConfig(db, profile, e)
     expect(second.status).toBe('skipped')
   })
+
+  it('forwards networkHosts/license/sourceUrl through to the created version, held for network', async () => {
+    const profile = {
+      id: '4244',
+      login: 'networked',
+      name: 'Networked',
+      avatarUrl: 'https://x/n.png',
+    }
+    await ensureSeededAuthor(db, profile)
+    const e: CommunityConfig = {
+      ...entry,
+      githubLogin: 'networked',
+      githubId: '4244',
+      title: 'Networked Config',
+      networkHosts: ['api.anthropic.com'],
+    }
+
+    const outcome = await seedCommunityConfig(db, profile, e)
+    expect(outcome.status).toBe('submitted')
+
+    const [ver] = await db
+      .select()
+      .from(configVersionsTable)
+      .where(eq(configVersionsTable.configId, outcome.configId as string))
+    expect(ver?.networkHosts).toEqual(['api.anthropic.com'])
+    expect(ver?.license).toBe('MIT')
+    expect(ver?.sourceUrl).toBe('https://github.com/seedocto/dotfiles')
+    expect(ver?.readsClaudeToken).toBe(false)
+
+    const [job] = await db
+      .select()
+      .from(renderJobsTable)
+      .where(eq(renderJobsTable.configVersionId, ver?.id as string))
+    expect(job?.status).toBe('held')
+  })
+
+  it('a no-network entry gets a queued (not held) render job', async () => {
+    const profile = {
+      id: '4245',
+      login: 'nonetwork',
+      name: 'No Network',
+      avatarUrl: 'https://x/nn.png',
+    }
+    await ensureSeededAuthor(db, profile)
+    const e: CommunityConfig = {
+      ...entry,
+      githubLogin: 'nonetwork',
+      githubId: '4245',
+      title: 'No Network Config',
+    }
+
+    const outcome = await seedCommunityConfig(db, profile, e)
+
+    const [ver] = await db
+      .select()
+      .from(configVersionsTable)
+      .where(eq(configVersionsTable.configId, outcome.configId as string))
+    const [job] = await db
+      .select()
+      .from(renderJobsTable)
+      .where(eq(renderJobsTable.configVersionId, ver?.id as string))
+    expect(job?.status).toBe('queued')
+  })
 })
 
 describe('seedCommunity', () => {
@@ -230,6 +297,8 @@ describe('seedCommunity', () => {
         description: 'd',
         interpreter: 'bash',
         source: '#!/usr/bin/env bash\necho ok',
+        license: 'MIT',
+        sourceUrl: 'https://example.com/missing1',
       },
       {
         githubLogin: 'good1',
@@ -238,6 +307,8 @@ describe('seedCommunity', () => {
         description: 'd',
         interpreter: 'bash',
         source: '#!/usr/bin/env bash\necho ok',
+        license: 'MIT',
+        sourceUrl: 'https://example.com/good1',
       },
     ]
 
@@ -257,6 +328,8 @@ describe('seedCommunity', () => {
         description: 'd',
         interpreter: 'bash',
         source: '#!/usr/bin/env bash\necho ok',
+        license: 'MIT',
+        sourceUrl: 'https://example.com/recycled',
       },
     ]
 
@@ -270,5 +343,113 @@ describe('seedCommunity', () => {
       .from(accountTable)
       .where(and(eq(accountTable.providerId, 'github'), eq(accountTable.accountId, '6002')))
     expect(accs.length).toBe(0)
+  })
+})
+
+describe('releaseHeldSeeds', () => {
+  // Isolate from held/pending render jobs left behind by earlier describe blocks in this file
+  // (cascades to configVersions + renderJobs) so the count assertion below is exact.
+  beforeEach(async () => {
+    await db.delete(configsTable)
+  })
+
+  it('flips every held render job to queued and returns the count', async () => {
+    const profile = {
+      id: '7001',
+      login: 'heldauthor',
+      name: 'Held Author',
+      avatarUrl: 'https://x/held.png',
+    }
+    await ensureSeededAuthor(db, profile)
+    const heldEntry: CommunityConfig = {
+      githubLogin: 'heldauthor',
+      githubId: '7001',
+      title: 'Held Config One',
+      description: 'd',
+      interpreter: 'bash',
+      source: '#!/usr/bin/env bash\necho ok',
+      license: 'MIT',
+      sourceUrl: 'https://example.com/held-one',
+      networkHosts: ['api.anthropic.com'],
+    }
+    const heldEntry2: CommunityConfig = {
+      ...heldEntry,
+      title: 'Held Config Two',
+      networkHosts: ['api.anthropic.com'],
+    }
+    const outcome1 = await seedCommunityConfig(db, profile, heldEntry)
+    const outcome2 = await seedCommunityConfig(db, profile, heldEntry2)
+
+    const count = await releaseHeldSeeds(db)
+    expect(count).toBe(2)
+
+    for (const configId of [outcome1.configId, outcome2.configId]) {
+      const [ver] = await db
+        .select()
+        .from(configVersionsTable)
+        .where(eq(configVersionsTable.configId, configId as string))
+      const [job] = await db
+        .select()
+        .from(renderJobsTable)
+        .where(eq(renderJobsTable.configVersionId, ver?.id as string))
+      expect(job?.status).toBe('queued')
+    }
+  })
+})
+
+describe('publishRenderedSeeds', () => {
+  // Isolate from pending versions left behind by earlier describe blocks in this file so the
+  // published/skipped counts below are exact.
+  beforeEach(async () => {
+    await db.delete(configsTable)
+  })
+
+  it('publishes every pending version whose render job is done, and counts the rest as skipped', async () => {
+    const profile = {
+      id: '8001',
+      login: 'publishauthor',
+      name: 'Publish Author',
+      avatarUrl: 'https://x/pub.png',
+    }
+    await ensureSeededAuthor(db, profile)
+
+    const doneEntry: CommunityConfig = {
+      githubLogin: 'publishauthor',
+      githubId: '8001',
+      title: 'Done Config',
+      description: 'd',
+      interpreter: 'bash',
+      source: '#!/usr/bin/env bash\necho ok',
+      license: 'MIT',
+      sourceUrl: 'https://example.com/done',
+    }
+    const notDoneEntry: CommunityConfig = { ...doneEntry, title: 'Not Done Config' }
+
+    const doneOutcome = await seedCommunityConfig(db, profile, doneEntry)
+    const notDoneOutcome = await seedCommunityConfig(db, profile, notDoneEntry)
+
+    const [doneVer] = await db
+      .select()
+      .from(configVersionsTable)
+      .where(eq(configVersionsTable.configId, doneOutcome.configId as string))
+    await db
+      .update(renderJobsTable)
+      .set({ status: 'done', finishedAt: new Date() })
+      .where(eq(renderJobsTable.configVersionId, doneVer?.id as string))
+
+    const result = await publishRenderedSeeds(db)
+    expect(result).toEqual({ published: 1, skipped: 1 })
+
+    const [doneCfg] = await db
+      .select()
+      .from(configsTable)
+      .where(eq(configsTable.id, doneOutcome.configId as string))
+    expect(doneCfg?.status).toBe('published')
+
+    const [notDoneCfg] = await db
+      .select()
+      .from(configsTable)
+      .where(eq(configsTable.id, notDoneOutcome.configId as string))
+    expect(notDoneCfg?.status).toBe('draft')
   })
 })

--- a/test/scripts/seed-community.test.ts
+++ b/test/scripts/seed-community.test.ts
@@ -380,6 +380,46 @@ describe('releaseHeldSeeds', () => {
     const outcome1 = await seedCommunityConfig(db, profile, heldEntry)
     const outcome2 = await seedCommunityConfig(db, profile, heldEntry2)
 
+    // A held job from a NON-seed author (a real web submission using the network-preview gate)
+    // must be left alone — releaseHeldSeeds only releases seed-authored (email seed+*) jobs.
+    const now = new Date()
+    await db.insert(userTable).values({
+      id: 'real-web-user',
+      name: 'Real Web User',
+      email: 'realuser@example.com',
+      emailVerified: true,
+      role: 'user',
+      createdAt: now,
+      updatedAt: now,
+    })
+    const [realConfig] = await db
+      .insert(configsTable)
+      .values({
+        slug: 'real-user-held-config',
+        title: 'Real User Held Config',
+        description: 'd',
+        authorId: 'real-web-user',
+        interpreter: 'bash',
+        status: 'draft',
+      })
+      .returning()
+    const [realVersion] = await db
+      .insert(configVersionsTable)
+      .values({
+        configId: realConfig?.id as string,
+        versionNumber: 1,
+        source: '#!/usr/bin/env bash\necho ok',
+        interpreter: 'bash',
+        contentSha256: 'deadbeef',
+        networkHosts: ['api.anthropic.com'],
+        status: 'pending',
+      })
+      .returning()
+    await db.insert(renderJobsTable).values({
+      configVersionId: realVersion?.id as string,
+      status: 'held',
+    })
+
     const count = await releaseHeldSeeds(db)
     expect(count).toBe(2)
 
@@ -394,6 +434,12 @@ describe('releaseHeldSeeds', () => {
         .where(eq(renderJobsTable.configVersionId, ver?.id as string))
       expect(job?.status).toBe('queued')
     }
+
+    const [realJob] = await db
+      .select()
+      .from(renderJobsTable)
+      .where(eq(renderJobsTable.configVersionId, realVersion?.id as string))
+    expect(realJob?.status).toBe('held')
   })
 })
 

--- a/test/submit/submit.test.ts
+++ b/test/submit/submit.test.ts
@@ -197,6 +197,29 @@ describe('submitConfig', () => {
     expect(ver?.readsClaudeToken).toBe(false)
   })
 
+  it('stores license and sourceUrl when provided, null otherwise', async () => {
+    const a = await submitConfig(db, {
+      ...input,
+      title: 'Licensed seed',
+      license: 'MIT',
+      sourceUrl: 'https://github.com/example/repo/blob/abc123/statusline.sh',
+    })
+    const [verA] = await db
+      .select()
+      .from(schema.configVersions)
+      .where(eq(schema.configVersions.configId, a.configId))
+    expect(verA?.license).toBe('MIT')
+    expect(verA?.sourceUrl).toBe('https://github.com/example/repo/blob/abc123/statusline.sh')
+
+    const b = await submitConfig(db, { ...input, title: 'Own work' })
+    const [verB] = await db
+      .select()
+      .from(schema.configVersions)
+      .where(eq(schema.configVersions.configId, b.configId))
+    expect(verB?.license).toBeNull()
+    expect(verB?.sourceUrl).toBeNull()
+  })
+
   it('gives each submission a unique slug', async () => {
     const a = await submitConfig(db, input)
     const b = await submitConfig(db, input)


### PR DESCRIPTION
Seeds 15 MIT-licensed community status line scripts into the gallery pipeline, with per-config license + source attribution shipped first.

## What's here

- **Provenance columns**: nullable `license` + `source_url` on `config_versions` (migration 0016, additive only). Web form submissions can't set them (validated input drops them) — they stay CC0 own-work; only the seed CLI sets them.
- **License display**: config pages show "MIT licensed · original source ↗" when set, nothing when null (existing pages render unchanged — null path test-covered). JSON-LD uses the per-config license; terms page gains one sentence about seeded entries keeping their original license.
- **Seeder**: `bun run seed:community [seed|release-held|publish-rendered]` — local-only by design (refuses on deployed images). `release-held` and `publish-rendered` are both scoped to seed-authored (`seed+%` email) draft configs, so a real submission in the review queue can never be batch-released or batch-published.
- **The 15 seeds**: each script vendored as its own file under `scripts/seed-data/sources/`, fetched at a pinned commit and sha256-verified against upstream (integrity review re-verified all 15 independently). One script trimmed (12-activity-feed.sh: removed a sibling-script call; trim note at the top). Entries in `scripts/seed-data/community-configs.ts` carry pinned source links, declared network hosts, and GitHub attribution (rename-protected via pinned numeric IDs). Tests prove all 15 pass the real submit-time rejection gates and that exactly 9 read the OAuth token (badged automatically).

## Review focus

1. **The 15 scripts** (`scripts/seed-data/sources/`) — this PR is the human-review checkpoint the seed pipeline requires before anything runs.
2. **Titles + descriptions** (`scripts/seed-data/community-configs.ts`).
3. One judgment call: 13 of 15 upstream repos keep their MIT notice in a repo-level LICENSE file (not in the script itself), so those vendored copies carry the license label + pinned source link but no literal notice text. Rows 05 and 10 had in-file headers; both preserved byte-for-byte.

## After merge

Deploy staging → `seed` → `release-held` → staging worker renders 15×8 scenarios → `publish-rendered` (staging only) → side-by-side keep/cut pass on staging.statuslin.es. Prod gets only the keepers, through the normal review queue.