### PR TITLE
feat: rank status lines by anonymous copies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # statuslin.es
 
-Community gallery of Claude Code status lines — browse configs as rendered previews, upvote, and copy one to use.
+Community gallery of Claude Code status lines — browse configs as rendered previews and copy one to use.
 
 > **This is an agent-first codebase.** Most changes are written by AI agents. The standards below are enforced mechanically (linter, typecheck, tests, git hooks, CI) **and** by every agent on itself. Do not bypass the gates — no `git commit --no-verify`, no skipping tests, no claiming "done" without showing green output in the same message.
 
@@ -13,7 +13,7 @@ Bun (runtime + toolchain) · Vite · TanStack Start (React, SSR) · Better Auth 
 The lifecycle of a config: **submit** (`src/submit`) → a render job is **queued** → the
 `worker` renders it in the E2B sandbox (`src/render`) → it lands in the **review queue**
 (`src/review`) → an admin publishes → it appears in the **gallery** (`src/gallery`),
-where visitors **upvote** (`src/votes`) and **copy it to use** (`src/adopt`).
+where visitors **copy it to use** (`src/adopt`).
 
 `src/` map (one responsibility each):
 - `routes/` — TanStack Start file-based routes: pages + API handlers
@@ -21,7 +21,7 @@ where visitors **upvote** (`src/votes`) and **copy it to use** (`src/adopt`).
 - `render/` — render pipeline: real E2B runner, fake runner (tests/no key), ANSI parsing, scenarios
 - `review/` — admin review queue and publish/reject decisions
 - `gallery/` — gallery list queries
-- `votes/` — upvoting · `adopt/` — copy/install a config
+- `votes/` — retained legacy voting code · `adopt/` — copy/install a config
 - `og/` — Open Graph card images · `legal/` — terms page
 - `db/` — Drizzle schema + migration client · `lib/` — shared utils (`env.ts`)
 - `ui/` — closed design-system components · `styles/` — tokens (`app.css`)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # statuslin.es
 
 A community gallery of [Claude Code](https://claude.com/claude-code) status lines. Browse real configs as
-**rendered previews**, upvote the good ones, and copy one to your terminal. You see what each script
+**rendered previews**, see which ones people copy, and copy one to your terminal. You see what each script
 actually renders to before you copy it, instead of guessing from the source.
 
 Live at **[statuslin.es](https://statuslin.es)**.

--- a/docs/testing-signed-in.md
+++ b/docs/testing-signed-in.md
@@ -1,6 +1,6 @@
 # Testing signed-in UX
 
-Auth is GitHub-only, so an automated browser can't reach the signed-in pages (vote, submit, admin) by clicking "Sign in" — GitHub OAuth can't be driven headlessly. Instead, mint a session directly and set its cookie. This is **dev-only** (it bypasses login by signing a cookie with `BETTER_AUTH_SECRET`); never expose it anywhere real.
+Auth is GitHub-only, so an automated browser can't reach the signed-in submission and admin pages by clicking "Sign in" — GitHub OAuth can't be driven headlessly. Instead, mint a session directly and set its cookie. This is **dev-only** (it bypasses login by signing a cookie with `BETTER_AUTH_SECRET`); never expose it anywhere real.
 
 ## TL;DR
 
@@ -12,8 +12,8 @@ bun run dev:login "Ada"      # by name
 bun run dev:login me@x.com   # by email
 # 3. copy the printed `agent-browser cookies set ...` line and run it
 # 4. drive the browser — now signed in:
-agent-browser open http://localhost:3100/c/<slug>
-agent-browser snapshot          # the upvote shows as a Button, not a Sign-in link
+agent-browser open http://localhost:3100/submit
+agent-browser snapshot          # the submission form is available
 ```
 
 `bun run dev:login` (`scripts/dev-login.ts`) inserts a row in the Better Auth `session` table for the chosen user and prints the **signed** `better-auth.session_token` cookie plus a ready `agent-browser cookies set …` command.
@@ -33,30 +33,19 @@ Standard base64 (`+/=`), **not** base64url. This matches better-call's `signCook
 The cookie is **httpOnly**, so JavaScript (`document.cookie`) can't set it — use
 `agent-browser cookies set … --httpOnly` (CDP), which the helper's printed command does.
 
-## Gotcha that bit us (2026-06-06)
-
-The signed-in detail page 500'd with `Failed query: select … from "votes"`. The `votes`
-migration was committed but never applied to the **dev** DB — the test suite uses PGlite (which
-auto-runs migrations), so the gate stayed green and hid it. Signed-out browsing didn't touch the
-table, so it only showed up signed in.
-
-**Always `bun run db:migrate` against the dev DB after adding a migration.** Signed-in testing is
-how you catch the gap, because a signed-in page often reads tables a signed-out one doesn't.
-
-## Full vote example (verified end-to-end)
+## Submission example
 
 ```bash
 bun run db:migrate
 COOKIE=$(bun run dev:login | sed -n 's/better-auth.session_token=//p')
 agent-browser cookies set better-auth.session_token "$COOKIE" --url http://localhost:3100 --httpOnly
-agent-browser open http://localhost:3100/c/<slug>
-agent-browser snapshot                      # find the "Upvote" button's @ref
-agent-browser click @<ref>                   # → "Remove upvote", count +1
-agent-browser click @<ref>                   # → "Upvote", count back down
+agent-browser open http://localhost:3100/submit
+agent-browser snapshot
 ```
 
-The count is recomputed from the actual `votes` rows on every toggle, so a seeded/denormalized
-count will self-correct to the real number on the first real vote.
+Always run `bun run db:migrate` against the dev database after adding a migration. PGlite-backed
+tests apply committed migrations independently, so signed-in browser testing catches a stale dev
+database before it hides a submission or admin issue.
 
 ## Cleanup
 

--- a/scripts/loadtest/seed.ts
+++ b/scripts/loadtest/seed.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
 import { eq, like } from 'drizzle-orm'
 import type { PgDatabase } from 'drizzle-orm/pg-core'
-import { configs, configVersions, user } from '@/db/schema'
+import { configs, configVersions, copyEvents, user } from '@/db/schema'
 import { assertNotProduction } from '@/lib/env'
 import { highlightSource } from '@/lib/highlight'
 import { SCENARIOS } from '@/render/scenarios'
@@ -13,7 +13,8 @@ type Db = PgDatabase<any, typeof import('@/db/schema')>
 
 /**
  * Volume seeder for load testing. Creates N *published* configs (slugs `loadtest-0001…`) with
- * varied upvote/copy/created-at so all three gallery sorts produce realistic orderings, and a
+ * varied copy-event/copy-count/created-at data so all three gallery sorts produce realistic
+ * orderings, and a
  * full set of previews (all 8 scenarios) per config so both the gallery card and the detail page
  * render. Inserts directly — it deliberately does NOT go through `submitConfig`, whose 10/hour
  * per-author rate limit (src/submit/submit.ts) would block volume seeding, nor through the E2B
@@ -141,8 +142,9 @@ export async function seedLoadConfigs(db: Db, opts: { count: number }): Promise<
     if (!author) throw new Error('no load-test author available')
     const source = buildSource(i)
     const contentSha256 = createHash('sha256').update(source).digest('hex')
-    // Spread created-at back in time and vary the counters so new/top/trending all differ.
+    // Spread submission and copy-event times independently so new/top/trending all differ.
     const createdAt = new Date(base - i * MS_PER_HOUR)
+    const eventCount = ((i * 5) % 11) + 1
 
     const [cfg] = await db
       .insert(configs)
@@ -154,11 +156,19 @@ export async function seedLoadConfigs(db: Db, opts: { count: number }): Promise<
         interpreter: 'bash',
         status: 'published',
         upvoteCount: (i * 37) % 300,
-        copyCount: (i * 53) % 500,
+        copyCount: eventCount,
         createdAt,
       })
       .returning()
     if (!cfg) throw new Error(`insert configs returned no row for ${slug}`)
+
+    await db.insert(copyEvents).values(
+      Array.from({ length: eventCount }, (_, j) => ({
+        configId: cfg.id,
+        ipHash: `loadtest:${i}:${j}`,
+        createdAt: new Date(base - ((i * 3 + j * 11) % 336) * MS_PER_HOUR),
+      })),
+    )
 
     const [ver] = await db
       .insert(configVersions)

--- a/src/adopt/adopt-actions.tsx
+++ b/src/adopt/adopt-actions.tsx
@@ -2,26 +2,25 @@ import { Check, Copy } from 'lucide-react'
 import { useState } from 'react'
 import { toast } from 'sonner'
 import { buildClaudePrompt } from '@/adopt/install'
-import { useRecordedCopy } from '@/adopt/use-recorded-copy'
+import type { RecordedCopyController } from '@/adopt/use-recorded-copy'
 import type { Interpreter } from '@/render/types'
 import { Button } from '@/ui/button'
+import { CopyCount } from '@/ui/copy-count'
 import { Row } from '@/ui/layout'
 
 interface AdoptPromptProps {
   source: string
   interpreter: Interpreter
   title: string
-  configId: string
-  copyCount: number
+  controller: RecordedCopyController
 }
 
 /** Title-row adopt control: primary "Copy install prompt" button + the displayed copy count. */
-export function AdoptPrompt({ source, interpreter, title, configId, copyCount }: AdoptPromptProps) {
-  const { copy } = useRecordedCopy(configId, copyCount)
+export function AdoptPrompt({ source, interpreter, title, controller }: AdoptPromptProps) {
   const [copied, setCopied] = useState(false)
 
   function copyPrompt() {
-    copy(buildClaudePrompt({ source, interpreter, title }), 'prompt', () => {
+    controller.copy(buildClaudePrompt({ source, interpreter, title }), 'prompt', () => {
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
       toast('Prompt copied', {
@@ -36,24 +35,22 @@ export function AdoptPrompt({ source, interpreter, title, configId, copyCount }:
         {copied ? <Check /> : <Copy />}
         {copied ? 'Copied!' : 'Copy install prompt'}
       </Button>
+      <CopyCount count={controller.count} />
     </Row>
   )
 }
 
 interface CopyScriptButtonProps {
   source: string
-  configId: string
+  controller: RecordedCopyController
 }
 
-/** Source-card control: outline button copying the raw script. Records the copy too, but the
- *  count it bumps is its own instance — the title-row count won't reflect a script copy until
- *  the page reloads. That's acceptable: the count is an approximate signal. */
-export function CopyScriptButton({ source, configId }: CopyScriptButtonProps) {
-  const { copy } = useRecordedCopy(configId, 0)
+/** Source-card control: outline button copying raw source through the page's shared recorder. */
+export function CopyScriptButton({ source, controller }: CopyScriptButtonProps) {
   const [copied, setCopied] = useState(false)
 
   function copyScript() {
-    copy(source, 'script', () => {
+    controller.copy(source, 'script', () => {
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     })

--- a/src/adopt/use-recorded-copy.ts
+++ b/src/adopt/use-recorded-copy.ts
@@ -1,7 +1,12 @@
 import { usePostHog } from '@posthog/react'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import type { CopyKind } from '@/adopt/copy-event'
 import { recordCopyFn } from '@/adopt/functions'
+
+export interface RecordedCopyController {
+  count: number
+  copy: (text: string, kind: CopyKind, onCopied: () => void) => void
+}
 
 /**
  * Shared copy-and-record logic for adopt controls: clipboard write → optimistic
@@ -12,12 +17,30 @@ import { recordCopyFn } from '@/adopt/functions'
  * server event, and copies are the North Star metric. We pass the browser's distinct + session ids
  * through so the server event still joins the same person's View→Copy funnel.
  */
-export function useRecordedCopy(configId: string, copyCount: number) {
+export function useRecordedCopy(configId: string, copyCount: number): RecordedCopyController {
   const posthog = usePostHog()
-  const [count, setCount] = useState(copyCount)
+  const activeConfigId = useRef(configId)
+  activeConfigId.current = configId
+  const authoritativeCount = useRef<{ configId: string; count: number | null }>({
+    configId,
+    count: null,
+  })
+  if (authoritativeCount.current.configId !== configId) {
+    authoritativeCount.current = { configId, count: null }
+  }
+  const [state, setState] = useState({ configId, count: copyCount })
+  if (state.configId !== configId) {
+    setState({ configId, count: copyCount })
+  }
+  const count = state.configId === configId ? Math.max(state.count, copyCount) : copyCount
 
   async function record(kind: CopyKind) {
-    setCount((c) => c + 1)
+    const requestConfigId = configId
+    setState((current) => ({
+      configId: requestConfigId,
+      count:
+        (current.configId === requestConfigId ? Math.max(current.count, copyCount) : copyCount) + 1,
+    }))
     // Best-effort PostHog ids so the server-side copy event can join this person's funnel. When
     // analytics is off (non-prod), the instance is uninitialized and these can be undefined or
     // throw — never let that stop the copy from being recorded.
@@ -32,7 +55,14 @@ export function useRecordedCopy(configId: string, copyCount: number) {
       // recordCopy returns 0 for a malformed/missing/unpublished config — don't let
       // that regress the display. copyCount is an approximate signal, so we keep the
       // optimistic value and only adopt a positive server total.
-      if (next > 0) setCount(next)
+      if (next > 0 && activeConfigId.current === requestConfigId) {
+        const previous = authoritativeCount.current.count
+        const reconciled = previous === null ? next : Math.max(previous, next)
+        authoritativeCount.current = { configId: requestConfigId, count: reconciled }
+        setState((current) =>
+          current.configId === requestConfigId ? { ...current, count: reconciled } : current,
+        )
+      }
     } catch {
       // Network/server error — keep the optimistic value.
     }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -61,12 +61,9 @@ export const configs = pgTable(
     // delete-user cascade and the submit rate-limit query (WHERE author_id ...
     // created_at) use an index instead of a seq scan.
     index('configs_author_created_idx').on(t.authorId, t.createdAt),
-    // The gallery's hot query is `WHERE status='published' ORDER BY <sort> LIMIT 10`. These two
-    // composites let Postgres satisfy the filter + sort + limit from the index instead of
-    // scanning and sorting every published row: `new` uses (status, created_at); `top` uses
-    // (status, upvote_count) for its leading sort key, with a top-N sort on the created_at
-    // tiebreak the query appends. The `trending` sort ranks by a now()-based decay expression
-    // that no btree can cover, so it intentionally has no index.
+    // The gallery's `new` sort uses (status, created_at). Top now orders by copy_count and
+    // Trending aggregates time-decayed copy events; the gallery is small enough that neither
+    // needs a new index yet. Keep the historical upvote index alongside the retained vote data.
     index('configs_status_created_idx').on(t.status, t.createdAt),
     index('configs_status_upvotes_idx').on(t.status, t.upvoteCount),
     // Supports the gallery tag filter's `all_tags @> '[...]'` containment check.

--- a/src/gallery/card-rows.ts
+++ b/src/gallery/card-rows.ts
@@ -24,7 +24,6 @@ export function mapCardRows(
     title: r.config.title,
     description: r.config.description,
     interpreter: coerceInterpreter(r.config.interpreter),
-    upvoteCount: r.config.upvoteCount,
     copyCount: r.config.copyCount,
     author: r.author
       ? {

--- a/src/gallery/config-card.tsx
+++ b/src/gallery/config-card.tsx
@@ -3,6 +3,7 @@ import { ConfigBadges } from '@/gallery/config-badges'
 import type { GalleryCard, GallerySort } from '@/gallery/queries'
 import { AuthorChip } from '@/ui/author-chip'
 import { Card, CardContent, CardHeader, CardTitle } from '@/ui/card'
+import { CopyCount } from '@/ui/copy-count'
 import { Row, Stack } from '@/ui/layout'
 import { StatuslinePreview } from '@/ui/statusline-preview'
 import { StretchedLink } from '@/ui/stretched-link'
@@ -53,9 +54,7 @@ export function GalleryConfigCard({
                 {card.title}
               </StretchedLink>
             </CardTitle>
-            <Text muted size="sm">
-              ⇧ {card.upvoteCount}
-            </Text>
+            <CopyCount count={card.copyCount} />
           </Row>
           <ConfigBadges tags={card.tags} networkHosts={card.networkHosts} align="end" />
         </Row>

--- a/src/gallery/facet-queries.ts
+++ b/src/gallery/facet-queries.ts
@@ -52,7 +52,7 @@ export async function getAvailableTags(db: Db): Promise<string[]> {
   return ALL_TAG_SLUGS.filter((slug) => (stats.get(slug)?.count ?? 0) >= 1)
 }
 
-/** A facet page's cards: published matches, most-upvoted first, newest as the tiebreak. */
+/** A facet page's cards: published matches, most-copied first, newest as the tiebreak. */
 export async function getFacetCards(db: Db, facet: Facet): Promise<GalleryCard[]> {
   const rows = await db
     .select({ config: configs, version: configVersions, author: user })
@@ -65,7 +65,7 @@ export async function getFacetCards(db: Db, facet: Facet): Promise<GalleryCard[]
         sql`${configs.allTags} @> ${JSON.stringify([facet.slug])}::jsonb`,
       ),
     )
-    .orderBy(desc(configs.upvoteCount), desc(configs.createdAt))
+    .orderBy(desc(configs.copyCount), desc(configs.createdAt))
   const cardPreviews = await selectCardPreviews(
     db,
     rows.map((r) => r.version.contentSha256),

--- a/src/gallery/functions.ts
+++ b/src/gallery/functions.ts
@@ -1,9 +1,7 @@
 import { createServerFn, createServerOnlyFn } from '@tanstack/react-start'
-import { getRequestHeaders } from '@tanstack/react-start/server'
 import { db } from '@/db'
 import { getAvailableTags } from '@/gallery/facet-queries'
 import { FACET_BY_SLUG, FACETS, tagHref } from '@/gallery/facets'
-import { auth } from '@/lib/auth'
 import { resolveSourceHtml } from '@/lib/highlight'
 import { withHttpStatus } from '@/lib/http.server'
 import { llmsResponse } from '@/lib/llms'
@@ -84,9 +82,7 @@ export const getConfigDetail = createServerFn({ method: 'GET' })
   .inputValidator((d: { slug: string }) => d)
   .handler(({ data }) =>
     withHttpStatus(async () => {
-      const session = await auth.api.getSession({ headers: getRequestHeaders() })
-      const userId = session?.user?.id
-      const detail = await getConfigBySlug(db, data.slug, userId)
+      const detail = await getConfigBySlug(db, data.slug)
       if (!detail) return null
       // Use the HTML highlighted at submit time when present; only fall back to live Shiki for
       // versions without it. Either way the browser gets escaped HTML, never Shiki itself.

--- a/src/gallery/queries.ts
+++ b/src/gallery/queries.ts
@@ -3,10 +3,10 @@ import type { PgDatabase } from 'drizzle-orm/pg-core'
 import type { GeneratedContent } from '@/content/types'
 import { configs, configVersions, previews, user } from '@/db/schema'
 import { ALL_TAG_SLUGS } from '@/gallery/facets'
-import { getVoteState } from '@/lib/vote-state'
 import { getPreviews } from '@/render/store'
 import type { AnsiSegment, Interpreter, RenderedPreview } from '@/render/types'
 import { coerceInterpreter, mapCardRows } from './card-rows'
+import { trendingScore } from './trending'
 
 // biome-ignore lint/suspicious/noExplicitAny: db type varies by driver (postgres-js/pglite); query surface identical.
 type Db = PgDatabase<any, typeof import('@/db/schema')>
@@ -55,7 +55,6 @@ export interface GalleryCard {
   title: string
   description: string
   interpreter: Interpreter
-  upvoteCount: number
   copyCount: number
   author: ConfigAuthor | null
   preview: AnsiSegment[] | null
@@ -100,10 +99,10 @@ export async function getPublishedConfigs(
 ): Promise<GalleryCard[]> {
   const orderBy =
     sort === 'top'
-      ? desc(configs.upvoteCount)
+      ? [desc(configs.copyCount)]
       : sort === 'trending'
-        ? sql`${configs.copyCount} / power(extract(epoch from (now() - ${configs.createdAt})) / 3600 + 2, 1.5) desc`
-        : desc(configs.createdAt)
+        ? [desc(trendingScore(configs.id))]
+        : [desc(configs.createdAt)]
 
   const tagFilter =
     tags.length > 0 ? sql`${configs.allTags} @> ${JSON.stringify(tags)}::jsonb` : undefined
@@ -114,9 +113,7 @@ export async function getPublishedConfigs(
     .innerJoin(configVersions, eq(configVersions.id, configs.currentVersionId))
     .leftJoin(user, eq(user.id, configs.authorId))
     .where(and(eq(configs.status, 'published'), tagFilter))
-    // createdAt tiebreak: zero-copy configs all score 0 on trending — without it, the default
-    // gallery order would be database-arbitrary.
-    .orderBy(orderBy, desc(configs.createdAt))
+    .orderBy(...orderBy)
     .limit(PAGE_SIZE)
     .offset((page - 1) * PAGE_SIZE)
 
@@ -167,10 +164,8 @@ export interface ConfigDetail {
   description: string
   interpreter: Interpreter
   tags: string[]
-  upvoteCount: number
   copyCount: number
   author: ConfigAuthor | null
-  hasVoted: boolean
   source: string
   /** Pre-highlighted HTML of `source`, or null when not yet computed (read path highlights live). */
   sourceHtml: string | null
@@ -192,11 +187,7 @@ export interface ConfigDetail {
   updatedAt: string
 }
 
-export async function getConfigBySlug(
-  db: Db,
-  slug: string,
-  userId?: string,
-): Promise<ConfigDetail | null> {
+export async function getConfigBySlug(db: Db, slug: string): Promise<ConfigDetail | null> {
   const [row] = await db
     .select({ config: configs, version: configVersions, author: user })
     .from(configs)
@@ -206,7 +197,6 @@ export async function getConfigBySlug(
     .limit(1)
   if (!row) return null
   const previews = await getPreviews(db, row.version.contentSha256)
-  const hasVoted = userId ? await getVoteState(db, userId, row.config.id) : false
   return {
     id: row.config.id,
     slug: row.config.slug,
@@ -214,7 +204,6 @@ export async function getConfigBySlug(
     description: row.config.description,
     interpreter: coerceInterpreter(row.config.interpreter),
     tags: row.config.allTags ?? [],
-    upvoteCount: row.config.upvoteCount,
     copyCount: row.config.copyCount,
     author: row.author
       ? {
@@ -223,7 +212,6 @@ export async function getConfigBySlug(
           image: row.author.image ?? null,
         }
       : null,
-    hasVoted,
     source: row.version.source,
     sourceHtml: row.version.sourceHtml,
     contentSha256: row.version.contentSha256,

--- a/src/gallery/related.ts
+++ b/src/gallery/related.ts
@@ -12,7 +12,7 @@ export interface RelatedConfig {
   slug: string
   title: string
   interpreter: Interpreter
-  upvoteCount: number
+  copyCount: number
   preview: AnsiSegment[] | null
 }
 
@@ -21,7 +21,7 @@ export const RELATED_LIMIT = 6
 
 /**
  * Other published configs for the "More status lines" section on a config page —
- * top-voted first (ties broken by newest), excluding the config being viewed.
+ * most-copied first (ties broken by newest), excluding the config being viewed.
  * Exists for internal linking: without it every config page is a crawl dead end.
  */
 export async function getRelatedConfigs(
@@ -34,7 +34,7 @@ export async function getRelatedConfigs(
     .from(configs)
     .innerJoin(configVersions, eq(configVersions.id, configs.currentVersionId))
     .where(and(eq(configs.status, 'published'), ne(configs.slug, slug)))
-    .orderBy(desc(configs.upvoteCount), desc(configs.createdAt))
+    .orderBy(desc(configs.copyCount), desc(configs.createdAt))
     .limit(limit)
 
   const cardPreviews = await selectCardPreviews(
@@ -47,7 +47,7 @@ export async function getRelatedConfigs(
     slug: r.config.slug,
     title: r.config.title,
     interpreter: coerceInterpreter(r.config.interpreter),
-    upvoteCount: r.config.upvoteCount,
+    copyCount: r.config.copyCount,
     preview: cardPreviews.get(r.version.contentSha256) ?? null,
   }))
 }

--- a/src/gallery/trending.ts
+++ b/src/gallery/trending.ts
@@ -1,0 +1,26 @@
+import { getTableName, type SQL, sql } from 'drizzle-orm'
+import type { PgColumn } from 'drizzle-orm/pg-core'
+import { copyEvents } from '@/db/schema'
+
+export const TRENDING_HALF_LIFE_SECONDS = 7 * 24 * 60 * 60
+
+function qualified(column: PgColumn): SQL {
+  return sql`${sql.identifier(getTableName(column.table))}.${sql.identifier(column.name)}`
+}
+
+/** Sum time-decayed, deduplicated copies for one config. Submission time never enters the score. */
+export function trendingScore(configId: PgColumn): SQL<number> {
+  const eventCreatedAt = qualified(copyEvents.createdAt)
+  const eventConfigId = qualified(copyEvents.configId)
+  const outerConfigId = qualified(configId)
+  return sql<number>`coalesce((
+    select sum(
+      power(
+        0.5,
+        extract(epoch from (now() - ${eventCreatedAt})) / ${TRENDING_HALF_LIFE_SECONDS}
+      )
+    )
+    from ${copyEvents}
+    where ${eventConfigId} = ${outerConfigId}
+  ), 0)`
+}

--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -53,7 +53,7 @@ export function homeJsonLd(
 /**
  * A config page as SoftwareSourceCode + breadcrumb, plus a FAQPage built from the
  * generated copy when present. The SoftwareSourceCode carries the GEO signals AI answer
- * engines weight: `dateModified` (freshness), an upvote `interactionStatistic` (a real
+ * engines weight: `dateModified` (freshness), a copy `interactionStatistic` (a real
  * stat), `runtimePlatform`, and facet `keywords`.
  */
 export function configJsonLd(
@@ -65,7 +65,7 @@ export function configJsonLd(
     interpreter: string
     authorName: string | null
     license: string | null
-    upvoteCount: number
+    copyCount: number
     keywords: string[]
     updatedAt: string | null
     generatedContent: GeneratedContent | null
@@ -86,8 +86,8 @@ export function configJsonLd(
       ...(config.keywords.length > 0 ? { keywords: config.keywords.join(', ') } : {}),
       interactionStatistic: {
         '@type': 'InteractionCounter',
-        interactionType: 'https://schema.org/LikeAction',
-        userInteractionCount: config.upvoteCount,
+        interactionType: 'https://schema.org/InstallAction',
+        userInteractionCount: config.copyCount,
       },
       ...(config.authorName ? { author: { '@type': 'Person', name: config.authorName } } : {}),
     },

--- a/src/lib/llms.ts
+++ b/src/lib/llms.ts
@@ -8,8 +8,8 @@
 export function buildLlmsTxt(base: string, facets: Array<{ slug: string; label: string }>): string {
   const blocks = [
     '# statuslin.es',
-    '> Community gallery of Claude Code status lines: browse real, sandbox-rendered previews, upvote the best, and copy one into your own setup.',
-    "statuslin.es is a curated, open gallery of status lines for Anthropic's Claude Code CLI. Every submission is a shell script; the site runs it in a sandbox and shows the actual rendered terminal output, plus community upvotes and a one-command copy to adopt it. It is a curation-first gallery, not documentation.",
+    '> Community gallery of Claude Code status lines: browse real, sandbox-rendered previews and copy one into your own setup.',
+    "statuslin.es is a curated, open gallery of status lines for Anthropic's Claude Code CLI. Every submission is a shell script; the site runs it in a sandbox and shows the actual rendered terminal output, plus its copy count and a one-command copy to adopt it. It is a curation-first gallery, not documentation.",
     ['## Browse', '', ...corePageLinks(base)].join('\n'),
   ]
   if (facets.length > 0) {
@@ -20,7 +20,7 @@ export function buildLlmsTxt(base: string, facets: Array<{ slug: string; label: 
 
 function corePageLinks(base: string): string[] {
   return [
-    `- [Gallery](${base}/): every published status line, sorted by newest and most upvoted`,
+    `- [Gallery](${base}/): every published status line, sorted by trending, newest, or most copied`,
     `- [Submit a status line](${base}/submit): add your own`,
     `- [Resources](${base}/resources): related Claude Code status line tools`,
   ]

--- a/src/og/meta.ts
+++ b/src/og/meta.ts
@@ -7,12 +7,15 @@ export function rootSocialMeta(): Array<Record<string, string>> {
     {
       name: 'description',
       content:
-        'A community gallery of Claude Code status lines — browse rendered previews, upvote, and copy one to use.',
+        'A community gallery of Claude Code status lines — browse rendered previews and copy one to use.',
     },
     { property: 'og:type', content: 'website' },
     { property: 'og:url', content: base },
     { property: 'og:title', content: 'statuslin.es' },
-    { property: 'og:description', content: 'A community gallery of Claude Code status lines.' },
+    {
+      property: 'og:description',
+      content: 'Browse rendered Claude Code status lines and copy one to use.',
+    },
     { property: 'og:image', content: `${base}/og/home.png` },
     { property: 'og:image:width', content: String(CARD_WIDTH) },
     { property: 'og:image:height', content: String(CARD_HEIGHT) },

--- a/src/routes/c.$slug.tsx
+++ b/src/routes/c.$slug.tsx
@@ -2,6 +2,7 @@ import { usePostHog } from '@posthog/react'
 import { createFileRoute, notFound } from '@tanstack/react-router'
 import { useEffect } from 'react'
 import { AdoptPrompt, CopyScriptButton } from '@/adopt/adopt-actions'
+import { useRecordedCopy } from '@/adopt/use-recorded-copy'
 import { ConfigBadges } from '@/gallery/config-badges'
 import { tagLabel } from '@/gallery/facets'
 import { getConfigDetail } from '@/gallery/functions'
@@ -16,6 +17,7 @@ import { configSocialMeta } from '@/og/meta'
 import { orderByScenario, SCENARIO_BY_KEY } from '@/render/scenarios'
 import { AuthorChip } from '@/ui/author-chip'
 import { Card, CardContent, CardHeader, CardTitle } from '@/ui/card'
+import { CopyCount } from '@/ui/copy-count'
 import { HighlightedCode } from '@/ui/highlighted-code'
 import { Row, Stack } from '@/ui/layout'
 import { ScenarioRow } from '@/ui/scenario-row'
@@ -24,7 +26,6 @@ import { PageShell } from '@/ui/shell'
 import { StatuslinePreview } from '@/ui/statusline-preview'
 import { StretchedLink } from '@/ui/stretched-link'
 import { Heading, Text, TextLink } from '@/ui/text'
-import { UpvoteButton } from '@/votes/upvote-button'
 
 export const Route = createFileRoute('/c/$slug')({
   loader: async ({ params }) => {
@@ -63,7 +64,7 @@ export const Route = createFileRoute('/c/$slug')({
             interpreter: detail.interpreter,
             authorName: detail.author?.name ?? null,
             license: detail.license,
-            upvoteCount: detail.upvoteCount,
+            copyCount: detail.copyCount,
             keywords: detail.facetLinks.map((f) => f.chipLabel),
             updatedAt: detail.updatedAt,
             generatedContent: detail.generatedContent,
@@ -83,6 +84,7 @@ export const Route = createFileRoute('/c/$slug')({
 function ConfigDetail() {
   const posthog = usePostHog()
   const { detail, user } = Route.useLoaderData()
+  const copyController = useRecordedCopy(detail.id, detail.copyCount)
 
   useEffect(() => {
     posthog.capture('statusline_detail_viewed', {
@@ -100,16 +102,7 @@ function ConfigDetail() {
       <Stack gap={6}>
         <Stack gap={3}>
           <Row gap={3} wrap justify="between">
-            <Row gap={3}>
-              <Heading level={1}>{detail.title}</Heading>
-              <UpvoteButton
-                configId={detail.id}
-                slug={detail.slug}
-                initialCount={detail.upvoteCount}
-                initialVoted={detail.hasVoted}
-                signedIn={!!user}
-              />
-            </Row>
+            <Heading level={1}>{detail.title}</Heading>
             <ConfigBadges tags={detail.tags} networkHosts={detail.networkHosts} />
           </Row>
 
@@ -160,8 +153,7 @@ function ConfigDetail() {
           source={detail.source}
           interpreter={detail.interpreter}
           title={detail.title}
-          configId={detail.id}
-          copyCount={detail.copyCount}
+          controller={copyController}
         />
 
         {/* All scenarios, stacked */}
@@ -191,7 +183,7 @@ function ConfigDetail() {
         <SectionCard
           title="Source"
           headingLevel={2}
-          action={<CopyScriptButton source={detail.source} configId={detail.id} />}
+          action={<CopyScriptButton source={detail.source} controller={copyController} />}
         >
           <HighlightedCode html={detail.sourceHtml} />
         </SectionCard>
@@ -223,9 +215,7 @@ function ConfigDetail() {
                           {r.title}
                         </StretchedLink>
                       </CardTitle>
-                      <Text muted size="sm">
-                        ⇧ {r.upvoteCount}
-                      </Text>
+                      <CopyCount count={r.copyCount} />
                     </Row>
                   </CardHeader>
                   <CardContent>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -53,7 +53,7 @@ export const Route = createFileRoute('/')({
       {
         name: 'description',
         content:
-          'Browse a community gallery of Claude Code status lines — see rendered previews, upvote your favorites, and copy one into your own terminal in a single paste.',
+          'Browse a community gallery of Claude Code status lines — see rendered previews and copy one into your own terminal in a single paste.',
       },
       ...(isFilteredHomeSearch(match.search)
         ? [{ name: 'robots', content: 'noindex, follow' }]

--- a/src/ui/copy-count.tsx
+++ b/src/ui/copy-count.tsx
@@ -1,0 +1,15 @@
+import { Copy } from 'lucide-react'
+import { Row } from '@/ui/layout'
+import { Text } from '@/ui/text'
+
+/** Compact, read-only popularity metric shared by gallery and detail surfaces. */
+export function CopyCount({ count }: { count: number }) {
+  return (
+    <Row gap={1}>
+      <Copy className="size-3.5 text-muted-foreground" aria-hidden="true" />
+      <Text muted size="sm">
+        {count} {count === 1 ? 'copy' : 'copies'}
+      </Text>
+    </Row>
+  )
+}

--- a/test/adopt/adopt-actions.test.tsx
+++ b/test/adopt/adopt-actions.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AdoptPrompt, CopyScriptButton } from '@/adopt/adopt-actions'
 import { buildClaudePrompt } from '@/adopt/install'
+import { useRecordedCopy } from '@/adopt/use-recorded-copy'
 
 const recordCopyFn = vi.hoisted(() => vi.fn())
 vi.mock('@/adopt/functions', () => ({ recordCopyFn }))
@@ -31,6 +32,38 @@ const props = {
 const promptButton = () =>
   screen.getByRole('button', { name: 'Copy install prompt — My Statusline' })
 
+function SharedCopyActions() {
+  const controller = useRecordedCopy(props.configId, props.copyCount)
+  return (
+    <>
+      <AdoptPrompt
+        source={props.source}
+        interpreter={props.interpreter}
+        title={props.title}
+        controller={controller}
+      />
+      <CopyScriptButton source={props.source} controller={controller} />
+    </>
+  )
+}
+
+function PromptHarness() {
+  const controller = useRecordedCopy(props.configId, props.copyCount)
+  return (
+    <AdoptPrompt
+      source={props.source}
+      interpreter={props.interpreter}
+      title={props.title}
+      controller={controller}
+    />
+  )
+}
+
+function ScriptHarness() {
+  const controller = useRecordedCopy(props.configId, props.copyCount)
+  return <CopyScriptButton source={props.source} controller={controller} />
+}
+
 beforeEach(() => {
   writeText.mockReset().mockResolvedValue(undefined)
   recordCopyFn.mockReset().mockResolvedValue(6)
@@ -47,8 +80,27 @@ afterEach(() => {
 })
 
 describe('AdoptPrompt', () => {
+  it('shares one reconciled count across both copy actions', async () => {
+    let resolveScriptCopy!: (count: number) => void
+    const scriptCopy = new Promise<number>((resolve) => {
+      resolveScriptCopy = resolve
+    })
+    recordCopyFn.mockResolvedValueOnce(6).mockReturnValueOnce(scriptCopy)
+    render(<SharedCopyActions />)
+
+    fireEvent.click(promptButton())
+    await waitFor(() => expect(screen.getByText('6 copies')).toBeTruthy())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy script' }))
+    await waitFor(() => expect(recordCopyFn).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(screen.getByText('7 copies')).toBeTruthy())
+
+    resolveScriptCopy(6)
+    await waitFor(() => expect(screen.getByText('6 copies')).toBeTruthy())
+  })
+
   it('renders a coral lg "Copy install prompt" button', () => {
-    render(<AdoptPrompt {...props} />)
+    render(<PromptHarness />)
     expect(screen.getByText('Copy install prompt')).toBeTruthy()
     // Coral (default/primary variant) at the large size.
     expect(promptButton().className).toContain('bg-primary')
@@ -56,7 +108,7 @@ describe('AdoptPrompt', () => {
   })
 
   it('copies the built Claude prompt and records the copy', async () => {
-    render(<AdoptPrompt {...props} />)
+    render(<PromptHarness />)
 
     fireEvent.click(promptButton())
 
@@ -68,7 +120,7 @@ describe('AdoptPrompt', () => {
 
   it('does not show "Copied!" or record when the clipboard rejects', async () => {
     writeText.mockRejectedValue(new Error('denied'))
-    render(<AdoptPrompt {...props} />)
+    render(<PromptHarness />)
 
     fireEvent.click(promptButton())
 
@@ -79,7 +131,7 @@ describe('AdoptPrompt', () => {
   })
 
   it('fires a success toast on prompt copy', async () => {
-    render(<AdoptPrompt {...props} />)
+    render(<PromptHarness />)
 
     fireEvent.click(promptButton())
 
@@ -92,7 +144,7 @@ describe('AdoptPrompt', () => {
 
   it('does NOT toast when the clipboard rejects', async () => {
     writeText.mockRejectedValue(new Error('denied'))
-    render(<AdoptPrompt {...props} />)
+    render(<PromptHarness />)
 
     fireEvent.click(promptButton())
 
@@ -103,7 +155,7 @@ describe('AdoptPrompt', () => {
 
 describe('CopyScriptButton', () => {
   it('copies the raw source and records the copy', async () => {
-    render(<CopyScriptButton source={props.source} configId={props.configId} />)
+    render(<ScriptHarness />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Copy script' }))
 
@@ -118,7 +170,7 @@ describe('CopyScriptButton', () => {
   })
 
   it('stays the outline variant during the "Copied!" swap (no variant flash)', async () => {
-    render(<CopyScriptButton source={props.source} configId={props.configId} />)
+    render(<ScriptHarness />)
     const button = screen.getByRole('button')
     // Outline at rest: background-only, no coral fill.
     expect(button.className).toContain('bg-background')
@@ -134,7 +186,7 @@ describe('CopyScriptButton', () => {
 
   it('does not show "Copied!" or record when the clipboard rejects', async () => {
     writeText.mockRejectedValue(new Error('denied'))
-    render(<CopyScriptButton source={props.source} configId={props.configId} />)
+    render(<ScriptHarness />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Copy script' }))
 

--- a/test/adopt/use-recorded-copy.test.tsx
+++ b/test/adopt/use-recorded-copy.test.tsx
@@ -13,6 +13,14 @@ vi.mock('@posthog/react', () => ({
 
 const writeText = vi.fn<(text: string) => Promise<void>>()
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
 beforeEach(() => {
   writeText.mockReset().mockResolvedValue(undefined)
   recordCopyFn.mockReset().mockResolvedValue(6)
@@ -57,6 +65,89 @@ describe('useRecordedCopy', () => {
     // Optimistic count (5 -> 6) must hold; a 0 from the server is ignored.
     await waitFor(() => expect(recordCopyFn).toHaveBeenCalled())
     await waitFor(() => expect(result.current.count).toBe(6))
+  })
+
+  it('keeps clipboard success and the optimistic count when recording rejects', async () => {
+    recordCopyFn.mockRejectedValue(new Error('offline'))
+    const onCopied = vi.fn()
+    const { result } = renderHook(() => useRecordedCopy('cfg-1', 5))
+
+    await act(async () => {
+      result.current.copy('text', 'prompt', onCopied)
+    })
+
+    await waitFor(() => expect(recordCopyFn).toHaveBeenCalled())
+    expect(onCopied).toHaveBeenCalledOnce()
+    expect(result.current.count).toBe(6)
+  })
+
+  it('does not let an older response regress a newer reconciled count', async () => {
+    const first = deferred<number>()
+    const second = deferred<number>()
+    recordCopyFn.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+    const { result } = renderHook(() => useRecordedCopy('cfg-1', 5))
+
+    act(() => {
+      result.current.copy('prompt', 'prompt', () => {})
+      result.current.copy('script', 'script', () => {})
+    })
+    await waitFor(() => expect(recordCopyFn).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(result.current.count).toBe(7))
+
+    await act(async () => second.resolve(9))
+    await waitFor(() => expect(result.current.count).toBe(9))
+
+    await act(async () => first.resolve(6))
+    expect(result.current.count).toBe(9)
+  })
+
+  it('does not let a later-started lower response regress a higher authoritative count', async () => {
+    const first = deferred<number>()
+    const second = deferred<number>()
+    recordCopyFn.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+    const { result } = renderHook(() => useRecordedCopy('cfg-1', 5))
+
+    act(() => {
+      result.current.copy('prompt', 'prompt', () => {})
+      result.current.copy('script', 'script', () => {})
+    })
+    await waitFor(() => expect(recordCopyFn).toHaveBeenCalledTimes(2))
+
+    await act(async () => first.resolve(9))
+    await waitFor(() => expect(result.current.count).toBe(9))
+
+    await act(async () => second.resolve(6))
+    expect(result.current.count).toBe(9)
+  })
+
+  it('reconciles an optimistic duplicate down to the authoritative total', async () => {
+    const response = deferred<number>()
+    recordCopyFn.mockReturnValueOnce(response.promise)
+    const { result } = renderHook(() => useRecordedCopy('cfg-1', 5))
+
+    act(() => result.current.copy('text', 'prompt', () => {}))
+    await waitFor(() => expect(result.current.count).toBe(6))
+
+    await act(async () => response.resolve(5))
+    expect(result.current.count).toBe(5)
+  })
+
+  it('resets for a new config and ignores the previous config response', async () => {
+    const oldResponse = deferred<number>()
+    recordCopyFn.mockReturnValueOnce(oldResponse.promise)
+    const { result, rerender } = renderHook(
+      ({ configId, count }) => useRecordedCopy(configId, count),
+      { initialProps: { configId: 'cfg-1', count: 5 } },
+    )
+
+    act(() => result.current.copy('text', 'prompt', () => {}))
+    await waitFor(() => expect(recordCopyFn).toHaveBeenCalledOnce())
+
+    rerender({ configId: 'cfg-2', count: 2 })
+    expect(result.current.count).toBe(2)
+
+    await act(async () => oldResponse.resolve(10))
+    expect(result.current.count).toBe(2)
   })
 
   it('does not bump the count when the clipboard rejects', async () => {

--- a/test/gallery/config-card.test.tsx
+++ b/test/gallery/config-card.test.tsx
@@ -13,13 +13,22 @@ vi.mock('@tanstack/react-router', () => ({
     to,
     params,
     children,
+    onClick,
     ...props
   }: {
     to: string
     params?: Record<string, string>
     children: React.ReactNode
+    onClick?: React.MouseEventHandler<HTMLAnchorElement>
   }) => (
-    <a href={params ? to.replace('$slug', params.slug ?? '') : to} {...props}>
+    <a
+      href={params ? to.replace('$slug', params.slug ?? '') : to}
+      onClick={(event) => {
+        event.preventDefault()
+        onClick?.(event)
+      }}
+      {...props}
+    >
       {children}
     </a>
   ),
@@ -39,7 +48,6 @@ describe('GalleryConfigCard analytics', () => {
           title: 'Example',
           description: 'An example status line.',
           interpreter: 'bash',
-          upvoteCount: 3,
           copyCount: 2,
           author: null,
           preview: null,
@@ -58,6 +66,8 @@ describe('GalleryConfigCard analytics', () => {
     )
 
     fireEvent.click(screen.getByRole('link', { name: 'Example' }))
+    expect(screen.getByText('2 copies')).toBeTruthy()
+    expect(screen.queryByText(/⇧|upvote/i)).toBeNull()
 
     expect(capture).toHaveBeenCalledWith('statusline_card_clicked', {
       configId: 'config-1',

--- a/test/gallery/detail.test.ts
+++ b/test/gallery/detail.test.ts
@@ -6,7 +6,6 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import * as schema from '@/db/schema'
 import { getConfigBySlug } from '@/gallery/queries'
 import { storePreviews } from '@/render/store'
-import { toggleVote } from '@/votes/vote'
 
 let client: PGlite
 let db: ReturnType<typeof drizzle<typeof schema>>
@@ -14,38 +13,19 @@ beforeAll(async () => {
   client = new PGlite()
   db = drizzle({ client, schema })
   await migrate(db, { migrationsFolder: './drizzle' })
-  // Seed users required by the votes FK (user_id → user.id) and the
-  // configs author FK (author_id → user.id, the 'u1' author below).
+  // Seed the user required by the configs author FK.
   await db
     .insert(schema.user)
-    .values([
-      {
-        id: 'u1',
-        name: 'Author One',
-        username: 'authorone',
-        email: 'author1@test.com',
-        image: 'https://example.com/avatar.png',
-        emailVerified: false,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-      {
-        id: 'user-voted',
-        name: 'User Voted',
-        email: 'uservoted@test.com',
-        emailVerified: false,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-      {
-        id: 'user-who-voted',
-        name: 'User Who Voted',
-        email: 'userwhovoted@test.com',
-        emailVerified: false,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-    ])
+    .values({
+      id: 'u1',
+      name: 'Author One',
+      username: 'authorone',
+      email: 'author1@test.com',
+      image: 'https://example.com/avatar.png',
+      emailVerified: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
     .onConflictDoNothing()
 })
 afterAll(async () => {
@@ -133,14 +113,18 @@ describe('getConfigBySlug', () => {
     expect(detail).toBeNull()
   })
 
-  it('returns upvoteCount on ConfigDetail', async () => {
+  it('returns copyCount without public vote state on ConfigDetail', async () => {
     const cfg = await seed('published', 'detail-counts', 'e'.repeat(64))
-    // Cast upvoteCount to 4 directly.
-    await db.update(schema.configs).set({ upvoteCount: 4 }).where(eq(schema.configs.id, cfg.id))
+    await db
+      .update(schema.configs)
+      .set({ upvoteCount: 4, copyCount: 6 })
+      .where(eq(schema.configs.id, cfg.id))
 
     const detail = await getConfigBySlug(db, 'detail-counts')
     expect(detail).not.toBeNull()
-    expect(detail?.upvoteCount).toBe(4)
+    expect(detail?.copyCount).toBe(6)
+    expect(detail).not.toHaveProperty('upvoteCount')
+    expect(detail).not.toHaveProperty('hasVoted')
   })
 
   it('returns author and copyCount on ConfigDetail', async () => {
@@ -155,35 +139,6 @@ describe('getConfigBySlug', () => {
       username: 'authorone',
       image: 'https://example.com/avatar.png',
     })
-  })
-
-  it('hasVoted is false when no userId is provided', async () => {
-    await seed('published', 'detail-hasvoted-no-user', 'f'.repeat(64))
-    const detail = await getConfigBySlug(db, 'detail-hasvoted-no-user')
-    expect(detail?.hasVoted).toBe(false)
-  })
-
-  it('hasVoted is false for a userId that has not voted', async () => {
-    await seed('published', 'detail-novote', '0'.repeat(64))
-    const detail = await getConfigBySlug(db, 'detail-novote', 'user-no-vote')
-    expect(detail?.hasVoted).toBe(false)
-  })
-
-  it('hasVoted is true for a userId that has voted', async () => {
-    const cfg = await seed('published', 'detail-voted', 'a1'.repeat(32))
-    await toggleVote(db, 'user-voted', cfg.id)
-
-    const detail = await getConfigBySlug(db, 'detail-voted', 'user-voted')
-    expect(detail?.hasVoted).toBe(true)
-  })
-
-  it('hasVoted is false for a different userId that has not voted', async () => {
-    const cfg = await seed('published', 'detail-voted-other', 'b2'.repeat(32))
-    await toggleVote(db, 'user-who-voted', cfg.id)
-
-    // A different user should see hasVoted = false.
-    const detail = await getConfigBySlug(db, 'detail-voted-other', 'user-who-did-not-vote')
-    expect(detail?.hasVoted).toBe(false)
   })
 
   it('returns the stored sourceHtml when the version has it', async () => {

--- a/test/gallery/facet-queries.test.ts
+++ b/test/gallery/facet-queries.test.ts
@@ -35,6 +35,7 @@ async function seed(
     interpreter?: string
     status?: string
     upvoteCount?: number
+    copyCount?: number
     createdAt?: Date
   } = {},
 ) {
@@ -56,6 +57,7 @@ async function seed(
         readsClaudeToken: false,
       }),
       upvoteCount: opts.upvoteCount ?? 0,
+      copyCount: opts.copyCount ?? 0,
       createdAt: opts.createdAt ?? new Date(2026, 0, 1),
     })
     .returning()
@@ -78,8 +80,18 @@ async function seed(
 
 describe('facet queries', () => {
   beforeAll(async () => {
-    await seed('git-a', { tags: ['git'], upvoteCount: 5, createdAt: new Date(2026, 5, 1) })
-    await seed('git-b', { tags: ['git', 'cost'], upvoteCount: 9, createdAt: new Date(2026, 5, 2) })
+    await seed('git-a', {
+      tags: ['git'],
+      upvoteCount: 9,
+      copyCount: 5,
+      createdAt: new Date(2026, 5, 1),
+    })
+    await seed('git-b', {
+      tags: ['git', 'cost'],
+      upvoteCount: 1,
+      copyCount: 9,
+      createdAt: new Date(2026, 5, 2),
+    })
     await seed('git-draft', { tags: ['git'], status: 'draft' })
     await seed('py-a', { interpreter: 'python', createdAt: new Date(2026, 5, 3) })
     await seed('plain', {})
@@ -99,7 +111,7 @@ describe('facet queries', () => {
     expect(cards.map((c) => c.slug)).not.toContain('git-draft')
   })
 
-  it('returns tag-facet cards by upvotes then newest', async () => {
+  it('returns tag-facet cards by lifetime copies', async () => {
     const cards = await getFacetCards(db, FACET_BY_SLUG.get('git')!)
     expect(cards.map((c) => c.slug)).toEqual(['git-b', 'git-a'])
   })

--- a/test/gallery/queries.test.ts
+++ b/test/gallery/queries.test.ts
@@ -1,10 +1,11 @@
 import { PGlite } from '@electric-sql/pglite'
-import { eq } from 'drizzle-orm'
+import { eq, inArray } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/pglite'
 import { migrate } from 'drizzle-orm/pglite/migrator'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import * as schema from '@/db/schema'
 import { getPublishedConfigs } from '@/gallery/queries'
+import { trendingScore } from '@/gallery/trending'
 import { storePreviews } from '@/render/store'
 
 let client: PGlite
@@ -135,26 +136,29 @@ describe('getPublishedConfigs sorting', () => {
   const msPerHour = 60 * 60 * 1000
   const msPerDay = 24 * msPerHour
 
-  it('top: returns cards ordered by upvoteCount descending', async () => {
+  it('top: returns cards ordered by copyCount descending', async () => {
     await seedPublished({
       slug: 'sort-top-5',
       title: 'Top5',
       sha: '1'.repeat(64),
-      upvoteCount: 5,
+      upvoteCount: 1,
+      copyCount: 5,
       createdAt: new Date(BASE.getTime() - msPerDay),
     })
     await seedPublished({
       slug: 'sort-top-1',
       title: 'Top1',
       sha: '2'.repeat(64),
-      upvoteCount: 1,
+      upvoteCount: 9,
+      copyCount: 1,
       createdAt: new Date(BASE.getTime() - 2 * msPerDay),
     })
     await seedPublished({
       slug: 'sort-top-3',
       title: 'Top3',
       sha: '3'.repeat(64),
-      upvoteCount: 3,
+      upvoteCount: 4,
+      copyCount: 3,
       createdAt: new Date(BASE.getTime() - 3 * msPerDay),
     })
 
@@ -163,7 +167,7 @@ describe('getPublishedConfigs sorting', () => {
     const relevant = cards.filter((c) =>
       ['sort-top-5', 'sort-top-1', 'sort-top-3'].includes(c.slug),
     )
-    const counts = relevant.map((c) => c.upvoteCount)
+    const counts = relevant.map((c) => c.copyCount)
     expect(counts[0]).toBe(5)
     expect(counts[1]).toBe(3)
     expect(counts[2]).toBe(1)
@@ -201,74 +205,73 @@ describe('getPublishedConfigs sorting', () => {
     expect(slugs.indexOf('sort-new-mid')).toBeLessThan(slugs.indexOf('sort-new-oldest'))
   })
 
-  it('trending: ranks by copies over time, not upvotes', async () => {
-    // SQL now() reflects the real wall clock, so anchor relative to actual Date.now().
-    // Same age, so age cancels out: the more-copied config wins despite fewer upvotes.
-    const sameAge = new Date(Date.now() - 1 * msPerHour)
-    await seedPublished({
-      slug: 'trend-copies',
-      title: 'Copies',
+  it('trending: uses copy-event age and ignores submission age and lifetime counts', async () => {
+    const oldSubmission = await seedPublished({
+      slug: 'trend-old-submission',
+      title: 'OldSubmission',
       sha: '7'.repeat(64),
-      copyCount: 100,
-      upvoteCount: 1,
-      createdAt: sameAge,
-    })
-    await seedPublished({
-      slug: 'trend-votes',
-      title: 'Votes',
-      sha: '8'.repeat(64),
       copyCount: 1,
-      upvoteCount: 100,
-      createdAt: sameAge,
+      createdAt: new Date(Date.now() - 365 * msPerDay),
     })
-    // Recency still applies to the copy score: a recent low-copy config beats an old high-copy one.
-    await seedPublished({
-      slug: 'trend-old-copies',
-      title: 'OldCopies',
-      sha: '9'.repeat(64),
+    const newSubmission = await seedPublished({
+      slug: 'trend-new-submission',
+      title: 'NewSubmission',
+      sha: '8'.repeat(64),
       copyCount: 100,
-      createdAt: new Date(Date.now() - 30 * msPerDay),
+      createdAt: new Date(),
     })
-    await seedPublished({
-      slug: 'trend-new-fewcopies',
-      title: 'NewFewCopies',
+    await db.insert(schema.copyEvents).values([
+      {
+        configId: oldSubmission.id,
+        ipHash: 'recent-copy',
+        createdAt: new Date(Date.now() - msPerHour),
+      },
+      {
+        configId: newSubmission.id,
+        ipHash: 'old-copy',
+        createdAt: new Date(Date.now() - 14 * msPerDay),
+      },
+    ])
+
+    const order = (await getPublishedConfigs(db, 'trending')).map((c) => c.slug)
+    expect(order).toContain('trend-old-submission')
+    expect(order).toContain('trend-new-submission')
+    expect(order.indexOf('trend-old-submission')).toBeLessThan(
+      order.indexOf('trend-new-submission'),
+    )
+  })
+
+  it('trending: gives a seven-day-old copy half the weight of a new copy', async () => {
+    const recent = await seedPublished({
+      slug: 'trend-half-life-recent',
+      title: 'HalfLifeRecent',
+      sha: '9'.repeat(64),
+    })
+    const weekOld = await seedPublished({
+      slug: 'trend-half-life-week-old',
+      title: 'HalfLifeWeekOld',
       sha: 'cc'.repeat(32),
-      copyCount: 5,
-      createdAt: new Date(Date.now() - 1 * msPerHour),
     })
+    const now = Date.now()
+    await db.insert(schema.copyEvents).values([
+      { configId: recent.id, ipHash: 'half-life-recent', createdAt: new Date(now) },
+      {
+        configId: weekOld.id,
+        ipHash: 'half-life-week-old',
+        createdAt: new Date(now - 7 * msPerDay),
+      },
+    ])
 
-    const order = (await getPublishedConfigs(db, 'trending')).map((c) => c.slug)
-    // Copies beat upvotes at equal age.
-    expect(order.indexOf('trend-copies')).toBeLessThan(order.indexOf('trend-votes'))
-    // Recency still applies to the copy score.
-    expect(order.indexOf('trend-new-fewcopies')).toBeLessThan(order.indexOf('trend-old-copies'))
+    const scores = await db
+      .select({ id: schema.configs.id, score: trendingScore(schema.configs.id) })
+      .from(schema.configs)
+      .where(inArray(schema.configs.id, [recent.id, weekOld.id]))
+    const scoreById = new Map(scores.map((row) => [row.id, Number(row.score)]))
+
+    expect(scoreById.get(weekOld.id)! / scoreById.get(recent.id)!).toBeCloseTo(0.5, 2)
   })
 
-  it('trending: zero-copy ties break newest-first (the default view must be deterministic)', async () => {
-    await seedPublished({
-      slug: 'trend-tie-old',
-      title: 'TieOld',
-      sha: 'da'.repeat(32),
-      copyCount: 0,
-      createdAt: new Date(Date.now() - 3 * msPerHour),
-    })
-    await seedPublished({
-      slug: 'trend-tie-new',
-      title: 'TieNew',
-      sha: 'db'.repeat(32),
-      copyCount: 0,
-      createdAt: new Date(Date.now() - 1 * msPerHour),
-    })
-
-    const order = (await getPublishedConfigs(db, 'trending')).map((c) => c.slug)
-    // Both must be on page 1: indexOf returning -1 would make the comparison pass vacuously,
-    // which is exactly how a broken tiebreak would slip through.
-    expect(order).toContain('trend-tie-new')
-    expect(order).toContain('trend-tie-old')
-    expect(order.indexOf('trend-tie-new')).toBeLessThan(order.indexOf('trend-tie-old'))
-  })
-
-  it('upvoteCount is populated on GalleryCard', async () => {
+  it('does not expose upvoteCount on GalleryCard', async () => {
     await seedPublished({
       slug: 'count-check',
       title: 'CountCheck',
@@ -276,12 +279,13 @@ describe('getPublishedConfigs sorting', () => {
       // (this was '9'.repeat(64), shared with trend-old-copies) silently wipes its preview.
       sha: 'f'.repeat(64),
       upvoteCount: 7,
+      copyCount: 1000,
     })
 
     const cards = await getPublishedConfigs(db, 'top')
     const card = cards.find((c) => c.slug === 'count-check')
     expect(card).toBeDefined()
-    expect(card?.upvoteCount).toBe(7)
+    expect(card).not.toHaveProperty('upvoteCount')
   })
 
   it('author and copyCount are populated on GalleryCard', async () => {

--- a/test/gallery/related.test.ts
+++ b/test/gallery/related.test.ts
@@ -39,6 +39,7 @@ async function seedPublished(opts: {
   title: string
   sha: string
   upvoteCount?: number
+  copyCount?: number
 }) {
   const cfgRows = await db
     .insert(schema.configs)
@@ -50,6 +51,7 @@ async function seedPublished(opts: {
       interpreter: 'bash',
       status: 'published',
       upvoteCount: opts.upvoteCount ?? 0,
+      copyCount: opts.copyCount ?? 0,
     })
     .returning()
   const cfg = cfgRows[0]!
@@ -85,10 +87,22 @@ async function seedPublished(opts: {
 }
 
 describe('getRelatedConfigs', () => {
-  it('returns other published configs top-voted first, excluding the viewed slug', async () => {
+  it('returns other published configs by lifetime copies, excluding the viewed slug', async () => {
     await seedPublished({ slug: 'viewed', title: 'Viewed', sha: 'a'.repeat(64), upvoteCount: 99 })
-    await seedPublished({ slug: 'popular', title: 'Popular', sha: 'b'.repeat(64), upvoteCount: 5 })
-    await seedPublished({ slug: 'quiet', title: 'Quiet', sha: 'c'.repeat(64), upvoteCount: 1 })
+    await seedPublished({
+      slug: 'popular',
+      title: 'Popular',
+      sha: 'b'.repeat(64),
+      upvoteCount: 1,
+      copyCount: 5,
+    })
+    await seedPublished({
+      slug: 'quiet',
+      title: 'Quiet',
+      sha: 'c'.repeat(64),
+      upvoteCount: 9,
+      copyCount: 1,
+    })
     await db.insert(schema.configs).values({
       slug: 'draft-one',
       title: 'Draft',
@@ -104,6 +118,8 @@ describe('getRelatedConfigs', () => {
     expect(slugs).not.toContain('draft-one')
     expect(slugs.indexOf('popular')).toBeLessThan(slugs.indexOf('quiet'))
     expect(related[0]?.preview?.[0]?.text).toBe('Popular')
+    expect(related[0]?.copyCount).toBe(5)
+    expect(related[0]).not.toHaveProperty('upvoteCount')
   })
 
   it('caps results at the limit', async () => {

--- a/test/lib/json-ld.test.ts
+++ b/test/lib/json-ld.test.ts
@@ -63,7 +63,7 @@ describe('configJsonLd', () => {
     interpreter: 'bash',
     authorName: 'LindseyB',
     license: null as string | null,
-    upvoteCount: 12,
+    copyCount: 12,
     keywords: ['Git', 'Token usage'],
     updatedAt: '2026-07-06',
     generatedContent: {
@@ -119,14 +119,14 @@ describe('configJsonLd', () => {
 
   // --- GEO enrichment: freshness, statistics, entity clarity, extractable Q&A ---
 
-  it('enriches SoftwareSourceCode with freshness, upvote stat, platform, and keywords', () => {
+  it('enriches SoftwareSourceCode with freshness, install stat, platform, and keywords', () => {
     const [code] = configJsonLd('https://statuslin.es', base) as Array<Record<string, unknown>>
     expect(code).toMatchObject({
       dateModified: '2026-07-06',
       runtimePlatform: 'Claude Code',
       interactionStatistic: {
         '@type': 'InteractionCounter',
-        interactionType: 'https://schema.org/LikeAction',
+        interactionType: 'https://schema.org/InstallAction',
         userInteractionCount: 12,
       },
     })

--- a/test/lib/llms.test.ts
+++ b/test/lib/llms.test.ts
@@ -12,11 +12,14 @@ describe('buildLlmsTxt', () => {
     const lines = txt.split('\n')
     expect(lines[0]).toBe('# statuslin.es')
     expect(txt).toMatch(/\n> .+/) // a blockquote summary line
+    expect(txt).toMatch(/cop(?:y|ied|ies)/i)
+    expect(txt).not.toMatch(/upvote/i)
   })
 
   it('links the core pages with absolute per-environment URLs', () => {
     const txt = buildLlmsTxt('https://statuslin.es', facets)
     expect(txt).toContain('(https://statuslin.es/)') // gallery home
+    expect(txt).toMatch(/sorted by trending, newest, or most copied/i)
     expect(txt).toContain('(https://statuslin.es/submit)')
     expect(txt).toContain('(https://statuslin.es/resources)')
   })

--- a/test/loadtest/seed.test.ts
+++ b/test/loadtest/seed.test.ts
@@ -32,15 +32,16 @@ describe('seedLoadConfigs', () => {
       expect(card.preview?.length ?? 0).toBeGreaterThan(0)
       expect(card.author).not.toBeNull()
     }
-    // Varied counts so all three sorts (new/top/trending) produce real orderings.
-    expect(new Set(seeded.map((c) => c.upvoteCount)).size).toBeGreaterThan(1)
+    // Varied counts and real events so all three sorts produce real orderings.
     expect(new Set(seeded.map((c) => c.copyCount)).size).toBeGreaterThan(1)
+    const copyEvents = await db.select().from(schema.copyEvents)
+    expect(copyEvents.length).toBeGreaterThan(0)
 
-    // The varied upvote counts must actually drive a non-degenerate `top` ordering.
-    const topUpvotes = (await getPublishedConfigs(db, 'top'))
+    // The varied copy counts must actually drive a non-degenerate `top` ordering.
+    const topCopies = (await getPublishedConfigs(db, 'top'))
       .filter((c) => c.slug.startsWith('loadtest-'))
-      .map((c) => c.upvoteCount)
-    expect(topUpvotes).toEqual([...topUpvotes].sort((a, b) => b - a))
+      .map((c) => c.copyCount)
+    expect(topCopies).toEqual([...topCopies].sort((a, b) => b - a))
   })
 
   it('is idempotent: re-running the same count creates nothing new', async () => {

--- a/test/og/meta.test.ts
+++ b/test/og/meta.test.ts
@@ -17,6 +17,9 @@ describe('social meta', () => {
     })
     expect(meta).toContainEqual({ property: 'og:url', content: 'https://statuslin.es' })
     expect(meta).toContainEqual({ name: 'twitter:card', content: 'summary_large_image' })
+    const description = meta.find((entry) => entry.property === 'og:description')?.content
+    expect(description).toMatch(/cop(?:y|ied|ies)/i)
+    expect(description).not.toMatch(/upvote/i)
   })
   it('config emits a per-slug og:image', () => {
     process.env.BETTER_AUTH_URL = 'https://statuslin.es'

--- a/test/ui/copy-count.test.tsx
+++ b/test/ui/copy-count.test.tsx
@@ -1,0 +1,19 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { CopyCount } from '@/ui/copy-count'
+
+describe('CopyCount', () => {
+  it('uses the singular label for one copy', () => {
+    render(<CopyCount count={1} />)
+    expect(screen.getByText('1 copy')).toBeTruthy()
+  })
+
+  it('uses the plural label for zero or multiple copies', () => {
+    const { rerender } = render(<CopyCount count={0} />)
+    expect(screen.getByText('0 copies')).toBeTruthy()
+
+    rerender(<CopyCount count={12} />)
+    expect(screen.getByText('12 copies')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

- Replace public upvotes with anonymous, per-config copy counts so popularity reflects actual adoption.
- Rank Top by lifetime copies and Trending by copy events with an exact seven-day half-life.
- Keep both copy actions on one shared, deduplicated counter while retaining authentication for submission and admin workflows.

## Changes

- Remove vote state and controls from public gallery and detail read paths.
- Add reusable copy-count UI and robust optimistic/server reconciliation across both copy buttons.
- Update related/facet ordering, structured data, metadata, machine-readable copy, load-test data, and documentation.
- Retain legacy vote infrastructure without exposing it publicly; no database migration is required.

## Verification

- Full pre-push gate: 148 test files passed, 922 tests passed, 2 files and 11 tests skipped.
- TypeScript, Biome, frontend constraints, and dependency boundaries passed.
- Live browser and database checks confirmed Trending/Top ordering, copy-only UI, InstallAction JSON-LD, and one event/count after using both copy buttons.

## Screenshots

### Trending gallery

<img width="1280" height="2292" alt="Trending gallery with copy counts" src="https://github.com/user-attachments/assets/5fb4a351-b189-41e5-99c3-1613c6f2236d" />

### Detail page

<img width="1280" height="720" alt="Detail page with shared copy count" src="https://github.com/user-attachments/assets/faafc336-94e0-4e91-84c7-b77021366d9c" />