### PR TITLE
test: harden rejection and resubmission E2E

### DIFF
--- a/scripts/e2e/rejection-resubmission-helpers.ts
+++ b/scripts/e2e/rejection-resubmission-helpers.ts
@@ -13,10 +13,75 @@ export interface ApprovalOutcomeRow {
   approvalEmailStatus: string | null
 }
 
+const ALLOWED_E2E_ORIGINS = new Set(['http://localhost:3100', 'https://staging.statuslin.es'])
+
+export function assertAllowedE2ETarget(baseUrl: string): void {
+  const target = new URL(baseUrl)
+  if (
+    !ALLOWED_E2E_ORIGINS.has(target.origin) ||
+    target.pathname !== '/' ||
+    target.search !== '' ||
+    target.hash !== ''
+  ) {
+    throw new Error('E2E target is not allowed')
+  }
+}
+
+export function assertDisposableUserCleanup(result: PromiseSettledResult<unknown>): void {
+  if (result.status === 'rejected') {
+    throw new Error('failed to remove disposable E2E users')
+  }
+}
+
+export async function runDisposableUserCleanup(
+  cleanup: () => Promise<unknown>,
+): Promise<PromiseSettledResult<unknown>> {
+  let result = await Promise.allSettled([cleanup()])
+  if (result[0]?.status === 'rejected') {
+    result = await Promise.allSettled([cleanup()])
+  }
+  return result[0] ?? { status: 'rejected', reason: new Error('cleanup did not run') }
+}
+
+export function isTerminalDecisionEmailStatus(status: string | null | undefined): boolean {
+  return ['sent', 'failed', 'unavailable', 'ambiguous'].includes(status ?? '')
+}
+
 export function parseSessionCookie(output: string): string {
   const cookie = output.match(/better-auth\.session_token=(\S+)/)?.[1]
   if (!cookie) throw new Error('dev:login did not return a session cookie')
   return cookie
+}
+
+export function sessionCookieName(baseUrl: string): string {
+  const prefix = new URL(baseUrl).protocol === 'https:' ? '__Secure-' : ''
+  return `${prefix}better-auth.session_token`
+}
+
+export function browserCookieCommand(baseUrl: string, cookie: string): string[] {
+  const command = [
+    'cookies',
+    'set',
+    sessionCookieName(baseUrl),
+    cookie,
+    '--url',
+    baseUrl,
+    '--httpOnly',
+  ]
+  if (new URL(baseUrl).protocol === 'https:') command.push('--secure')
+  return command
+}
+
+export function renderStrategy(baseUrl: string): 'inline' | 'external' {
+  return new URL(baseUrl).hostname === 'localhost' ? 'inline' : 'external'
+}
+
+export function commandFailureMessage(
+  label: string,
+  output: string,
+  exposeOutput: boolean,
+): string {
+  return `${label} failed${exposeOutput && output ? `: ${output}` : ''}`
 }
 
 export function browserConsoleErrors(output: string): string[] {
@@ -24,6 +89,21 @@ export function browserConsoleErrors(output: string): string[] {
     .split('\n')
     .map((line) => line.trim())
     .filter((line) => /\[(error|console\.error)\]|hydrat|unhandled/i.test(line))
+}
+
+export function describeBrowserCommand(session: string, args: string[]): string {
+  const [command, first, second] = args
+  const prefix = `${session} browser: ${command ?? 'unknown'}`
+  if (command === 'wait') {
+    return [prefix, first, second].filter(Boolean).join(' ')
+  }
+  if (command === 'cookies') {
+    return [prefix, first].filter(Boolean).join(' ')
+  }
+  if (['click', 'fill', 'select', 'type'].includes(command ?? '')) {
+    return [prefix, first].filter(Boolean).join(' ')
+  }
+  return prefix
 }
 
 export function assertLinkedHistory(
@@ -53,7 +133,7 @@ export function assertLinkedHistory(
   }
 }
 
-export function assertPublishedAfterApprovalFailure(
+export function assertPublishedAfterApprovalDelivery(
   row: ApprovalOutcomeRow,
   expectedVersionId: string,
 ): void {
@@ -61,8 +141,8 @@ export function assertPublishedAfterApprovalFailure(
     row.configStatus !== 'published' ||
     row.currentVersionId !== expectedVersionId ||
     row.versionStatus !== 'approved' ||
-    row.approvalEmailStatus !== 'failed'
+    !isTerminalDecisionEmailStatus(row.approvalEmailStatus)
   ) {
-    throw new Error('approval email failure prevented publication')
+    throw new Error('approval decision is not fully published')
   }
 }

--- a/scripts/e2e/rejection-resubmission.ts
+++ b/scripts/e2e/rejection-resubmission.ts
@@ -7,14 +7,24 @@ import { configs, configVersions, renderJobs } from '@/db/schema'
 import { FakeSandboxRunner } from '@/render/fake-runner'
 import { processNextRenderJob } from '@/submit/worker'
 import {
+  assertAllowedE2ETarget,
+  assertDisposableUserCleanup,
   assertLinkedHistory,
-  assertPublishedAfterApprovalFailure,
+  assertPublishedAfterApprovalDelivery,
   browserConsoleErrors,
+  browserCookieCommand,
+  commandFailureMessage,
+  describeBrowserCommand,
+  isTerminalDecisionEmailStatus,
   parseSessionCookie,
+  renderStrategy,
+  runDisposableUserCleanup,
   type VersionHistoryRow,
 } from './rejection-resubmission-helpers'
 
 const BASE = process.env.BETTER_AUTH_URL ?? 'http://localhost:3100'
+assertAllowedE2ETarget(BASE)
+const RENDER_STRATEGY = renderStrategy(BASE)
 const AUTHOR_ID = 'e2e-rejection-author'
 const ADMIN_ID = 'e2e-rejection-admin'
 const AUTHOR_EMAIL = 'e2e-rejection-author@test.invalid'
@@ -26,7 +36,11 @@ const originalSource = '#!/bin/bash\necho original-e2e'
 const correctedSource = 'console.log("corrected-e2e")'
 const reason = `Remove the updater. ${marker}`
 
-async function run(command: string[], sensitive = false): Promise<string> {
+async function run(
+  command: string[],
+  sensitive = false,
+  label: string = command[0] ?? 'command',
+): Promise<string> {
   const proc = Bun.spawn(command, { stdout: 'pipe', stderr: 'pipe' })
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
@@ -34,24 +48,33 @@ async function run(command: string[], sensitive = false): Promise<string> {
     proc.exited,
   ])
   if (exitCode !== 0) {
-    throw new Error(`${command[0]} failed${sensitive ? '' : `: ${stderr || stdout}`}`)
+    throw new Error(commandFailureMessage(label, stderr || stdout, !sensitive))
   }
   return stdout
 }
 
 async function browser(session: string, ...args: string[]): Promise<string> {
-  return run(['agent-browser', '--session', session, ...args], args[0] === 'cookies')
+  return run(
+    ['agent-browser', '--session', session, ...args],
+    true,
+    describeBrowserCommand(session, args),
+  )
 }
 
 async function mintCookie(email: string): Promise<string> {
   return parseSessionCookie(await run(['bun', 'run', 'dev:login', email], true))
 }
 
-async function waitFor<T>(label: string, query: () => Promise<T | undefined>): Promise<T> {
-  for (let attempt = 0; attempt < 50; attempt++) {
+async function waitFor<T>(
+  label: string,
+  query: () => Promise<T | undefined>,
+  attempts = 50,
+  intervalMs = 200,
+): Promise<T> {
+  for (let attempt = 0; attempt < attempts; attempt++) {
     const result = await query()
     if (result !== undefined) return result
-    await sleep(200)
+    await sleep(intervalMs)
   }
   throw new Error(`timed out waiting for ${label}`)
 }
@@ -87,7 +110,25 @@ async function openReady(session: string, path: string, readySelector: string) {
   if (failures.length > 0) throw new Error(`${path} browser errors: ${failures.join(' | ')}`)
 }
 
-async function renderNext() {
+async function renderVersion(versionId: string) {
+  if (RENDER_STRATEGY === 'external') {
+    await waitFor(
+      `render job ${versionId}`,
+      async () => {
+        const [job] = await db
+          .select({ status: renderJobs.status })
+          .from(renderJobs)
+          .where(eq(renderJobs.configVersionId, versionId))
+        if (job?.status === 'failed') {
+          throw new Error(`render job ${versionId} failed`)
+        }
+        return job?.status === 'done' ? job : undefined
+      },
+      120,
+      1000,
+    )
+    return
+  }
   const processed = await processNextRenderJob(
     db,
     new FakeSandboxRunner({ 'clean-main': { stdout: 'e2e-preview' } }),
@@ -139,26 +180,8 @@ async function main() {
     mintCookie(AUTHOR_EMAIL),
     mintCookie(ADMIN_EMAIL),
   ])
-  await browser(
-    AUTHOR_SESSION,
-    'cookies',
-    'set',
-    'better-auth.session_token',
-    authorCookie,
-    '--url',
-    BASE,
-    '--httpOnly',
-  )
-  await browser(
-    ADMIN_SESSION,
-    'cookies',
-    'set',
-    'better-auth.session_token',
-    adminCookie,
-    '--url',
-    BASE,
-    '--httpOnly',
-  )
+  await browser(AUTHOR_SESSION, ...browserCookieCommand(BASE, authorCookie))
+  await browser(ADMIN_SESSION, ...browserCookieCommand(BASE, adminCookie))
 
   await openReady(AUTHOR_SESSION, '/submit', '#title')
   await browser(AUTHOR_SESSION, 'fill', '#title', marker)
@@ -169,24 +192,24 @@ async function main() {
     const [row] = await db.select().from(configs).where(eq(configs.title, marker))
     return row
   })
-  await renderNext()
 
   const [v1] = await db
     .select()
     .from(configVersions)
     .where(eq(configVersions.configId, submitted.id))
   if (!v1) throw new Error('submitted version not found')
+  await renderVersion(v1.id)
 
   await openReady(ADMIN_SESSION, '/admin', 'main')
   await clickButtonInCard(ADMIN_SESSION, marker, 'Reject')
   await browser(ADMIN_SESSION, 'fill', `#rejection-reason-${v1.id}`, reason)
   await clickButtonInCard(ADMIN_SESSION, marker, 'Reject and email author')
-  await waitFor('failed rejection email', async () => {
+  await waitFor('terminal rejection email delivery', async () => {
     const [row] = await db
-      .select()
+      .select({ emailStatus: configVersions.rejectionEmailStatus })
       .from(configVersions)
-      .where(and(eq(configVersions.id, v1.id), eq(configVersions.rejectionEmailStatus, 'failed')))
-    return row
+      .where(eq(configVersions.id, v1.id))
+    return isTerminalDecisionEmailStatus(row?.emailStatus) ? row : undefined
   })
 
   await openReady(AUTHOR_SESSION, '/me', 'main')
@@ -240,11 +263,11 @@ async function main() {
 
   await openReady(ADMIN_SESSION, '/admin', 'main')
   await clickButtonInCard(ADMIN_SESSION, `${marker} corrected`, 'Run network preview')
-  await renderNext()
+  await renderVersion(v2Record.id)
   await browser(ADMIN_SESSION, 'reload')
   await browser(ADMIN_SESSION, 'wait', '500')
   await clickButtonInCard(ADMIN_SESSION, `${marker} corrected`, 'Approve')
-  const approvalOutcome = await waitFor('published v2 with failed approval email', async () => {
+  const approvalOutcome = await waitFor('published v2 with terminal approval email', async () => {
     const [row] = await db
       .select({
         configStatus: configs.status,
@@ -255,9 +278,9 @@ async function main() {
       .from(configVersions)
       .innerJoin(configs, eq(configs.id, configVersions.configId))
       .where(and(eq(configs.id, submitted.id), eq(configVersions.id, v2Record.id)))
-    return row?.approvalEmailStatus === 'failed' ? row : undefined
+    return isTerminalDecisionEmailStatus(row?.approvalEmailStatus) ? row : undefined
   })
-  assertPublishedAfterApprovalFailure(approvalOutcome, v2Record.id)
+  assertPublishedAfterApprovalDelivery(approvalOutcome, v2Record.id)
 
   await openReady(AUTHOR_SESSION, `/c/${submitted.slug}`, 'main')
   const detail = await browser(AUTHOR_SESSION, 'snapshot')
@@ -266,13 +289,25 @@ async function main() {
   console.log(`E2E PASSED: ${submitted.slug}`)
 }
 
+let mainFailure: unknown
 try {
   await main()
-} finally {
-  await Promise.allSettled([
-    browser(AUTHOR_SESSION, 'close'),
-    browser(ADMIN_SESSION, 'close'),
-    db.delete(user).where(inArray(user.id, [AUTHOR_ID, ADMIN_ID])),
-  ])
+} catch (error) {
+  mainFailure = error
 }
+const browserCleanup = Promise.allSettled([
+  browser(AUTHOR_SESSION, 'close'),
+  browser(ADMIN_SESSION, 'close'),
+])
+const databaseCleanup = await runDisposableUserCleanup(() =>
+  db.delete(user).where(inArray(user.id, [AUTHOR_ID, ADMIN_ID])),
+)
+await browserCleanup
+try {
+  assertDisposableUserCleanup(databaseCleanup)
+} catch (cleanupError) {
+  if (mainFailure === undefined) mainFailure = cleanupError
+  else console.error('failed to remove disposable E2E users after an earlier failure')
+}
+if (mainFailure !== undefined) throw mainFailure
 process.exit(0)

--- a/test/scripts/rejection-resubmission-e2e.test.ts
+++ b/test/scripts/rejection-resubmission-e2e.test.ts
@@ -1,9 +1,18 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
+  assertAllowedE2ETarget,
+  assertDisposableUserCleanup,
   assertLinkedHistory,
-  assertPublishedAfterApprovalFailure,
+  assertPublishedAfterApprovalDelivery,
   browserConsoleErrors,
+  browserCookieCommand,
+  commandFailureMessage,
+  describeBrowserCommand,
+  isTerminalDecisionEmailStatus,
   parseSessionCookie,
+  renderStrategy,
+  runDisposableUserCleanup,
+  sessionCookieName,
 } from '../../scripts/e2e/rejection-resubmission-helpers'
 
 describe('rejection/resubmission E2E helpers', () => {
@@ -34,6 +43,105 @@ better-auth.session_token=token.signature==
     expect(browserConsoleErrors('[debug] [vite] connected.')).toEqual([])
   })
 
+  it('identifies browser waits and selectors without exposing submitted values or cookies', () => {
+    expect(describeBrowserCommand('author', ['wait', '--load', 'networkidle'])).toBe(
+      'author browser: wait --load networkidle',
+    )
+    expect(describeBrowserCommand('author', ['fill', '#source', 'secret script source'])).toBe(
+      'author browser: fill #source',
+    )
+    expect(
+      describeBrowserCommand('author', [
+        'cookies',
+        'set',
+        'better-auth.session_token',
+        'secret-cookie',
+      ]),
+    ).toBe('author browser: cookies set')
+  })
+
+  it('uses Better Auth’s secure cookie name only for HTTPS targets', () => {
+    expect(sessionCookieName('http://localhost:3100')).toBe('better-auth.session_token')
+    expect(sessionCookieName('https://staging.statuslin.es')).toBe(
+      '__Secure-better-auth.session_token',
+    )
+  })
+
+  it('constructs secure staging cookies without weakening local cookies', () => {
+    expect(browserCookieCommand('http://localhost:3100', 'test-cookie')).toEqual([
+      'cookies',
+      'set',
+      'better-auth.session_token',
+      'test-cookie',
+      '--url',
+      'http://localhost:3100',
+      '--httpOnly',
+    ])
+    expect(browserCookieCommand('https://staging.statuslin.es', 'test-cookie')).toEqual([
+      'cookies',
+      'set',
+      '__Secure-better-auth.session_token',
+      'test-cookie',
+      '--url',
+      'https://staging.statuslin.es',
+      '--httpOnly',
+      '--secure',
+    ])
+  })
+
+  it('refuses to forge sessions outside the exact local and staging origins', () => {
+    expect(() => assertAllowedE2ETarget('http://localhost:3100')).not.toThrow()
+    expect(() => assertAllowedE2ETarget('https://staging.statuslin.es')).not.toThrow()
+    expect(() => assertAllowedE2ETarget('https://statuslin.es')).toThrow(
+      'E2E target is not allowed',
+    )
+    expect(() => assertAllowedE2ETarget('https://staging.statuslin.es.attacker.test')).toThrow(
+      'E2E target is not allowed',
+    )
+  })
+
+  it('redacts raw command output and cleanup errors from harness failures', () => {
+    expect(
+      commandFailureMessage(
+        'author browser: fill #source',
+        'secret script source and session cookie',
+        false,
+      ),
+    ).toBe('author browser: fill #source failed')
+    expect(() =>
+      assertDisposableUserCleanup({
+        status: 'rejected',
+        reason: new Error('postgres://secret@database'),
+      }),
+    ).toThrow('failed to remove disposable E2E users')
+    expect(() =>
+      assertDisposableUserCleanup({
+        status: 'fulfilled',
+        value: [{ id: 'e2e-rejection-author' }],
+      }),
+    ).not.toThrow()
+  })
+
+  it('retries a transient disposable-user cleanup failure once', async () => {
+    const cleanup = vi
+      .fn<() => Promise<unknown>>()
+      .mockRejectedValueOnce(new Error('connection closed'))
+      .mockResolvedValueOnce([{ id: 'e2e-rejection-author' }])
+
+    const result = await runDisposableUserCleanup(cleanup)
+
+    expect(cleanup).toHaveBeenCalledTimes(2)
+    expect(result).toEqual({
+      status: 'fulfilled',
+      value: [{ id: 'e2e-rejection-author' }],
+    })
+  })
+
+  it('renders inline only when the E2E targets the local app', () => {
+    expect(renderStrategy('http://localhost:3100')).toBe('inline')
+    expect(renderStrategy('https://staging.statuslin.es')).toBe('external')
+  })
+
   it('accepts only a same-config, same-slug rejected v1 and pending v2 history', () => {
     expect(() =>
       assertLinkedHistory(
@@ -62,29 +170,48 @@ better-auth.session_token=token.signature==
     ).not.toThrow()
   })
 
-  it('requires approval email failure to leave the corrected version published', () => {
+  it.each([
+    'sent',
+    'failed',
+    'unavailable',
+    'ambiguous',
+  ])('requires a published corrected version after %s approval email delivery', (approvalEmailStatus) => {
     expect(() =>
-      assertPublishedAfterApprovalFailure(
+      assertPublishedAfterApprovalDelivery(
         {
           configStatus: 'published',
           currentVersionId: 'version-2',
           versionStatus: 'approved',
-          approvalEmailStatus: 'failed',
+          approvalEmailStatus,
         },
         'version-2',
       ),
     ).not.toThrow()
+  })
+
+  it('rejects a non-terminal approval email status', () => {
     expect(() =>
-      assertPublishedAfterApprovalFailure(
+      assertPublishedAfterApprovalDelivery(
         {
-          configStatus: 'draft',
-          currentVersionId: null,
+          configStatus: 'published',
+          currentVersionId: 'version-2',
           versionStatus: 'approved',
-          approvalEmailStatus: 'failed',
+          approvalEmailStatus: 'sending',
         },
         'version-2',
       ),
-    ).toThrow('approval email failure prevented publication')
+    ).toThrow('approval decision is not fully published')
+  })
+
+  it('distinguishes terminal decision email outcomes from in-progress delivery', () => {
+    expect(
+      ['sent', 'failed', 'unavailable', 'ambiguous'].map(isTerminalDecisionEmailStatus),
+    ).toEqual([true, true, true, true])
+    expect(['pending', 'sending', null].map(isTerminalDecisionEmailStatus)).toEqual([
+      false,
+      false,
+      false,
+    ])
   })
 
   it.each([


### PR DESCRIPTION
## What changed

- instruments browser commands with safe, actionable failure labels
- supports secure Better Auth cookies and the real staging render worker
- verifies terminal approval and rejection email outcomes
- restricts session forging to exact local and staging origins and redacts sensitive failures
- makes disposable-user cleanup mandatory with one retry for transient database disconnects

## Why

The production rollout needs a high-confidence signed-in staging test for the complete submit, reject, resubmit, approve, and publish journey. The prior harness could hang without identifying the browser boundary, assumed local-only rendering and email behavior, and could silently leave test users behind.

## Validation

- complete staging E2E passed against the real worker and Resend
- cleanup confirmed with a fresh database query returning no disposable users
- bun run check: 155 test files passed; 999 tests passed