### PR TITLE
Fix Search Console indexing issues

### DIFF
--- a/src/gallery/generated-content.tsx
+++ b/src/gallery/generated-content.tsx
@@ -19,7 +19,7 @@ export function GeneratedContentSections({ content }: { content: GeneratedConten
   return (
     <>
       {sections.map((s) => (
-        <SectionCard key={s.key} title={s.title}>
+        <SectionCard key={s.key} title={s.title} headingLevel={2}>
           <BulletList items={content[s.key]} />
         </SectionCard>
       ))}

--- a/src/lib/canonical.ts
+++ b/src/lib/canonical.ts
@@ -21,6 +21,19 @@ export function isFilteredHomeSearch(search: HomeCanonicalSearch): boolean {
   return search.sort !== undefined || search.tags !== undefined
 }
 
+/** Search params for gallery pagination links. The default trending sort is implicit, so keeping
+ * it out of the URL prevents an unfiltered page from being mistaken for a noindex sorted view. */
+export function homePaginationSearch<TSort extends string>(
+  page: number,
+  search: { sort?: TSort; tags?: string } = {},
+): { page?: number; sort?: TSort; tags?: string } {
+  return {
+    ...(search.sort && search.sort !== 'trending' ? { sort: search.sort } : {}),
+    ...(page > 1 ? { page } : {}),
+    ...(search.tags ? { tags: search.tags } : {}),
+  }
+}
+
 /**
  * Canonical path for the gallery home. Preserve sort, tag, and page state so a paginated URL never
  * canonicalizes to different content. Filtered and sorted views get noindex metadata at the route

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -401,10 +401,11 @@ export const routeTree = rootRouteImport
   ._addFileTypes<FileRouteTypes>()
 
 import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
+import type { startInstance } from './start.ts'
 declare module '@tanstack/react-start' {
   interface Register {
     ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }
 }

--- a/src/routes/c.$slug.tsx
+++ b/src/routes/c.$slug.tsx
@@ -165,7 +165,7 @@ function ConfigDetail() {
         />
 
         {/* All scenarios, stacked */}
-        <SectionCard title="Preview">
+        <SectionCard title="Preview" headingLevel={2}>
           {orderedPreviews.length > 0 ? (
             <Stack gap={3}>
               {orderedPreviews.map((p) => {
@@ -190,6 +190,7 @@ function ConfigDetail() {
         {/* Source */}
         <SectionCard
           title="Source"
+          headingLevel={2}
           action={<CopyScriptButton source={detail.source} configId={detail.id} />}
         >
           <HighlightedCode html={detail.sourceHtml} />
@@ -200,7 +201,7 @@ function ConfigDetail() {
 
         {/* Internal links: without these, every config page is a crawl dead end. */}
         {detail.related.length > 0 && (
-          <SectionCard title="More status lines">
+          <SectionCard title="More status lines" headingLevel={2}>
             <Stack gap={3}>
               {detail.related.map((r, index) => (
                 <Card key={r.slug} interactive>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -5,7 +5,12 @@ import { getGallery } from '@/gallery/functions'
 import { GalleryControls } from '@/gallery/gallery-controls'
 import { coercePage, coerceSort, coerceTags, type GallerySort } from '@/gallery/queries'
 import { getSession } from '@/lib/auth-functions'
-import { canonicalLink, homeCanonicalPath, isFilteredHomeSearch } from '@/lib/canonical'
+import {
+  canonicalLink,
+  homeCanonicalPath,
+  homePaginationSearch,
+  isFilteredHomeSearch,
+} from '@/lib/canonical'
 import { homeJsonLd, jsonLdScript } from '@/lib/json-ld'
 import { HOME_TITLE_BASE } from '@/lib/page-title'
 import { siteUrl } from '@/lib/site'
@@ -116,7 +121,10 @@ function Home() {
                 <Link
                   to="/"
                   onClick={() => trackPageChange(page - 1)}
-                  search={{ sort, page: page - 1, ...(tags ? { tags } : {}) }}
+                  search={homePaginationSearch(page - 1, {
+                    sort,
+                    ...(tags ? { tags } : {}),
+                  })}
                 >
                   ← Previous
                 </Link>
@@ -130,7 +138,10 @@ function Home() {
                 <Link
                   to="/"
                   onClick={() => trackPageChange(page + 1)}
-                  search={{ sort, page: page + 1, ...(tags ? { tags } : {}) }}
+                  search={homePaginationSearch(page + 1, {
+                    sort,
+                    ...(tags ? { tags } : {}),
+                  })}
                 >
                   Next →
                 </Link>

--- a/src/server/template-path-guard.ts
+++ b/src/server/template-path-guard.ts
@@ -1,0 +1,29 @@
+import { createMiddleware } from '@tanstack/react-start'
+
+/** Detect an unexpanded shell/template marker in a request pathname. Query values and request
+ * bodies are intentionally out of scope: only malformed paths can trigger the router loop. */
+export function hasUnexpandedTemplatePath(url: string): boolean {
+  const rawPath = url.split(/[?#]/, 1)[0] ?? ''
+  if (/\$\{[^}]+\}/.test(rawPath)) return true
+
+  try {
+    const pathname = new URL(url, 'http://localhost').pathname
+    try {
+      return /\$\{[^}]+\}/.test(decodeURIComponent(pathname))
+    } catch {
+      return false
+    }
+  } catch {
+    return false
+  }
+}
+
+/** Stop malformed template paths before the application router can normalize them into a
+ * self-redirect. Normal requests continue through the request middleware chain. */
+export const templatePathGuardMiddleware = createMiddleware().server(({ request, next }) => {
+  if (hasUnexpandedTemplatePath(request.url)) {
+    return new Response('Not Found', { status: 404 })
+  }
+
+  return next()
+})

--- a/src/server/template-path-guard.ts
+++ b/src/server/template-path-guard.ts
@@ -1,18 +1,27 @@
 import { createMiddleware } from '@tanstack/react-start'
 
+const UNEXPANDED_TEMPLATE_PATTERN = /\$\{[^}]+\}/
+
+function decodePercentTokens(pathname: string): string {
+  const decoded = pathname.replace(/%([0-9a-f]{2})/gi, (_, hex: string) =>
+    String.fromCharCode(Number.parseInt(hex, 16)),
+  )
+
+  return Array.from(decoded, (character) => {
+    const code = character.charCodeAt(0)
+    return code <= 31 || code === 127 ? '' : character
+  }).join('')
+}
+
 /** Detect an unexpanded shell/template marker in a request pathname. Query values and request
  * bodies are intentionally out of scope: only malformed paths can trigger the router loop. */
 export function hasUnexpandedTemplatePath(url: string): boolean {
   const rawPath = url.split(/[?#]/, 1)[0] ?? ''
-  if (/\$\{[^}]+\}/.test(rawPath)) return true
+  if (UNEXPANDED_TEMPLATE_PATTERN.test(rawPath)) return true
 
   try {
     const pathname = new URL(url, 'http://localhost').pathname
-    try {
-      return /\$\{[^}]+\}/.test(decodeURIComponent(pathname))
-    } catch {
-      return false
-    }
+    return UNEXPANDED_TEMPLATE_PATTERN.test(decodePercentTokens(pathname))
   } catch {
     return false
   }

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,0 +1,11 @@
+import { createCsrfMiddleware, createStart } from '@tanstack/react-start'
+
+import { templatePathGuardMiddleware } from './server/template-path-guard'
+
+const csrfMiddleware = createCsrfMiddleware({
+  filter: (context) => context.handlerType === 'serverFn',
+})
+
+export const startInstance = createStart(() => ({
+  requestMiddleware: [templatePathGuardMiddleware, csrfMiddleware],
+}))

--- a/src/ui/card.tsx
+++ b/src/ui/card.tsx
@@ -47,10 +47,10 @@ function CardHeader({ children }: { children?: React.ReactNode }) {
   )
 }
 
-// The card / section-card title. Renders through Heading (level 3) so card titles are
-// real <h3>s and their look lives with every other heading, not as ad-hoc classes here.
-function CardTitle({ children }: { children?: React.ReactNode }) {
-  return <Heading level={3}>{children}</Heading>
+// The card / section-card title. Card titles default to h3; top-level page sections can opt into
+// h2 without bypassing this closed component or restating heading styles.
+function CardTitle({ level = 3, children }: { level?: 2 | 3; children?: React.ReactNode }) {
+  return <Heading level={level}>{children}</Heading>
 }
 
 // data-slot stays on the wrapper because CardHeader's grid selects it; the text itself

--- a/src/ui/section-card.tsx
+++ b/src/ui/section-card.tsx
@@ -11,11 +11,13 @@ import { Row } from '@/ui/layout'
 export function SectionCard({
   title,
   action,
+  headingLevel = 3,
   interactive = false,
   children,
 }: {
   title: React.ReactNode
   action?: React.ReactNode
+  headingLevel?: 2 | 3
   /** Adds the gallery hover/lift treatment so a stretched-link title makes the whole card clickable. */
   interactive?: boolean
   children: React.ReactNode
@@ -24,7 +26,7 @@ export function SectionCard({
     <Card interactive={interactive}>
       <CardHeader>
         <Row gap={3} justify="between">
-          <CardTitle>{title}</CardTitle>
+          <CardTitle level={headingLevel}>{title}</CardTitle>
           {action}
         </Row>
       </CardHeader>

--- a/test/gallery/generated-content.test.tsx
+++ b/test/gallery/generated-content.test.tsx
@@ -14,9 +14,9 @@ const CONTENT: GeneratedContent = {
 describe('GeneratedContentSections', () => {
   it('renders the three section titles and their items', () => {
     render(<GeneratedContentSections content={CONTENT} />)
-    expect(screen.getByText('What it shows')).toBeTruthy()
-    expect(screen.getByText('Requirements')).toBeTruthy()
-    expect(screen.getByText('Behavior notes')).toBeTruthy()
+    expect(screen.getByRole('heading', { level: 2, name: 'What it shows' })).toBeTruthy()
+    expect(screen.getByRole('heading', { level: 2, name: 'Requirements' })).toBeTruthy()
+    expect(screen.getByRole('heading', { level: 2, name: 'Behavior notes' })).toBeTruthy()
     expect(screen.getByText('jq on PATH')).toBeTruthy()
   })
 

--- a/test/lib/canonical.test.ts
+++ b/test/lib/canonical.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { canonicalLink, homeCanonicalPath } from '@/lib/canonical'
+import { canonicalLink, homeCanonicalPath, homePaginationSearch } from '@/lib/canonical'
 
 const ORIGINAL = process.env.BETTER_AUTH_URL
 afterEach(() => {
@@ -33,5 +33,18 @@ describe('homeCanonicalPath', () => {
     expect(homeCanonicalPath(1, { sort: 'new' })).toBe('/?sort=new')
     expect(homeCanonicalPath(2, { sort: 'top' })).toBe('/?sort=top&page=2')
     expect(homeCanonicalPath(2, { tags: 'git' })).toBe('/?tags=git&page=2')
+  })
+})
+
+describe('homePaginationSearch', () => {
+  it('omits the default sort so unfiltered pages stay indexable', () => {
+    expect(homePaginationSearch(2)).toEqual({ page: 2 })
+    expect(homePaginationSearch(2, { sort: 'trending' })).toEqual({ page: 2 })
+    expect(homePaginationSearch(1, { sort: 'trending' })).toEqual({})
+  })
+
+  it('preserves explicit sorts and tag filters', () => {
+    expect(homePaginationSearch(2, { sort: 'top' })).toEqual({ sort: 'top', page: 2 })
+    expect(homePaginationSearch(2, { tags: 'git' })).toEqual({ page: 2, tags: 'git' })
   })
 })

--- a/test/server/template-path-guard.test.ts
+++ b/test/server/template-path-guard.test.ts
@@ -17,6 +17,14 @@ describe('hasUnexpandedTemplatePath', () => {
     expect(hasUnexpandedTemplatePath(`/tmp/cache-${TEMPLATE_MARKER}.json/%ZZ`)).toBe(true)
   })
 
+  it('detects an encoded marker even when another segment has malformed encoding', () => {
+    expect(hasUnexpandedTemplatePath('/tmp/cache-%24%7Bname%7D.json/%ZZ')).toBe(true)
+  })
+
+  it('detects a marker separated by an encoded control character', () => {
+    expect(hasUnexpandedTemplatePath('/tmp/cache-$%0D%7Bname%7D.json')).toBe(true)
+  })
+
   it('allows ordinary dollar signs and template markers outside the pathname', () => {
     expect(hasUnexpandedTemplatePath('/price/$5')).toBe(false)
     expect(hasUnexpandedTemplatePath(`/c/activity-feed?value=${TEMPLATE_MARKER}`)).toBe(false)

--- a/test/server/template-path-guard.test.ts
+++ b/test/server/template-path-guard.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  hasUnexpandedTemplatePath,
+  templatePathGuardMiddleware,
+} from '@/server/template-path-guard'
+
+const TEMPLATE_MARKER = '$' + '{name}'
+
+describe('hasUnexpandedTemplatePath', () => {
+  it('detects raw and encoded shell template markers in the pathname', () => {
+    expect(hasUnexpandedTemplatePath(`/tmp/cache-${TEMPLATE_MARKER}.json`)).toBe(true)
+    expect(hasUnexpandedTemplatePath('/tmp/cache-%24%7Bname%7D.json')).toBe(true)
+  })
+
+  it('detects a raw marker even when another segment has malformed encoding', () => {
+    expect(hasUnexpandedTemplatePath(`/tmp/cache-${TEMPLATE_MARKER}.json/%ZZ`)).toBe(true)
+  })
+
+  it('allows ordinary dollar signs and template markers outside the pathname', () => {
+    expect(hasUnexpandedTemplatePath('/price/$5')).toBe(false)
+    expect(hasUnexpandedTemplatePath(`/c/activity-feed?value=${TEMPLATE_MARKER}`)).toBe(false)
+  })
+})
+
+describe('templatePathGuardMiddleware', () => {
+  it('returns a 404 before continuing an unexpanded template path', async () => {
+    const next = vi.fn()
+    const request = new Request(`http://localhost/tmp/cache-${TEMPLATE_MARKER}.json`)
+    const response = await templatePathGuardMiddleware.options.server?.({
+      request,
+      pathname: `/tmp/cache-${TEMPLATE_MARKER}.json`,
+      context: undefined,
+      handlerType: 'router',
+      next,
+    })
+
+    expect(response).toEqual(expect.objectContaining({ status: 404 }))
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('continues ordinary routes', async () => {
+    const downstream = {
+      request: new Request('http://localhost/c/activity-feed'),
+      pathname: '/c/activity-feed',
+      context: undefined,
+      response: new Response(null, { status: 204 }),
+    }
+    const next = vi.fn().mockResolvedValue(downstream)
+    const response = await templatePathGuardMiddleware.options.server?.({
+      request: downstream.request,
+      pathname: downstream.pathname,
+      context: undefined,
+      handlerType: 'router',
+      next,
+    })
+
+    expect(response).toBe(downstream)
+    expect(next).toHaveBeenCalledOnce()
+  })
+})

--- a/test/ui/section-card.test.tsx
+++ b/test/ui/section-card.test.tsx
@@ -12,8 +12,17 @@ describe('SectionCard', () => {
         <p>body</p>
       </SectionCard>,
     )
-    expect(screen.getByText('Preview')).toBeTruthy()
+    expect(screen.getByRole('heading', { level: 3, name: 'Preview' })).toBeTruthy()
     expect(screen.getByText('body')).toBeTruthy()
+  })
+
+  it('renders a level-two heading when the page hierarchy requires it', () => {
+    render(
+      <SectionCard headingLevel={2} title="Source">
+        <p>body</p>
+      </SectionCard>,
+    )
+    expect(screen.getByRole('heading', { level: 2, name: 'Source' })).toBeTruthy()
   })
 
   it('renders an action next to the title when provided', () => {


### PR DESCRIPTION
## Summary

- keep default gallery pagination discoverable by omitting the implicit trending sort parameter
- reject unexpanded template paths before router normalization can create a redirect loop
- restore a semantic H1 → H2 → H3 hierarchy on config detail pages

## Changes

- centralize pagination search construction and cover default, sorted, and tagged views
- add early TanStack Start request middleware while retaining server-function CSRF protection
- allow section cards to opt into H2 headings without changing their H3 default
- add regression coverage for pagination, malformed paths, and heading levels