### PR TITLE
feat(analytics): track gallery and auth funnels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,16 @@ where visitors **upvote** (`src/votes`) and **copy it to use** (`src/adopt`).
 6. **Clear names.** Name things for what they do, not how they work.
 7. **Untrusted by default.** Submitted status line scripts are hostile until proven otherwise — the E2B sandbox is the safety boundary; trust comes from the supply-chain controls (open-source + human review + hash-pinned immutable versions + re-review on every update). See `SECURITY.md`.
 
+## Scope control
+
+- **Make the smallest correct change.** Implement only the requested behavior; do not address hypothetical edge cases or expand the feature without approval.
+- **Ask before adding infrastructure.** Get explicit approval before introducing providers, queues, compatibility layers, broad abstractions, new frameworks, or other cross-cutting machinery.
+- **Keep the diff focused.** If the work needs more than five production files or starts touching unrelated areas, stop and explain why before continuing.
+- **Bound the feedback loop.** Run focused tests once after implementation, then run `bun run check` once. If either fails, make the minimal fix and rerun only what the fix invalidated. Do not repeatedly rerun green checks.
+- **Use one review pass.** Treat review findings outside the acceptance criteria as follow-ups, not blockers. Stop and ask before acting on feedback that materially expands scope.
+- **Stop after two blocked attempts.** Explain the blocker and options instead of continuing to add complexity.
+- **Summarize before the gate.** Show what changed, which files were touched, and why the diff is still within scope before starting final verification.
+
 ## Conventions
 
 - **Run it:** `bun run dev` (the app) + `bun run worker` (renders queued jobs locally, or nothing reaches the review queue); full setup in `README.md`.

--- a/src/gallery/card-rows.ts
+++ b/src/gallery/card-rows.ts
@@ -19,6 +19,7 @@ export function mapCardRows(
   cardPreviews: Map<string, AnsiSegment[]>,
 ): GalleryCard[] {
   return rows.map((r) => ({
+    configId: r.config.id,
     slug: r.config.slug,
     title: r.config.title,
     description: r.config.description,

--- a/src/gallery/config-card.tsx
+++ b/src/gallery/config-card.tsx
@@ -1,21 +1,55 @@
+import { usePostHog } from '@posthog/react'
 import { ConfigBadges } from '@/gallery/config-badges'
+import type { GalleryCard, GallerySort } from '@/gallery/queries'
 import { AuthorChip } from '@/ui/author-chip'
 import { Card, CardContent, CardHeader, CardTitle } from '@/ui/card'
 import { Row, Stack } from '@/ui/layout'
 import { StatuslinePreview } from '@/ui/statusline-preview'
 import { StretchedLink } from '@/ui/stretched-link'
 import { Text } from '@/ui/text'
-import type { GalleryCard } from './queries'
+
+export interface GalleryCardAnalytics {
+  surface: 'home' | 'facet'
+  position: number
+  facet?: string
+  sort?: GallerySort
+  page?: number
+  selectedTags?: string[]
+}
 
 /** One gallery card: title, badges, preview, description, author. Used by the home gallery and facet pages. */
-export function GalleryConfigCard({ card }: { card: GalleryCard }) {
+export function GalleryConfigCard({
+  card,
+  analytics,
+}: {
+  card: GalleryCard
+  analytics?: GalleryCardAnalytics
+}) {
+  const posthog = usePostHog()
+
   return (
     <Card interactive>
       <CardHeader>
         <Row gap={2} align="start" justify="between">
           <Row gap={2}>
             <CardTitle>
-              <StretchedLink to="/c/$slug" params={{ slug: card.slug }}>
+              <StretchedLink
+                to="/c/$slug"
+                params={{ slug: card.slug }}
+                onClick={() => {
+                  if (!analytics) return
+                  posthog.capture('statusline_card_clicked', {
+                    configId: card.configId,
+                    slug: card.slug,
+                    surface: analytics.surface,
+                    position: analytics.position,
+                    ...(analytics.facet ? { facet: analytics.facet } : {}),
+                    ...(analytics.sort ? { sort: analytics.sort } : {}),
+                    ...(analytics.page ? { page: analytics.page } : {}),
+                    ...(analytics.selectedTags ? { selectedTags: analytics.selectedTags } : {}),
+                  })
+                }}
+              >
                 {card.title}
               </StretchedLink>
             </CardTitle>

--- a/src/gallery/gallery-controls.tsx
+++ b/src/gallery/gallery-controls.tsx
@@ -46,7 +46,11 @@ export function GalleryControls({
   const facets = FACETS.filter((f) => availableSet.has(f.slug))
 
   const setSort = (value: GallerySort) => {
-    posthog.capture('gallery_sort_changed', { sort: value })
+    posthog.capture('gallery_sort_changed', {
+      sort: value,
+      selectedTags: tags,
+      page: 1,
+    })
     navigate({
       to: '/',
       search: (prev) => {
@@ -63,6 +67,13 @@ export function GalleryControls({
       next.add(slug)
     }
     const csv = buildTagsCsv(next)
+    posthog.capture('gallery_filter_changed', {
+      action: next.has(slug) ? 'add' : 'remove',
+      tag: slug,
+      selectedTags: csv ? csv.split(',') : [],
+      sort,
+      page: 1,
+    })
     navigate({
       to: '/',
       search: (prev) => {
@@ -113,6 +124,14 @@ export function GalleryControls({
         <Button asChild variant="outline" size="icon-lg" aria-label="Clear filters">
           <Link
             to="/"
+            onClick={() => {
+              posthog.capture('gallery_filter_changed', {
+                action: 'clear',
+                selectedTags: [],
+                sort,
+                page: 1,
+              })
+            }}
             search={(prev) => {
               const { page: _page, tags: _tags, ...rest } = prev
               return rest

--- a/src/gallery/queries.ts
+++ b/src/gallery/queries.ts
@@ -50,6 +50,7 @@ export interface ConfigAuthor {
 }
 
 export interface GalleryCard {
+  configId: string
   slug: string
   title: string
   description: string

--- a/src/gallery/related.ts
+++ b/src/gallery/related.ts
@@ -8,6 +8,7 @@ import { coerceInterpreter, selectCardPreviews } from './queries'
 type Db = PgDatabase<any, typeof import('@/db/schema')>
 
 export interface RelatedConfig {
+  configId: string
   slug: string
   title: string
   interpreter: Interpreter
@@ -42,6 +43,7 @@ export async function getRelatedConfigs(
   )
 
   return rows.map((r) => ({
+    configId: r.config.id,
     slug: r.config.slug,
     title: r.config.title,
     interpreter: coerceInterpreter(r.config.interpreter),

--- a/src/lib/posthog-identity.ts
+++ b/src/lib/posthog-identity.ts
@@ -1,0 +1,27 @@
+import type { PostHog } from 'posthog-js'
+import { consumePendingAuthIntent } from '@/lib/sign-in'
+
+const CURRENT_URL_PROPERTY = '$current_url'
+
+export interface AnalyticsUser {
+  id: string
+  name: string
+  username?: string | null | undefined
+}
+
+/** Identify a signed-in user and close the OAuth funnel when a pending intent exists. */
+export function identifyPostHogUser(
+  posthog: Pick<PostHog, 'identify' | 'capture'>,
+  user: AnalyticsUser,
+): void {
+  posthog.identify(user.id, { name: user.username ?? user.name, username: user.username })
+  const pendingAuth = consumePendingAuthIntent()
+  if (pendingAuth) {
+    posthog.capture('auth_completed', {
+      provider: 'github',
+      entryPoint: pendingAuth.entryPoint,
+      returnPath: pendingAuth.returnPath,
+      [CURRENT_URL_PROPERTY]: pendingAuth.returnPath,
+    })
+  }
+}

--- a/src/lib/sign-in.ts
+++ b/src/lib/sign-in.ts
@@ -1,11 +1,75 @@
+import type { PostHog } from 'posthog-js'
 import { authClient } from '@/lib/auth-client'
 import { safeNextPath } from '@/lib/next-path'
+
+export type AuthEntryPoint = 'header' | 'upvote' | 'submit' | 'account' | 'admin'
+export const PENDING_AUTH_KEY = 'statuslines.pending-auth'
+const CURRENT_URL_PROPERTY = '$current_url'
+
+const AUTH_ENTRY_POINTS = new Set<AuthEntryPoint>([
+  'header',
+  'upvote',
+  'submit',
+  'account',
+  'admin',
+])
+
+export interface PendingAuthIntent {
+  entryPoint: AuthEntryPoint
+  returnPath: string
+}
+
+function analyticsPath(path: string): string {
+  return path.split(/[?#]/, 1)[0] || '/'
+}
 
 /**
  * Starts the one-click GitHub OAuth redirect, returning the user to `next` (sanitized
  * against open redirects) once they come back. Every sign-in entry point goes through
  * here so the flow lives in exactly one place.
  */
-export function startGitHubSignIn(next?: string): void {
-  void authClient.signIn.social({ provider: 'github', callbackURL: safeNextPath(next) })
+export function startGitHubSignIn(
+  next?: string,
+  entryPoint: AuthEntryPoint = 'header',
+  posthog?: Pick<PostHog, 'capture'>,
+): void {
+  const returnPath = safeNextPath(next)
+  const trackedReturnPath = analyticsPath(returnPath)
+  try {
+    window.sessionStorage.setItem(
+      PENDING_AUTH_KEY,
+      JSON.stringify({ entryPoint, returnPath: trackedReturnPath } satisfies PendingAuthIntent),
+    )
+  } catch {
+    // Storage can be unavailable in privacy-restricted browsers; OAuth still works without it.
+  }
+  posthog?.capture('auth_started', {
+    provider: 'github',
+    entryPoint,
+    returnPath: trackedReturnPath,
+    [CURRENT_URL_PROPERTY]: trackedReturnPath,
+  })
+  void authClient.signIn.social({ provider: 'github', callbackURL: returnPath })
+}
+
+/** Consume the short-lived OAuth intent after the callback returns to the app. */
+export function consumePendingAuthIntent(): PendingAuthIntent | null {
+  try {
+    const raw = window.sessionStorage.getItem(PENDING_AUTH_KEY)
+    window.sessionStorage.removeItem(PENDING_AUTH_KEY)
+    if (!raw) return null
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null) return null
+    const intent = parsed as { entryPoint?: unknown; returnPath?: unknown }
+    if (
+      typeof intent.entryPoint !== 'string' ||
+      !AUTH_ENTRY_POINTS.has(intent.entryPoint as AuthEntryPoint) ||
+      typeof intent.returnPath !== 'string'
+    ) {
+      return null
+    }
+    return { entryPoint: intent.entryPoint as AuthEntryPoint, returnPath: intent.returnPath }
+  } catch {
+    return null
+  }
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,10 +1,10 @@
 import '@/styles/app.css'
-import { PostHogProvider, usePostHog } from '@posthog/react'
+import { PostHogProvider } from '@posthog/react'
 import { createRootRoute, HeadContent, Outlet, Scripts } from '@tanstack/react-router'
-import { useEffect } from 'react'
 import { getAnalyticsToken } from '@/lib/analytics-config'
 import { getSession } from '@/lib/auth-functions'
 import { POSTHOG_INGEST_HOST, POSTHOG_UI_HOST } from '@/lib/posthog-hosts'
+import { identifyPostHogUser } from '@/lib/posthog-identity'
 import { rootSocialMeta } from '@/og/meta'
 import { Toaster } from '@/ui/sonner'
 
@@ -30,27 +30,8 @@ export const Route = createRootRoute({
   component: RootComponent,
 })
 
-function PostHogIdentifier() {
-  const posthog = usePostHog()
-  const { user } = Route.useLoaderData()
-
-  useEffect(() => {
-    if (user) {
-      // Identify by the stable user id so client events line up with server events (which also
-      // key on the user id) — username can be null or change, so it's not a safe identifier.
-      // (The root loader doesn't re-run on child navigation, so `user` is a stable ref; and PostHog
-      // dedupes identical identify calls, so this fires effectively once per session.)
-      // Send the GitHub username as `name` so PostHog shows it as the person's display name
-      // (falling back to the GitHub display name when the username is missing).
-      posthog.identify(user.id, { name: user.username ?? user.name, username: user.username })
-    }
-  }, [posthog, user])
-
-  return null
-}
-
 function RootComponent() {
-  const { posthogToken } = Route.useLoaderData()
+  const { posthogToken, user } = Route.useLoaderData()
   const body = (
     <>
       <Outlet />
@@ -81,9 +62,11 @@ function RootComponent() {
               // We only use product analytics, not session replay.
               disable_session_recording: true,
               debug: import.meta.env.DEV,
+              loaded: (posthog) => {
+                if (user) identifyPostHogUser(posthog, user)
+              },
             }}
           >
-            <PostHogIdentifier />
             {body}
           </PostHogProvider>
         ) : (

--- a/src/routes/c.$slug.tsx
+++ b/src/routes/c.$slug.tsx
@@ -202,12 +202,23 @@ function ConfigDetail() {
         {detail.related.length > 0 && (
           <SectionCard title="More status lines">
             <Stack gap={3}>
-              {detail.related.map((r) => (
+              {detail.related.map((r, index) => (
                 <Card key={r.slug} interactive>
                   <CardHeader>
                     <Row gap={2}>
                       <CardTitle>
-                        <StretchedLink to="/c/$slug" params={{ slug: r.slug }}>
+                        <StretchedLink
+                          to="/c/$slug"
+                          params={{ slug: r.slug }}
+                          onClick={() =>
+                            posthog.capture('statusline_card_clicked', {
+                              configId: r.configId,
+                              slug: r.slug,
+                              surface: 'related',
+                              position: index + 1,
+                            })
+                          }
+                        >
                           {r.title}
                         </StretchedLink>
                       </CardTitle>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,3 +1,4 @@
+import { usePostHog } from '@posthog/react'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { GalleryConfigCard } from '@/gallery/config-card'
 import { getGallery } from '@/gallery/functions'
@@ -64,6 +65,16 @@ function Home() {
   const { cards, page, pageCount } = gallery
   const { sort: rawSort, tags } = Route.useSearch()
   const sort = rawSort ?? 'trending'
+  const selectedTags = tags ? tags.split(',') : []
+  const posthog = usePostHog()
+
+  const trackPageChange = (nextPage: number) => {
+    posthog.capture('gallery_page_changed', {
+      page: nextPage,
+      sort,
+      selectedTags,
+    })
+  }
 
   return (
     <PageShell user={user}>
@@ -83,8 +94,18 @@ function Home() {
             />
             <SubmitCta signedIn={!!user} />
           </Row>
-          {cards.map((card) => (
-            <GalleryConfigCard key={card.slug} card={card} />
+          {cards.map((card, index) => (
+            <GalleryConfigCard
+              key={card.slug}
+              card={card}
+              analytics={{
+                surface: 'home',
+                position: index + 1,
+                page,
+                sort,
+                selectedTags,
+              }}
+            />
           ))}
         </Stack>
 
@@ -92,7 +113,11 @@ function Home() {
           <Row gap={4} align="center" justify="center">
             {page > 1 ? (
               <Button asChild variant="ghost" size="sm">
-                <Link to="/" search={{ sort, page: page - 1, ...(tags ? { tags } : {}) }}>
+                <Link
+                  to="/"
+                  onClick={() => trackPageChange(page - 1)}
+                  search={{ sort, page: page - 1, ...(tags ? { tags } : {}) }}
+                >
                   ← Previous
                 </Link>
               </Button>
@@ -102,7 +127,11 @@ function Home() {
             </Text>
             {page < pageCount ? (
               <Button asChild variant="ghost" size="sm">
-                <Link to="/" search={{ sort, page: page + 1, ...(tags ? { tags } : {}) }}>
+                <Link
+                  to="/"
+                  onClick={() => trackPageChange(page + 1)}
+                  search={{ sort, page: page + 1, ...(tags ? { tags } : {}) }}
+                >
                   Next →
                 </Link>
               </Button>

--- a/src/routes/status-lines.$facet.tsx
+++ b/src/routes/status-lines.$facet.tsx
@@ -70,8 +70,12 @@ function FacetPage() {
         </Stack>
         <Stack gap={4}>
           <VisuallyHidden as="h2">Status lines</VisuallyHidden>
-          {page.cards.map((card) => (
-            <GalleryConfigCard key={card.slug} card={card} />
+          {page.cards.map((card, index) => (
+            <GalleryConfigCard
+              key={card.slug}
+              card={card}
+              analytics={{ surface: 'facet', facet: page.slug, position: index + 1 }}
+            />
           ))}
         </Stack>
         {page.otherFacets.length > 0 ? (

--- a/src/ui/sign-in-button.tsx
+++ b/src/ui/sign-in-button.tsx
@@ -1,15 +1,29 @@
+import { usePostHog } from '@posthog/react'
 import { startGitHubSignIn } from '@/lib/sign-in'
 import { Button } from './button'
 
 /** One-click GitHub sign-in — starts the OAuth redirect directly, no intermediate page. */
 export function SignInButton() {
+  const posthog = usePostHog()
+
   return (
     <Button
       type="button"
       variant="outline"
       size="lg"
       // Return the user to wherever they clicked sign-in from.
-      onClick={() => startGitHubSignIn(window.location.pathname + window.location.search)}
+      onClick={() => {
+        const path = window.location.pathname
+        const entryPoint =
+          path === '/submit'
+            ? 'submit'
+            : path === '/me'
+              ? 'account'
+              : path.startsWith('/admin')
+                ? 'admin'
+                : 'header'
+        startGitHubSignIn(path + window.location.search, entryPoint, posthog)
+      }}
     >
       <GitHubMark />
       Sign in with GitHub

--- a/src/ui/stretched-link.tsx
+++ b/src/ui/stretched-link.tsx
@@ -4,21 +4,22 @@ import type * as React from 'react'
 const STRETCHED_LINK_CLASS =
   'rounded-sm after:absolute after:inset-0 focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50'
 
-type StretchedLinkProps =
+type StretchedLinkProps = {
+  children: React.ReactNode
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>
+} & (
   | {
       to: NonNullable<LinkProps['to']>
       params?: LinkProps['params']
       href?: never
-      children: React.ReactNode
     }
   // External URL; opens in a new tab. Use instead of `to` for off-site links (e.g. resource cards).
   | {
       href: string
       to?: never
       params?: never
-      children: React.ReactNode
     }
-
+)
 /**
  * The gallery-card title link that makes the whole card clickable via an
  * `after` overlay covering the nearest positioned ancestor.
@@ -36,6 +37,7 @@ export function StretchedLink(props: StretchedLinkProps) {
         target="_blank"
         rel="noopener noreferrer"
         className={STRETCHED_LINK_CLASS}
+        onClick={props.onClick}
       >
         {props.children}
       </a>
@@ -46,6 +48,7 @@ export function StretchedLink(props: StretchedLinkProps) {
       to={props.to}
       {...(props.params !== undefined ? { params: props.params } : {})}
       className={STRETCHED_LINK_CLASS}
+      onClick={props.onClick}
     >
       {props.children}
     </Link>

--- a/src/ui/submit-cta.tsx
+++ b/src/ui/submit-cta.tsx
@@ -1,3 +1,4 @@
+import { usePostHog } from '@posthog/react'
 import { Link } from '@tanstack/react-router'
 import { Plus } from 'lucide-react'
 import { startGitHubSignIn } from '@/lib/sign-in'
@@ -11,6 +12,8 @@ import { Button } from '@/ui/button'
  * afterward — no intermediate "Sign in to submit" page.
  */
 export function SubmitCta({ signedIn }: { signedIn: boolean }) {
+  const posthog = usePostHog()
+
   if (signedIn) {
     return (
       <Button asChild size="lg">
@@ -23,7 +26,7 @@ export function SubmitCta({ signedIn }: { signedIn: boolean }) {
   }
 
   return (
-    <Button type="button" size="lg" onClick={() => startGitHubSignIn('/submit')}>
+    <Button type="button" size="lg" onClick={() => startGitHubSignIn('/submit', 'submit', posthog)}>
       <Plus />
       Submit a status line
     </Button>

--- a/src/votes/upvote-button.tsx
+++ b/src/votes/upvote-button.tsx
@@ -1,4 +1,5 @@
 import NumberFlow from '@number-flow/react'
+import { usePostHog } from '@posthog/react'
 import { useRouter } from '@tanstack/react-router'
 import { useState } from 'react'
 import { startGitHubSignIn } from '@/lib/sign-in'
@@ -18,6 +19,7 @@ export function UpvoteButton({
   initialVoted: boolean
   signedIn: boolean
 }) {
+  const posthog = usePostHog()
   const router = useRouter()
   const [voted, setVoted] = useState(initialVoted)
   const [count, setCount] = useState(initialCount)
@@ -68,7 +70,7 @@ export function UpvoteButton({
       variant="outline"
       size="lg"
       title="Sign in to vote"
-      onClick={() => startGitHubSignIn(`/c/${slug}`)}
+      onClick={() => startGitHubSignIn(`/c/${slug}`, 'upvote', posthog)}
       aria-label={`Upvote (sign in to vote) — ${count} upvotes`}
     >
       ⇧ <NumberFlow value={count} />

--- a/test/gallery/config-card.test.tsx
+++ b/test/gallery/config-card.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const capture = vi.fn()
+
+vi.mock('@posthog/react', () => ({
+  usePostHog: () => ({ capture }),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    to,
+    params,
+    children,
+    ...props
+  }: {
+    to: string
+    params?: Record<string, string>
+    children: React.ReactNode
+  }) => (
+    <a href={params ? to.replace('$slug', params.slug ?? '') : to} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+const { GalleryConfigCard } = await import('@/gallery/config-card')
+
+afterEach(() => capture.mockClear())
+
+describe('GalleryConfigCard analytics', () => {
+  it('captures the discovery context when a card opens', () => {
+    render(
+      <GalleryConfigCard
+        card={{
+          configId: 'config-1',
+          slug: 'example',
+          title: 'Example',
+          description: 'An example status line.',
+          interpreter: 'bash',
+          upvoteCount: 3,
+          copyCount: 2,
+          author: null,
+          preview: null,
+          networkHosts: [],
+          readsClaudeToken: false,
+          tags: [],
+        }}
+        analytics={{
+          surface: 'home',
+          position: 2,
+          page: 1,
+          sort: 'trending',
+          selectedTags: ['git'],
+        }}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('link', { name: 'Example' }))
+
+    expect(capture).toHaveBeenCalledWith('statusline_card_clicked', {
+      configId: 'config-1',
+      slug: 'example',
+      surface: 'home',
+      position: 2,
+      sort: 'trending',
+      page: 1,
+      selectedTags: ['git'],
+    })
+  })
+})

--- a/test/gallery/gallery-controls.test.tsx
+++ b/test/gallery/gallery-controls.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import { Children, cloneElement } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const navigate = vi.fn()
+const capture = vi.fn()
+
+vi.mock('@posthog/react', () => ({
+  usePostHog: () => ({ capture }),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ to, children, ...props }: { to: string; children: React.ReactNode }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+  useNavigate: () => navigate,
+}))
+
+vi.mock('@/ui/button', () => ({
+  Button: ({ asChild, children, ...props }: { asChild?: boolean; children: React.ReactNode }) =>
+    asChild ? (
+      cloneElement(children as React.ReactElement, props)
+    ) : (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    ),
+}))
+
+vi.mock('@/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuButtonTrigger: ({ label }: { label: string }) => (
+    <button type="button">{label}</button>
+  ),
+  DropdownMenuCheckboxItem: ({
+    children,
+    checked,
+    onSelect,
+  }: {
+    children: React.ReactNode
+    checked?: boolean
+    onSelect?: (event: { preventDefault: () => void }) => void
+  }) => (
+    <button
+      type="button"
+      aria-checked={checked}
+      role="menuitemcheckbox"
+      onClick={() => onSelect?.({ preventDefault: vi.fn() })}
+    >
+      {children}
+    </button>
+  ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuRadioGroup: ({
+    children,
+    onValueChange,
+  }: {
+    children: React.ReactNode
+    onValueChange: (value: string) => void
+  }) => (
+    <div>
+      {Children.map(children, (child) =>
+        cloneElement(child as React.ReactElement<{ onValueChange?: (value: string) => void }>, {
+          onValueChange,
+        }),
+      )}
+    </div>
+  ),
+  DropdownMenuRadioItem: ({
+    children,
+    value,
+    onValueChange,
+  }: {
+    children: React.ReactNode
+    value?: string
+    onValueChange?: (value: string) => void
+  }) => (
+    <button type="button" onClick={() => onValueChange?.(value ?? '')}>
+      {children}
+    </button>
+  ),
+}))
+
+const { GalleryControls } = await import('@/gallery/gallery-controls')
+
+afterEach(() => {
+  navigate.mockClear()
+  capture.mockClear()
+})
+
+describe('GalleryControls analytics', () => {
+  it('captures a tag addition with the resulting filter state', () => {
+    render(<GalleryControls sort="trending" tags={[]} available={['git']} />)
+
+    fireEvent.click(screen.getByRole('menuitemcheckbox', { name: 'Git' }))
+
+    expect(capture).toHaveBeenCalledWith('gallery_filter_changed', {
+      action: 'add',
+      tag: 'git',
+      selectedTags: ['git'],
+      sort: 'trending',
+      page: 1,
+    })
+  })
+
+  it('captures a tag removal with the resulting filter state', () => {
+    render(<GalleryControls sort="new" tags={['git']} available={['git']} />)
+
+    fireEvent.click(screen.getByRole('menuitemcheckbox', { name: 'Git' }))
+
+    expect(capture).toHaveBeenCalledWith('gallery_filter_changed', {
+      action: 'remove',
+      tag: 'git',
+      selectedTags: [],
+      sort: 'new',
+      page: 1,
+    })
+  })
+
+  it('captures clearing filters', () => {
+    render(<GalleryControls sort="top" tags={['git']} available={['git']} />)
+
+    fireEvent.click(screen.getByRole('link', { name: 'Clear filters' }))
+
+    expect(capture).toHaveBeenCalledWith('gallery_filter_changed', {
+      action: 'clear',
+      selectedTags: [],
+      sort: 'top',
+      page: 1,
+    })
+  })
+
+  it('captures sort changes with the active filter state', () => {
+    render(<GalleryControls sort="trending" tags={['git']} available={['git']} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Top' }))
+
+    expect(capture).toHaveBeenCalledWith('gallery_sort_changed', {
+      sort: 'top',
+      selectedTags: ['git'],
+      page: 1,
+    })
+  })
+})

--- a/test/lib/posthog-identity.test.ts
+++ b/test/lib/posthog-identity.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { identifyPostHogUser } from '@/lib/posthog-identity'
+import { PENDING_AUTH_KEY } from '@/lib/sign-in'
+
+const identify = vi.fn()
+const capture = vi.fn()
+const posthog = { identify, capture }
+
+beforeEach(() => {
+  window.sessionStorage.clear()
+  identify.mockClear()
+  capture.mockClear()
+})
+
+describe('identifyPostHogUser', () => {
+  it('identifies the user and captures the completed OAuth intent', () => {
+    window.sessionStorage.setItem(
+      PENDING_AUTH_KEY,
+      JSON.stringify({ entryPoint: 'submit', returnPath: '/submit' }),
+    )
+
+    identifyPostHogUser(posthog, { id: 'user-1', name: 'Nate', username: 'nate' })
+
+    expect(identify).toHaveBeenCalledWith('user-1', { name: 'nate', username: 'nate' })
+    expect(capture).toHaveBeenCalledWith('auth_completed', {
+      provider: 'github',
+      entryPoint: 'submit',
+      returnPath: '/submit',
+      $current_url: '/submit',
+    })
+  })
+
+  it('does not emit completion without a pending OAuth intent', () => {
+    identifyPostHogUser(posthog, { id: 'user-1', name: 'Nate', username: null })
+
+    expect(identify).toHaveBeenCalledWith('user-1', { name: 'Nate', username: null })
+    expect(capture).not.toHaveBeenCalled()
+  })
+})

--- a/test/lib/sign-in-analytics.test.ts
+++ b/test/lib/sign-in-analytics.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/auth-client', () => ({
+  authClient: { signIn: { social: vi.fn().mockResolvedValue(undefined) } },
+}))
+
+const { consumePendingAuthIntent, startGitHubSignIn } = await import('@/lib/sign-in')
+
+beforeEach(() => window.sessionStorage.clear())
+
+describe('startGitHubSignIn analytics context', () => {
+  it('stores the pending entry point across the OAuth redirect', () => {
+    startGitHubSignIn('/submit', 'submit')
+
+    expect(JSON.parse(window.sessionStorage.getItem('statuslines.pending-auth') ?? 'null')).toEqual(
+      {
+        entryPoint: 'submit',
+        returnPath: '/submit',
+      },
+    )
+  })
+
+  it('consumes a valid pending intent once', () => {
+    startGitHubSignIn('/c/example', 'upvote')
+
+    expect(consumePendingAuthIntent()).toEqual({
+      entryPoint: 'upvote',
+      returnPath: '/c/example',
+    })
+    expect(consumePendingAuthIntent()).toBeNull()
+  })
+
+  it('drops malformed pending intent data', () => {
+    window.sessionStorage.setItem(
+      'statuslines.pending-auth',
+      JSON.stringify({ entryPoint: 'unknown', returnPath: '/submit' }),
+    )
+
+    expect(consumePendingAuthIntent()).toBeNull()
+    expect(window.sessionStorage.getItem('statuslines.pending-auth')).toBeNull()
+  })
+})

--- a/test/lib/sign-in.test.ts
+++ b/test/lib/sign-in.test.ts
@@ -2,13 +2,20 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 // Spy on the Better Auth social sign-in so we can assert the redirect args without a network call.
 const socialSignIn = vi.fn().mockResolvedValue(undefined)
+const capture = vi.fn()
 vi.mock('@/lib/auth-client', () => ({
   authClient: { signIn: { social: (opts: unknown) => socialSignIn(opts) } },
+}))
+vi.mock('@posthog/react', () => ({
+  usePostHog: () => ({ capture }),
 }))
 
 const { startGitHubSignIn } = await import('@/lib/sign-in')
 
-afterEach(() => socialSignIn.mockClear())
+afterEach(() => {
+  socialSignIn.mockClear()
+  capture.mockClear()
+})
 
 describe('startGitHubSignIn', () => {
   it('starts GitHub OAuth returning to the given path', () => {
@@ -24,5 +31,26 @@ describe('startGitHubSignIn', () => {
   it('defaults to "/" when no path is given', () => {
     startGitHubSignIn()
     expect(socialSignIn).toHaveBeenCalledWith({ provider: 'github', callbackURL: '/' })
+  })
+
+  it('tracks the entry point and return path when OAuth starts', () => {
+    startGitHubSignIn('/submit', 'submit', { capture })
+    expect(capture).toHaveBeenCalledWith('auth_started', {
+      provider: 'github',
+      entryPoint: 'submit',
+      returnPath: '/submit',
+      $current_url: '/submit',
+    })
+  })
+
+  it('does not send query parameters in auth analytics', () => {
+    startGitHubSignIn('/?tags=git&private=secret', 'header', { capture })
+
+    expect(capture).toHaveBeenCalledWith('auth_started', {
+      provider: 'github',
+      entryPoint: 'header',
+      returnPath: '/',
+      $current_url: '/',
+    })
   })
 })

--- a/test/ui/stretched-link.test.tsx
+++ b/test/ui/stretched-link.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 // TanStack Router's <Link> needs a router context; stub it to a plain anchor that
@@ -46,6 +46,19 @@ describe('StretchedLink', () => {
     ]) {
       expect(a.className.split(/\s+/)).toContain(cls)
     }
+  })
+
+  it('forwards an internal-link click handler', () => {
+    const onClick = vi.fn()
+    const { container } = render(
+      <StretchedLink to="/c/$slug" params={{ slug: 'abc' }} onClick={onClick}>
+        Title
+      </StretchedLink>,
+    )
+
+    fireEvent.click(container.querySelector('a') as HTMLAnchorElement)
+
+    expect(onClick).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/test/ui/submit-cta.test.tsx
+++ b/test/ui/submit-cta.test.tsx
@@ -4,8 +4,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 // Spy on the Better Auth social sign-in so we can assert the one-click redirect when signed out.
 const socialSignIn = vi.fn().mockResolvedValue(undefined)
+const capture = vi.fn()
 vi.mock('@/lib/auth-client', () => ({
   authClient: { signIn: { social: (opts: unknown) => socialSignIn(opts) } },
+}))
+vi.mock('@posthog/react', () => ({
+  usePostHog: () => ({ capture }),
 }))
 
 // TanStack Router's <Link> needs a router context; stub it to a plain anchor so the
@@ -20,7 +24,10 @@ vi.mock('@tanstack/react-router', () => ({
 
 const { SubmitCta } = await import('@/ui/submit-cta')
 
-afterEach(() => socialSignIn.mockClear())
+afterEach(() => {
+  socialSignIn.mockClear()
+  capture.mockClear()
+})
 
 describe('SubmitCta', () => {
   it('links to the submit form when signed in', () => {
@@ -37,5 +44,11 @@ describe('SubmitCta', () => {
     expect(screen.queryByRole('link', { name: /submit a status line/i })).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: /submit a status line/i }))
     expect(socialSignIn).toHaveBeenCalledWith({ provider: 'github', callbackURL: '/submit' })
+    expect(capture).toHaveBeenCalledWith('auth_started', {
+      provider: 'github',
+      entryPoint: 'submit',
+      returnPath: '/submit',
+      $current_url: '/submit',
+    })
   })
 })

--- a/test/votes/upvote-button.test.tsx
+++ b/test/votes/upvote-button.test.tsx
@@ -4,8 +4,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 // Spy on the Better Auth social sign-in so we can assert the signed-out one-click redirect.
 const socialSignIn = vi.fn().mockResolvedValue(undefined)
+const capture = vi.fn()
 vi.mock('@/lib/auth-client', () => ({
   authClient: { signIn: { social: (opts: unknown) => socialSignIn(opts) } },
+}))
+vi.mock('@posthog/react', () => ({
+  usePostHog: () => ({ capture }),
 }))
 
 // The component reaches for the router at render time; stub it so it renders in isolation.
@@ -24,7 +28,10 @@ vi.mock('@/votes/functions', () => ({ toggleVoteFn: vi.fn() }))
 
 const { UpvoteButton } = await import('@/votes/upvote-button')
 
-afterEach(() => socialSignIn.mockClear())
+afterEach(() => {
+  socialSignIn.mockClear()
+  capture.mockClear()
+})
 
 describe('UpvoteButton (signed out)', () => {
   it('starts GitHub sign-in returning to the config page, not a link to /login', () => {
@@ -42,5 +49,11 @@ describe('UpvoteButton (signed out)', () => {
     expect(screen.queryByRole('link', { name: /sign in to vote/i })).toBeNull()
     fireEvent.click(screen.getByRole('button', { name: /sign in to vote/i }))
     expect(socialSignIn).toHaveBeenCalledWith({ provider: 'github', callbackURL: '/c/cool-line' })
+    expect(capture).toHaveBeenCalledWith('auth_started', {
+      provider: 'github',
+      entryPoint: 'upvote',
+      returnPath: '/c/cool-line',
+      $current_url: '/c/cool-line',
+    })
   })
 })


### PR DESCRIPTION
## Summary
- track gallery filter, sort, pagination, and discovery interactions in PostHog
- connect GitHub sign-in starts and completions with their originating intent
- add focused analytics coverage and repository scope-control guidance

## Changes
- capture tag additions, removals, filter clears, sort changes, and page changes with active gallery context
- capture home, facet, and related-card discovery with stable config IDs and positions
- persist safe OAuth intent across redirects and emit `auth_started` / `auth_completed` events
- extend card data and stretched links only where needed for analytics attribution

## Verification
- `bun run check`
- pre-push `bun run check:ci`
- 867 tests passed, 7 skipped