### PR TITLE
fix: harden SEO rendering and crawl signals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
 # syntax=docker/dockerfile:1
+ARG PREVIOUS_IMAGE=asset-retention-bootstrap
+
+FROM oven/bun:1 AS asset-retention-bootstrap
+RUN mkdir -p /app/.output/public/assets
+
+FROM ${PREVIOUS_IMAGE} AS previous
+
 FROM oven/bun:1 AS base
 WORKDIR /app
 
@@ -7,7 +14,9 @@ ENV NODE_ENV=production
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 COPY . .
-RUN bun run build
+RUN --mount=type=bind,from=previous,source=/app/.output,target=/previous-output,readonly \
+    bun run build && \
+    bun run scripts/retain-build-assets.ts /app/.output/public/assets /previous-output/public/assets
 
 FROM base AS runtime
 ENV NODE_ENV=production

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -21,6 +21,26 @@ filled differs per environment:
 **Staging and production run the same Docker image.** You validate an image on staging, then
 deploy that exact image (by digest) to production — never a separate rebuild.
 
+## Fingerprinted asset retention
+
+Each candidate image is self-contained with the current plus nineteen prior distinct
+`/assets/**` generations. The Docker build mounts the previous production image's `.output`
+read-only, builds the current generation, then `scripts/retain-build-assets.ts` copies the selected
+historical files and writes `.output/public/assets/.asset-generations.json`. Identical generations
+and identical files are stored once; malformed manifests, missing files, unsafe paths, symlinks,
+and same-name files with different contents fail the build.
+
+Nitro's generated static manifest knows only about the current build. Current assets are served by
+Nitro's normal static middleware; on a miss, the explicit method-agnostic `/assets/**` handler runs
+before the catch-all renderer and serves retained `GET`/`HEAD` files with immutable caching. Other
+methods return 405. Do not add a non-fallthrough `publicAssets` base for this directory: it would
+intercept retained paths before the fallback can inspect them safely.
+
+`PREVIOUS_IMAGE` defaults to the Dockerfile's empty `asset-retention-bootstrap` stage so the first
+build has a valid `/app/.output/public/assets` mount. Normal staging deploys must override it with
+the exact currently running production image; production still promotes the tested staging digest
+without rebuilding.
+
 ## What runs in each Fly app
 
 Two process groups off one image (declared in `fly.toml` for prod and `fly.staging.toml` for staging):
@@ -109,8 +129,14 @@ machine before the box is in trouble.
 
 Staging:
 ```sh
-bun run deploy:staging   # fly deploy --config fly.staging.toml
+bun run deploy:staging
 ```
+This command reads every production machine's full image reference and requires unanimous agreement
+on the registry, repository, and digest. It then passes that exact reference to the staging build as
+`PREVIOUS_IMAGE`. Missing, malformed, or mixed production images abort before `fly deploy`; do not
+replace this command with a direct staging deploy, because doing so drops the previous generation
+that the Docker build uses to retain hashed assets.
+
 The `release_command` in the Fly config runs `bun run src/db/migrate.ts` against that env's DB before
 the new version goes live. That script applies migrations via `drizzle-orm`'s runtime migrator
 (`drizzle-orm/postgres-js/migrator`) reading the committed `drizzle/` SQL folder — it does **not**
@@ -154,17 +180,22 @@ Promote to production with the **gated** command — never promote by hand:
 ```sh
 bun run deploy:prod
 ```
-`scripts/deploy-prod.ts` does three things and **refuses to promote unless the middle one passes**:
-1. reads the digest of the image staging is running **now** (deploy staging first with
-   `bun run deploy:staging` — the promote doesn't deploy staging itself, so a staging build you
-   already validated isn't rebuilt).
-2. a **real-browser smoke against staging** — `SMOKE_BASE_URL=https://staging.statuslin.es
-   SMOKE_SIGNED_OUT_ONLY=1 bun run smoke` — which loads the home + a `/c/<slug>` detail page in
-   `agent-browser` and fails if either doesn't hydrate or logs a console error.
-3. only on green, re-reads the staging digest and **refuses if it changed during the smoke**
-   (someone redeployed staging mid-run), then
-   `fly deploy --app statuslines --image registry.fly.io/statuslines-staging@<digest>`
-   (the exact image it validated, by digest — no rebuild).
+`scripts/deploy-prod.ts` gates the promotion as one operation:
+
+1. It saves the current production asset URLs referenced by `/`, `/resources`, `/terms`, and one
+   linked `/c/<slug>` detail page.
+2. It runs a real-browser smoke against staging. The browser requires the expected homepage title,
+   exact root canonical, H1, and non-error body; it also fetches every same-origin initial script,
+   stylesheet, and modulepreload and requires at least one and success for all.
+3. It requests every saved production asset from staging and requires status 200, a file-extension
+   appropriate non-HTML content type/body, and one-year immutable caching without contradictory
+   `no-cache` or `no-store` directives. Every required production page must reference at least one
+   qualifying same-origin asset.
+4. Immediately before promotion it re-reads both production and staging image references. Either
+   changing during validation aborts. The exact staging image is promoted by digest, without a
+   rebuild.
+5. After promotion, every saved asset must pass the same status, type/body, and caching checks on
+   production.
 
 **Why this is mandatory, not optional:** every source gate (tsc/lint/vitest) passes while the client
 bundle is dead — a server-only import leaking into the browser throws `Buffer is not defined`,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "check:frontend": "bun run scripts/check-frontend.ts",
     "smoke": "bun run scripts/smoke.ts",
     "e2e:rejection-resubmission": "bun run scripts/e2e/rejection-resubmission.ts",
-    "deploy:staging": "fly deploy --config fly.staging.toml",
+    "deploy:staging": "bun run scripts/deploy-staging.ts",
     "deploy:prod": "bun run scripts/deploy-prod.ts",
     "render": "bun run scripts/render.ts",
     "rerender:previews": "bun run scripts/rerender-previews.ts",

--- a/scripts/deploy-prod.ts
+++ b/scripts/deploy-prod.ts
@@ -1,126 +1,178 @@
-/**
- * Gated production promote: smoke whatever staging runs → promote that exact image by digest.
- *
- * Why this exists: source gates (tsc/lint/vitest) all pass while the client bundle is dead —
- * a server-only import leaking into the browser throws `Buffer is not defined`, hydration
- * fails, every button goes dead, and SSR still returns 200 so nothing alerts. On 2026-06-29
- * that shipped to prod for ~2.5h. The fix is to make a REAL browser confirm staging hydrates
- * before prod can ever see the image. Staging runs the exact same Docker image we promote, so
- * smoking staging smokes the real production bundle.
- *
- * Deploy staging first with `bun run deploy:staging` (its own command, so a staging deploy
- * that was already validated by hand isn't repeated here). Then this script:
- *   1. reads the digest of the image staging is running now
- *   2. smokes staging       (signed-out browser checks: pages hydrate, no console errors)
- *   3. re-reads the digest and refuses if it changed mid-smoke (someone redeployed staging),
- *      then promotes on green only (fly deploy --app statuslines --image …@<digest>)
- *
- * Run: `bun run deploy:prod`. Aborts before promoting if the smoke fails or the digest moved.
- */
 import { spawn, spawnSync } from 'node:child_process'
+import { parseFlyImageReference } from './deploy-staging'
 
+const PRODUCTION_APP = 'statuslines'
 const STAGING_APP = 'statuslines-staging'
-const PROD_APP = 'statuslines'
+const PRODUCTION_URL = 'https://statuslin.es'
 const STAGING_URL = 'https://staging.statuslin.es'
 
-/**
- * Pull the single image digest from `fly image show --app <app> --json` output. Every machine in
- * the app runs the same image, so all `Digest` fields must agree — if they don't, the deploy
- * hasn't settled and promoting would ship an ambiguous image, so we throw instead of guessing.
- */
-export function parseStagingDigest(jsonOutput: string): string {
-  // fly emits PascalCase keys (Digest, Repository, …); read via an index type so we don't declare
-  // a non-camelCase property name (which the linter rejects).
-  const entries = JSON.parse(jsonOutput) as Array<Record<string, string>>
-  const [digest, ...rest] = [...new Set(entries.map((e) => e.Digest).filter((d) => !!d))]
-  if (!digest) throw new Error('no image digest found in `fly image show` output')
-  if (rest.length > 0)
-    throw new Error(
-      `staging is running mixed images (${[digest, ...rest].join(', ')}) — deploy not settled, refusing to promote`,
-    )
-  if (!/^sha256:[0-9a-f]{64}$/.test(digest))
-    throw new Error(`unexpected digest format from fly: ${digest}`)
-  return digest
+type ImageCheckpoint = {
+  productionBefore: string
+  productionNow: string
+  stagingBefore: string
+  stagingNow: string
 }
 
-/**
- * The digest smoked and the digest promoted must be the same image. If staging was redeployed
- * while the smoke ran, the smoke's verdict says nothing about what a promote would ship — throw
- * instead of promoting an unvalidated image.
- */
-export function assertDigestUnchanged(smoked: string, current: string): void {
-  if (smoked !== current)
+/** Promotion is valid only while both checked deployments remain unchanged. */
+export function assertImageReferencesUnchanged(checkpoint: ImageCheckpoint): void {
+  if (checkpoint.productionBefore !== checkpoint.productionNow)
     throw new Error(
-      `staging image changed during the smoke (smoked ${smoked}, staging now runs ${current}) — refusing to promote. Re-run bun run deploy:prod.`,
+      `production image changed during validation (${checkpoint.productionBefore} → ${checkpoint.productionNow})`,
+    )
+  if (checkpoint.stagingBefore !== checkpoint.stagingNow)
+    throw new Error(
+      `staging image changed during validation (${checkpoint.stagingBefore} → ${checkpoint.stagingNow})`,
     )
 }
 
-/** Run a command with the parent's stdio attached; resolve its exit code. */
-function run(cmd: string[], env: NodeJS.ProcessEnv = process.env): Promise<number> {
-  return new Promise((resolve) => {
-    const [bin, ...args] = cmd
-    if (!bin) throw new Error('run: empty command')
-    const child = spawn(bin, args, { stdio: 'inherit', env })
-    // A spawn failure (e.g. `fly` not on PATH) emits 'error' and may never emit 'close' — resolve
-    // non-zero so the gate fails closed instead of hanging forever.
-    child.on('error', (err) => {
-      console.error(`failed to run \`${bin}\`: ${err.message}`)
-      resolve(1)
-    })
-    child.on('close', (code: number | null) => resolve(code ?? 1))
-  })
+function attributeValues(html: string, pattern: RegExp): string[] {
+  return [...html.matchAll(pattern)].flatMap((match) => (match[1] ? [match[1]] : []))
 }
 
-function die(message: string): never {
-  console.error(`\n✗ ${message}`)
-  process.exit(1)
+function assetsFromHtml(html: string, pageUrl: string): string[] {
+  const origin = new URL(pageUrl).origin
+  const sources = [
+    ...attributeValues(html, /<script\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/gi),
+    ...attributeValues(
+      html,
+      /<link\b(?=[^>]*\brel=["'][^"']*\b(?:stylesheet|modulepreload)\b[^"']*["'])[^>]*\bhref=["']([^"']+)["'][^>]*>/gi,
+    ),
+  ]
+  return sources
+    .map((source) => new URL(source, pageUrl))
+    .filter((url) => url.origin === origin)
+    .map((url) => url.href)
 }
 
-/** Read the digest staging is running right now (dies on error/ambiguity). */
-function readStagingDigest(): string {
-  const shown = spawnSync('fly', ['image', 'show', '--app', STAGING_APP, '--json'], {
-    encoding: 'utf8',
-  })
-  if (shown.status !== 0) die(`could not read staging image: ${shown.stderr || shown.stdout}`)
-  try {
-    return parseStagingDigest(shown.stdout)
-  } catch (err) {
-    die(err instanceof Error ? err.message : String(err))
+/**
+ * Save the current production generation's assets from the three stable pages and one real detail
+ * page. The caller supplies page loading so this remains unit-testable without network access.
+ */
+export async function collectProductionAssetUrls(
+  origin: string,
+  fetchPage: (url: string) => Promise<string>,
+): Promise<string[]> {
+  const base = origin.replace(/\/$/, '')
+  const homeUrl = `${base}/`
+  const home = await fetchPage(homeUrl)
+  const detailHref = attributeValues(home, /<a\b[^>]*\bhref=["'](\/c\/[^"'?#]+)["'][^>]*>/gi)[0]
+  if (!detailHref) throw new Error('production homepage has no linked detail page')
+
+  const pageUrls = [homeUrl, `${base}/resources`, `${base}/terms`, new URL(detailHref, base).href]
+  const pages = await Promise.all(
+    pageUrls.map(async (pageUrl) => ({ html: await fetchPage(pageUrl), pageUrl })),
+  )
+  const pageAssets = pages.map(({ html, pageUrl }) => ({
+    assets: assetsFromHtml(html, pageUrl),
+    pageUrl,
+  }))
+  for (const { assets, pageUrl } of pageAssets) {
+    if (assets.length === 0)
+      throw new Error(`${new URL(pageUrl).pathname} has no qualifying same-origin asset`)
+  }
+  return [...new Set(pageAssets.flatMap(({ assets }) => assets))].sort()
+}
+
+const CONTENT_TYPES: Record<string, RegExp> = {
+  '.css': /^text\/css\b/i,
+  '.gif': /^image\/gif\b/i,
+  '.jpeg': /^image\/jpeg\b/i,
+  '.jpg': /^image\/jpeg\b/i,
+  '.js': /^(?:text|application)\/javascript\b/i,
+  '.mjs': /^(?:text|application)\/javascript\b/i,
+  '.png': /^image\/png\b/i,
+  '.svg': /^image\/svg\+xml\b/i,
+  '.webp': /^image\/webp\b/i,
+  '.woff': /^font\/woff\b/i,
+  '.woff2': /^font\/woff2\b/i,
+}
+
+/** Validate one retained asset response, including the common HTML fallback failure mode. */
+export async function assertAssetResponse(url: string, response: Response): Promise<void> {
+  if (response.status !== 200) throw new Error(`${url} returned status ${response.status}`)
+  const pathname = new URL(url).pathname.toLowerCase()
+  const extension = Object.keys(CONTENT_TYPES).find((candidate) => pathname.endsWith(candidate))
+  const contentType = response.headers.get('content-type') ?? ''
+  const expectedType = extension ? CONTENT_TYPES[extension] : undefined
+  if (!expectedType?.test(contentType))
+    throw new Error(`${url} has unexpected content-type ${contentType || '(missing)'}`)
+  const cacheControl = response.headers.get('cache-control') ?? ''
+  const contradictory = cacheControl.match(/(?:^|,)\s*(no-store|no-cache)\b/i)?.[1]
+  if (contradictory) throw new Error(`${url} has contradictory ${contradictory} caching`)
+  if (!/\bimmutable\b/i.test(cacheControl)) throw new Error(`${url} is missing immutable caching`)
+  const maxAge = Number(cacheControl.match(/(?:^|,)\s*max-age=(\d+)\b/i)?.[1] ?? 0)
+  if (maxAge < 31_536_000) throw new Error(`${url} has insufficient max-age caching`)
+
+  const beginning = new TextDecoder().decode((await response.arrayBuffer()).slice(0, 256))
+  const withoutLeadingComments = beginning.replace(/^\s*(?:<!--[\s\S]*?-->\s*)*/, '')
+  if (/^\s*<(?:!doctype\s+html|html|head|body)\b/i.test(withoutLeadingComments))
+    throw new Error(`${url} returned an HTML body instead of an asset`)
+}
+
+async function fetchPage(url: string): Promise<string> {
+  const response = await fetch(url)
+  if (!response.ok) throw new Error(`${url} returned status ${response.status}`)
+  return response.text()
+}
+
+async function verifyAssets(assetUrls: string[], targetOrigin: string): Promise<void> {
+  const target = new URL(targetOrigin)
+  for (const productionAssetUrl of assetUrls) {
+    const source = new URL(productionAssetUrl)
+    const url = new URL(`${source.pathname}${source.search}`, target).href
+    await assertAssetResponse(url, await fetch(url))
   }
 }
 
-async function main(): Promise<void> {
-  console.log('▸ [1/3] reading the image staging runs now …')
-  console.log(`  (deploy staging first with \`bun run deploy:staging\` if you haven't)`)
-  const digest = readStagingDigest()
-  console.log(`  staging image digest: ${digest}`)
+function readImage(app: string, label: string): string {
+  const shown = spawnSync('fly', ['image', 'show', '--app', app, '--json'], {
+    encoding: 'utf8',
+  })
+  if (shown.status !== 0) throw new Error(`could not read ${label} image`)
+  return parseFlyImageReference(shown.stdout, label)
+}
 
-  console.log('\n▸ [2/3] smoking staging in a real browser (signed-out hydration) …')
-  // Member-assign the env vars (not an object literal) so their SCREAMING_SNAKE names don't trip
-  // the camelCase property-name lint.
+function run(command: string[], env: NodeJS.ProcessEnv = process.env): Promise<number> {
+  const [bin, ...args] = command
+  if (!bin) throw new Error('cannot run an empty command')
+  return new Promise((resolve) => {
+    const child = spawn(bin, args, { env, stdio: 'inherit' })
+    child.on('error', () => resolve(1))
+    child.on('close', (code) => resolve(code ?? 1))
+  })
+}
+
+export async function main(): Promise<void> {
+  const productionBefore = readImage(PRODUCTION_APP, 'production')
+  const stagingBefore = readImage(STAGING_APP, 'staging')
+  const assetUrls = await collectProductionAssetUrls(PRODUCTION_URL, fetchPage)
+
   const smokeEnv = { ...process.env }
   smokeEnv.SMOKE_BASE_URL = STAGING_URL
   smokeEnv.SMOKE_SIGNED_OUT_ONLY = '1'
-  const smokeCode = await run(['bun', 'run', 'smoke'], smokeEnv)
-  if (smokeCode !== 0) {
-    die(`staging smoke FAILED — refusing to promote ${digest} to ${PROD_APP}. Fix staging first.`)
-  }
+  if ((await run(['bun', 'run', 'smoke'], smokeEnv)) !== 0)
+    throw new Error('staging browser smoke failed')
 
-  console.log('\n▸ [3/3] smoke green — promoting validated image to production …')
-  try {
-    assertDigestUnchanged(digest, readStagingDigest())
-  } catch (err) {
-    die(err instanceof Error ? err.message : String(err))
-  }
-  const image = `registry.fly.io/${STAGING_APP}@${digest}`
-  if ((await run(['fly', 'deploy', '--app', PROD_APP, '--image', image])) !== 0) {
-    die('prod promote failed (staging is healthy; image is validated — safe to retry the promote)')
-  }
-  console.log(`\n✓ production now running validated image ${image}`)
+  await verifyAssets(assetUrls, STAGING_URL)
+  assertImageReferencesUnchanged({
+    productionBefore,
+    productionNow: readImage(PRODUCTION_APP, 'production'),
+    stagingBefore,
+    stagingNow: readImage(STAGING_APP, 'staging'),
+  })
+
+  if ((await run(['fly', 'deploy', '--app', PRODUCTION_APP, '--image', stagingBefore])) !== 0)
+    throw new Error('production promotion failed')
+
+  await verifyAssets(assetUrls, PRODUCTION_URL)
+  console.log(`production is running validated image ${stagingBefore}`)
 }
 
-// Only run the deploy when invoked directly (`bun run scripts/deploy-prod.ts`); importing this
-// file (e.g. from the test) must NOT trigger a deploy.
 if (import.meta.main) {
-  await main()
+  try {
+    await main()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
 }

--- a/scripts/deploy-staging.ts
+++ b/scripts/deploy-staging.ts
@@ -1,0 +1,81 @@
+import { spawn, spawnSync } from 'node:child_process'
+
+const PRODUCTION_APP = 'statuslines'
+
+type FlyImageEntry = Record<string, unknown>
+
+function imageReference(entry: FlyImageEntry, label: string): string {
+  const registry = entry.Registry
+  const repository = entry.Repository
+  const digest = entry.Digest
+  if (typeof registry !== 'string' || !/^[a-z0-9.-]+(?::[0-9]+)?$/.test(registry))
+    throw new Error(`${label} image has an unexpected registry`)
+  if (typeof repository !== 'string' || !/^[a-z0-9]+(?:[._/-][a-z0-9]+)*$/.test(repository))
+    throw new Error(`${label} image has an unexpected repository`)
+  if (typeof digest !== 'string' || !/^sha256:[0-9a-f]{64}$/.test(digest))
+    throw new Error(`${label} image has an unexpected digest`)
+  return `${registry}/${repository}@${digest}`
+}
+
+/** Parse the one full image reference unanimously running across an app's machines. */
+export function parseFlyImageReference(jsonOutput: string, label: string): string {
+  const entries = JSON.parse(jsonOutput) as unknown
+  if (!Array.isArray(entries) || entries.length === 0)
+    throw new Error(`no image found for ${label}`)
+
+  const references = [
+    ...new Set(entries.map((entry) => imageReference(entry as FlyImageEntry, label))),
+  ]
+  if (references.length !== 1)
+    throw new Error(`${label} is running mixed images (${references.join(', ')})`)
+  const reference = references[0]
+  if (!reference) throw new Error(`no image found for ${label}`)
+  return reference
+}
+
+/** Construct the staging deploy whose build inherits the exact current production image. */
+export function buildStagingDeployCommand(productionImage: string): string[] {
+  return [
+    'fly',
+    'deploy',
+    '--config',
+    'fly.staging.toml',
+    '--build-arg',
+    `PREVIOUS_IMAGE=${productionImage}`,
+  ]
+}
+
+export function readFlyImageReference(app: string, label: string): string {
+  const shown = spawnSync('fly', ['image', 'show', '--app', app, '--json'], {
+    encoding: 'utf8',
+  })
+  if (shown.status !== 0)
+    throw new Error(`could not read ${label} image: ${shown.stderr || shown.stdout}`)
+  return parseFlyImageReference(shown.stdout, label)
+}
+
+function run(command: string[]): Promise<number> {
+  const [bin, ...args] = command
+  if (!bin) throw new Error('cannot run an empty command')
+  return new Promise((resolve) => {
+    const child = spawn(bin, args, { stdio: 'inherit' })
+    child.on('error', () => resolve(1))
+    child.on('close', (code) => resolve(code ?? 1))
+  })
+}
+
+export async function main(): Promise<void> {
+  const productionImage = readFlyImageReference(PRODUCTION_APP, 'production')
+  console.log(`building staging with retained assets from ${productionImage}`)
+  const code = await run(buildStagingDeployCommand(productionImage))
+  if (code !== 0) throw new Error('staging deploy failed')
+}
+
+if (import.meta.main) {
+  try {
+    await main()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
+}

--- a/scripts/retain-build-assets.ts
+++ b/scripts/retain-build-assets.ts
@@ -1,0 +1,169 @@
+import { copyFile, lstat, mkdir, readdir, readFile, realpath, writeFile } from 'node:fs/promises'
+import { dirname, posix, relative, resolve, sep } from 'node:path'
+
+const MANIFEST_FILENAME = '.asset-generations.json'
+const DEFAULT_GENERATION_LIMIT = 20
+
+type AssetManifest = {
+  version: 1
+  generations: string[][]
+}
+
+export type RetainBuildAssetsOptions = {
+  currentAssetsDir: string
+  previousAssetsDir: string
+  generationLimit?: number
+}
+
+function assertSafeAssetPath(path: string): void {
+  if (
+    path.length === 0 ||
+    path.includes('\0') ||
+    path.includes('\\') ||
+    path === MANIFEST_FILENAME ||
+    posix.isAbsolute(path) ||
+    posix.normalize(path) !== path ||
+    path === '..' ||
+    path.startsWith('../')
+  ) {
+    throw new Error(`Asset manifest contains unsafe path: ${JSON.stringify(path)}`)
+  }
+}
+
+async function listFiles(root: string, directory = root): Promise<string[]> {
+  const files: string[] = []
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    if (directory === root && entry.name === MANIFEST_FILENAME) continue
+    const absolutePath = resolve(directory, entry.name)
+    const relativePath = relative(root, absolutePath).split(sep).join('/')
+    assertSafeAssetPath(relativePath)
+    if (entry.isSymbolicLink()) throw new Error(`Asset is a symlink: ${relativePath}`)
+    if (entry.isDirectory()) files.push(...(await listFiles(root, absolutePath)))
+    else if (entry.isFile()) files.push(relativePath)
+  }
+  return files.sort()
+}
+
+function parseManifest(contents: string): AssetManifest {
+  let value: unknown
+  try {
+    value = JSON.parse(contents)
+  } catch {
+    throw new Error('Asset generation manifest is malformed')
+  }
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    !('version' in value) ||
+    value.version !== 1 ||
+    !('generations' in value) ||
+    !Array.isArray(value.generations) ||
+    !value.generations.every(
+      (generation) =>
+        Array.isArray(generation) && generation.every((path) => typeof path === 'string'),
+    )
+  ) {
+    throw new Error('Asset generation manifest is malformed')
+  }
+  const generations = value.generations.map((generation) => {
+    for (const path of generation) assertSafeAssetPath(path)
+    return [...new Set(generation)].sort()
+  })
+  return { version: 1, generations }
+}
+
+async function previousGenerations(previousAssetsDir: string): Promise<string[][]> {
+  const manifestPath = resolve(previousAssetsDir, MANIFEST_FILENAME)
+  try {
+    return parseManifest(await readFile(manifestPath, 'utf8')).generations
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    const legacyFiles = await listFiles(previousAssetsDir)
+    return legacyFiles.length === 0 ? [] : [legacyFiles]
+  }
+}
+
+async function assertRegularFile(root: string, path: string): Promise<string> {
+  assertSafeAssetPath(path)
+  const rootPath = await realpath(root)
+  const filePath = resolve(rootPath, path)
+  if (!filePath.startsWith(`${rootPath}${sep}`)) throw new Error(`Asset path is unsafe: ${path}`)
+  let stats: Awaited<ReturnType<typeof lstat>>
+  let canonicalPath: string
+  try {
+    ;[stats, canonicalPath] = await Promise.all([lstat(filePath), realpath(filePath)])
+  } catch {
+    throw new Error(`Asset manifest references missing file: ${path}`)
+  }
+  if (!stats.isFile() || stats.isSymbolicLink() || canonicalPath !== filePath) {
+    throw new Error(`Asset manifest references unsafe file: ${path}`)
+  }
+  return filePath
+}
+
+async function copyUniqueAsset(source: string, destination: string, path: string): Promise<void> {
+  try {
+    const existing = await readFile(destination)
+    const incoming = await readFile(source)
+    if (!existing.equals(incoming)) throw new Error(`Asset filename collision: ${path}`)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    await mkdir(dirname(destination), { recursive: true })
+    await copyFile(source, destination)
+  }
+}
+
+export async function retainBuildAssets({
+  currentAssetsDir,
+  previousAssetsDir,
+  generationLimit = DEFAULT_GENERATION_LIMIT,
+}: RetainBuildAssetsOptions): Promise<void> {
+  if (!Number.isInteger(generationLimit) || generationLimit < 1) {
+    throw new Error('generationLimit must be a positive integer')
+  }
+
+  const currentGeneration = await listFiles(currentAssetsDir)
+  const previous = await previousGenerations(previousAssetsDir)
+  const distinctGenerations: string[][] = []
+  const seen = new Set<string>()
+  for (const generation of [currentGeneration, ...previous]) {
+    const normalized = [...new Set(generation)].sort()
+    const identity = JSON.stringify(normalized)
+    if (!seen.has(identity)) {
+      seen.add(identity)
+      distinctGenerations.push(normalized)
+    }
+  }
+
+  for (const generation of previous) {
+    for (const path of generation) await assertRegularFile(previousAssetsDir, path)
+  }
+
+  const retainedGenerations = distinctGenerations.slice(0, generationLimit)
+  const retainedIdentities = new Set(
+    retainedGenerations.map((generation) => JSON.stringify(generation)),
+  )
+  const retainedPriorFiles = previous
+    .filter((generation) => retainedIdentities.has(JSON.stringify(generation)))
+    .flat()
+  for (const path of new Set(retainedPriorFiles)) {
+    const source = await assertRegularFile(previousAssetsDir, path)
+    await copyUniqueAsset(source, resolve(currentAssetsDir, path), path)
+  }
+
+  const manifest: AssetManifest = { version: 1, generations: retainedGenerations }
+  await writeFile(
+    resolve(currentAssetsDir, MANIFEST_FILENAME),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  )
+}
+
+if (import.meta.main) {
+  const [currentAssetsDir, previousAssetsDir] = process.argv.slice(2)
+  if (!currentAssetsDir || !previousAssetsDir) {
+    throw new Error(
+      'Usage: bun run scripts/retain-build-assets.ts <current-assets-dir> <previous-assets-dir>',
+    )
+  }
+  await retainBuildAssets({ currentAssetsDir, previousAssetsDir })
+}

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -10,6 +10,98 @@
  */
 import { type ChildProcess, spawn } from 'node:child_process'
 import { setTimeout as sleep } from 'node:timers/promises'
+import { HOME_HEADING_BASE, HOME_TITLE_BASE } from '../src/lib/page-title'
+
+export const EXPECTED_HOME = {
+  h1: `statuslin.es ${HOME_HEADING_BASE}`,
+  title: `${HOME_TITLE_BASE} | statuslin.es`,
+} as const
+
+type HomeDocument = {
+  bodyText: string
+  canonical: string | null
+  h1: string | null
+  title: string
+}
+
+type BrowserResourceKind = 'modulepreload' | 'script' | 'stylesheet'
+
+type BrowserResource = {
+  kind: BrowserResourceKind
+  status: number
+  url: string
+}
+
+function normalizedText(value: string | null): string {
+  return (value ?? '').trim().replace(/\s+/g, ' ')
+}
+
+function normalizedRoot(url: string): string | undefined {
+  const parsed = new URL(url)
+  if (parsed.pathname !== '/' || parsed.search || parsed.hash) return undefined
+  return parsed.origin
+}
+
+/** Assert the browser-facing homepage metadata and rendered shell. */
+export function assertHomeDocument(document: HomeDocument, baseUrl: string): void {
+  if (document.title !== EXPECTED_HOME.title)
+    throw new Error(`unexpected homepage title: ${document.title}`)
+  const expectedCanonical = normalizedRoot(baseUrl)
+  if (
+    !document.canonical ||
+    !expectedCanonical ||
+    normalizedRoot(document.canonical) !== expectedCanonical
+  )
+    throw new Error(`unexpected homepage canonical: ${document.canonical ?? '(missing)'}`)
+  if (normalizedText(document.h1) !== EXPECTED_HOME.h1)
+    throw new Error(`unexpected homepage H1: ${normalizedText(document.h1) || '(missing)'}`)
+  if (!normalizedText(document.bodyText)) throw new Error('homepage rendered an empty body')
+  if (
+    /(?:application|internal server|rendering)\s+error|something went wrong/i.test(
+      document.bodyText,
+    )
+  )
+    throw new Error('homepage rendered an error shell')
+}
+
+/** Assert every browser-requested same-origin script and stylesheet loaded successfully. */
+export function assertFirstPartyResources(resources: BrowserResource[], baseUrl: string): void {
+  const origin = new URL(baseUrl).origin
+  const firstParty = resources.filter((resource) => new URL(resource.url).origin === origin)
+  if (firstParty.length === 0) throw new Error('no same-origin initial browser resource found')
+  for (const resource of firstParty) {
+    if (resource.status < 200 || resource.status >= 400)
+      throw new Error(`${resource.url} returned status ${resource.status}`)
+  }
+}
+
+export const INITIAL_BROWSER_RESOURCE_SELECTOR =
+  'script[src],link[rel="stylesheet"][href],link[rel="modulepreload"][href]'
+
+/** Collect the initial same-origin browser resources selected by the live smoke probe. */
+export function collectInitialBrowserResources(
+  root: ParentNode,
+  baseUrl: string,
+): Array<Omit<BrowserResource, 'status'>> {
+  const origin = new URL(baseUrl).origin
+  return [
+    ...root.querySelectorAll<HTMLScriptElement | HTMLLinkElement>(
+      INITIAL_BROWSER_RESOURCE_SELECTOR,
+    ),
+  ].flatMap((element) => {
+    const source = element.getAttribute(element instanceof HTMLScriptElement ? 'src' : 'href')
+    if (!source) return []
+    const url = new URL(source, baseUrl).href
+    if (new URL(url).origin !== origin) return []
+    const kind: BrowserResourceKind =
+      element instanceof HTMLScriptElement
+        ? 'script'
+        : element.rel === 'modulepreload'
+          ? 'modulepreload'
+          : 'stylesheet'
+    return [{ kind, url }]
+  })
+}
 
 // SMOKE_BASE_URL points the smoke at an already-running, possibly remote app (e.g. deployed
 // staging — which runs the exact production image we promote). When it's set we DON'T boot or
@@ -31,7 +123,16 @@ function check(ok: boolean, label: string, detail = '') {
   }
 }
 
-/** Run an agent-browser subcommand, return trimmed stdout (stderr folded in). */
+/** Normalize an agent-browser subprocess result for the smoke runner. */
+export function browserCommandOutput(stdout: string, stderr: string, exitCode: number): string {
+  if (exitCode !== 0) {
+    const detail = stderr.trim() || stdout.trim()
+    throw new Error(`agent-browser exited with code ${exitCode}${detail ? `: ${detail}` : ''}`)
+  }
+  return stdout.trim()
+}
+
+/** Run an agent-browser subcommand and return its trimmed stdout. */
 async function ab(...args: string[]): Promise<string> {
   // Own session so the smoke never shares cookies/state with manual agent-browser usage.
   const proc = Bun.spawn(['agent-browser', '--session-name', 'statuslines-smoke', ...args], {
@@ -42,8 +143,33 @@ async function ab(...args: string[]): Promise<string> {
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
   ])
-  await proc.exited
-  return `${out}${err}`.trim()
+  const exitCode = await proc.exited
+  return browserCommandOutput(out, err, exitCode)
+}
+
+function parseBrowserJson<T>(raw: string): T {
+  let parsed: unknown = JSON.parse(raw)
+  if (typeof parsed === 'string') parsed = JSON.parse(parsed)
+  return parsed as T
+}
+
+async function checkBrowserFacingHome(): Promise<void> {
+  const document = parseBrowserJson<HomeDocument>(
+    await ab(
+      'eval',
+      `JSON.stringify({title:document.title,canonical:document.querySelector('link[rel="canonical"]')?.href||null,h1:document.querySelector('h1')?.textContent||null,bodyText:document.body.innerText})`,
+    ),
+  )
+  assertHomeDocument(document, BASE)
+
+  const resources = parseBrowserJson<BrowserResource[]>(
+    await ab(
+      'eval',
+      `(async()=>{const elements=[...document.querySelectorAll(${JSON.stringify(INITIAL_BROWSER_RESOURCE_SELECTOR)})];const firstParty=elements.filter(element=>new URL(element.src||element.href).origin===location.origin);return JSON.stringify(await Promise.all(firstParty.map(async element=>{const url=element.src||element.href;const response=await fetch(url,{cache:'no-cache'});const kind=element.tagName==='SCRIPT'?'script':element.rel==='modulepreload'?'modulepreload':'stylesheet';return {kind,status:response.status,url}})))})()`,
+    ),
+  )
+  assertFirstPartyResources(resources, BASE)
+  check(true, 'home title, canonical, H1, body, and initial resources are valid')
 }
 
 async function reachable(url: string): Promise<boolean> {
@@ -159,6 +285,7 @@ async function checkSignedOut() {
   await ensureSignedOut()
 
   await pageConsoleClean('home', '/')
+  await checkBrowserFacingHome()
   check(/Trending/i.test(await ab('snapshot', '-i')), 'home gallery renders')
 
   const detail = (
@@ -296,15 +423,16 @@ async function main() {
   console.log('\nSMOKE PASSED')
 }
 
-try {
-  await main()
-} catch (err) {
-  // Harness/env failure (no agent-browser, server won't boot, no admin user). Still non-zero so
-  // the gate doesn't silently "pass" — fix the environment, don't skip the browser check.
-  console.error(`\nSMOKE ERROR: ${err instanceof Error ? err.message : String(err)}`)
-  process.exit(1)
+if (import.meta.main) {
+  try {
+    await main()
+  } catch (err) {
+    // Harness/env failure (no agent-browser, server won't boot, no admin user). Still non-zero so
+    // the gate doesn't silently "pass" — fix the environment, don't skip the browser check.
+    console.error(`\nSMOKE ERROR: ${err instanceof Error ? err.message : String(err)}`)
+    process.exit(1)
+  }
+  // Force exit: agent-browser leaves a detached headless-Chrome daemon and other spawned children
+  // can hold open handles that otherwise keep this process alive forever.
+  process.exit(failures.length > 0 ? 1 : 0)
 }
-// Force exit: agent-browser leaves a detached headless-Chrome daemon and other spawned children can
-// hold open handles that otherwise keep this process alive forever — which hangs the pre-push hook.
-// main() already logged the result and killed the dev server; this just guarantees we actually exit.
-process.exit(failures.length > 0 ? 1 : 0)

--- a/src/gallery/facet-queries.ts
+++ b/src/gallery/facet-queries.ts
@@ -8,6 +8,9 @@ import { type GalleryCard, selectCardPreviews } from './queries'
 // biome-ignore lint/suspicious/noExplicitAny: db type varies by driver (postgres-js/pglite); query surface identical.
 type Db = PgDatabase<any, typeof import('@/db/schema')>
 
+/** Minimum published inventory before a facet is surfaced to crawlers and cross-facet discovery. */
+export const MIN_INDEXABLE_FACET_CONFIGS = 3
+
 export interface FacetStats {
   count: number
   latest: Date | null
@@ -16,6 +19,7 @@ export interface FacetStats {
 interface StatsRow {
   allTags: string[] | null
   createdAt: Date
+  reviewedAt: Date | null
 }
 
 function facetMatches(row: StatsRow, facet: Facet): boolean {
@@ -23,14 +27,20 @@ function facetMatches(row: StatsRow, facet: Facet): boolean {
 }
 
 /**
- * Match counts + newest createdAt for every registry facet, from ONE scan of published configs.
- * The gallery is small (tens of rows); a per-facet SQL query apiece would be slower and noisier
- * than counting in JS. Drives each facet page's live/404 decision, the sitemap, and count line.
+ * Match counts + newest effective update date for every registry facet, from ONE scan of
+ * published configs joined to their current versions. The gallery is small (tens of rows); a
+ * per-facet SQL query apiece would be slower and noisier than counting in JS. Drives each facet
+ * page's live/404 decision, the sitemap, and count line.
  */
 export async function getFacetStats(db: Db): Promise<Map<string, FacetStats>> {
   const rows = await db
-    .select({ allTags: configs.allTags, createdAt: configs.createdAt })
+    .select({
+      allTags: configs.allTags,
+      createdAt: configs.createdAt,
+      reviewedAt: configVersions.reviewedAt,
+    })
     .from(configs)
+    .innerJoin(configVersions, eq(configVersions.id, configs.currentVersionId))
     .where(eq(configs.status, 'published'))
   const stats = new Map<string, FacetStats>(FACETS.map((f) => [f.slug, { count: 0, latest: null }]))
   for (const row of rows) {
@@ -39,7 +49,8 @@ export async function getFacetStats(db: Db): Promise<Map<string, FacetStats>> {
       const s = stats.get(facet.slug)
       if (!s) continue
       s.count += 1
-      if (!s.latest || row.createdAt > s.latest) s.latest = row.createdAt
+      const updatedAt = row.reviewedAt ?? row.createdAt
+      if (!s.latest || updatedAt > s.latest) s.latest = updatedAt
     }
   }
   return stats
@@ -80,12 +91,17 @@ export function resolveLiveFacet(slug: string, stats: Map<string, FacetStats>): 
   return (stats.get(facet.slug)?.count ?? 0) >= 1 ? facet : null
 }
 
-/** Links for every live facet (a page facet with >= 1 match), optionally excluding the current one. */
+/** Whether a known facet has enough published inventory to be indexed and promoted. */
+export function isIndexableFacet(slug: string, stats: Map<string, FacetStats>): boolean {
+  return (stats.get(slug)?.count ?? 0) >= MIN_INDEXABLE_FACET_CONFIGS
+}
+
+/** Links for every indexable facet, optionally excluding the current one. */
 export function liveFacetLinks(
   stats: Map<string, FacetStats>,
   excludeSlug?: string,
 ): Array<{ slug: string; chipLabel: string }> {
   return FACETS.filter(
-    (f) => f.page && f.slug !== excludeSlug && (stats.get(f.slug)?.count ?? 0) >= 1,
+    (f) => f.page && f.slug !== excludeSlug && isIndexableFacet(f.slug, stats),
   ).map((f) => ({ slug: f.slug, chipLabel: f.chipLabel }))
 }

--- a/src/gallery/functions.ts
+++ b/src/gallery/functions.ts
@@ -1,7 +1,7 @@
 import { createServerFn, createServerOnlyFn } from '@tanstack/react-start'
 import { db } from '@/db'
 import { getAvailableTags } from '@/gallery/facet-queries'
-import { FACET_BY_SLUG, FACETS, tagHref } from '@/gallery/facets'
+import { FACET_BY_SLUG, tagHref } from '@/gallery/facets'
 import { resolveSourceHtml } from '@/lib/highlight'
 import { withHttpStatus } from '@/lib/http.server'
 import { llmsResponse } from '@/lib/llms'
@@ -18,6 +18,7 @@ import {
   getPublishedCount,
   getPublishedSlugsForSitemap,
   getRelatedConfigs,
+  isIndexableFacet,
   liveFacetLinks,
   PAGE_SIZE,
   resolveLiveFacet,
@@ -26,7 +27,7 @@ import {
 /**
  * The `/sitemap.xml` response. Lives here (not in the route file) because route files can't import
  * the db client directly — they reach gallery data through this module, the same way the og image
- * routes call into `@/og/routes`. Keeps `createdAt` a real `Date` by avoiding the server-fn RPC
+ * routes call into `@/og/routes`. Keeps `updatedAt` a real `Date` by avoiding the server-fn RPC
  * boundary that would serialize it to a string.
  */
 // createServerOnlyFn keeps `db` (and the whole postgres driver) out of the CLIENT bundle: this
@@ -34,27 +35,30 @@ import {
 // touching `db` here would drag the Node-only postgres driver into the browser, where it throws
 // `Buffer is not defined` and kills hydration. The server-only wrapper strips the body (and its
 // `db` reference) from the client build. It also avoids the server-fn RPC boundary, so the
-// sitemap's `createdAt` stays a real `Date` instead of being serialized to a string.
+// sitemap's `updatedAt` stays a real `Date` instead of being serialized to a string.
 export const sitemapResponseForRoute = createServerOnlyFn(async (): Promise<Response> => {
   const stats = await getFacetStats(db)
-  const facets = FACETS.filter((f) => f.page && (stats.get(f.slug)?.count ?? 0) >= 1).map((f) => ({
-    slug: f.slug,
-    latest: stats.get(f.slug)?.latest ?? null,
+  const facets = liveFacetLinks(stats).map((facet) => ({
+    slug: facet.slug,
+    latest: stats.get(facet.slug)?.latest ?? null,
   }))
   return sitemapResponse(siteUrl(), await getPublishedSlugsForSitemap(db), facets)
 })
 
 /**
  * The `/llms.txt` response. Server-only for the same reason as the sitemap: it reads live facet
- * counts from `db`, which route files can't import. Lists only page facets with at least one
- * published match, so the map never points AI engines at a facet page that would 404.
+ * counts from `db`, which route files can't import. Lists only indexable page facets that meet the
+ * shared inventory threshold.
  */
 export const llmsTxtResponseForRoute = createServerOnlyFn(async (): Promise<Response> => {
   const stats = await getFacetStats(db)
-  const facets = FACETS.filter((f) => f.page && (stats.get(f.slug)?.count ?? 0) >= 1).map((f) => ({
-    slug: f.slug,
-    label: f.heading ?? f.chipLabel,
-  }))
+  const facets = liveFacetLinks(stats).map((link) => {
+    const facet = FACET_BY_SLUG.get(link.slug)
+    return {
+      slug: link.slug,
+      label: facet?.heading ?? link.chipLabel,
+    }
+  })
   return llmsResponse(siteUrl(), facets)
 })
 
@@ -117,11 +121,12 @@ export const getFacetPage = createServerFn({ method: 'GET' })
       return {
         slug: facet.slug,
         cards,
+        indexable: isIndexableFacet(facet.slug, stats),
         // Pre-formatted: a Date through the server-fn RPC boundary is the serialization
         // gamble the sitemapResponseForRoute comment above warns about; the page only
         // needs the display string anyway.
         updated: stats.get(facet.slug)?.latest?.toISOString().slice(0, 10) ?? null,
-        // Other live facets, for the "more ways to browse" row (never link a 404).
+        // Other indexable facets that meet the shared threshold, for "more ways to browse".
         otherFacets: liveFacetLinks(stats, facet.slug),
       }
     }),

--- a/src/gallery/queries.ts
+++ b/src/gallery/queries.ts
@@ -76,19 +76,25 @@ export async function getPublishedCount(db: Db, tags: string[] = []): Promise<nu
   return row?.n ?? 0
 }
 
-/**
- * Every published config's slug + createdAt, newest first — the minimal columns the sitemap
- * needs. Deliberately unpaginated and join-free (the sitemap lists all configs, not a page),
- * so it stays a single index-covered scan over `(status, created_at)`.
- */
+/** Published sitemap rows joined to their current version, newest reviewed/created date first. */
 export async function getPublishedSlugsForSitemap(
   db: Db,
-): Promise<Array<{ slug: string; createdAt: Date }>> {
-  return db
-    .select({ slug: configs.slug, createdAt: configs.createdAt })
+): Promise<Array<{ slug: string; updatedAt: Date }>> {
+  const effectiveUpdatedAt = sql`coalesce(${configVersions.reviewedAt}, ${configs.createdAt})`
+  const rows = await db
+    .select({
+      slug: configs.slug,
+      createdAt: configs.createdAt,
+      reviewedAt: configVersions.reviewedAt,
+    })
     .from(configs)
+    .innerJoin(configVersions, eq(configVersions.id, configs.currentVersionId))
     .where(eq(configs.status, 'published'))
-    .orderBy(desc(configs.createdAt))
+    .orderBy(desc(effectiveUpdatedAt))
+  return rows.map((row) => ({
+    slug: row.slug,
+    updatedAt: row.reviewedAt ?? row.createdAt,
+  }))
 }
 
 export async function getPublishedConfigs(
@@ -227,7 +233,14 @@ export async function getConfigBySlug(db: Db, slug: string): Promise<ConfigDetai
 
 export { coerceInterpreter } from './card-rows'
 export type { FacetStats } from './facet-queries'
-export { getFacetCards, getFacetStats, liveFacetLinks, resolveLiveFacet } from './facet-queries'
+export {
+  getFacetCards,
+  getFacetStats,
+  isIndexableFacet,
+  liveFacetLinks,
+  MIN_INDEXABLE_FACET_CONFIGS,
+  resolveLiveFacet,
+} from './facet-queries'
 // Re-exported so @/gallery/queries stays the single import surface for gallery
 // queries (related.ts exists only to respect the 250-line file gate).
 export type { RelatedConfig } from './related'

--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -1,5 +1,5 @@
 import type { GeneratedContent } from '@/content/types'
-import { HOME_TITLE_BASE, RESOURCES_TITLE_BASE } from '@/lib/page-title'
+import { homePageName, RESOURCES_TITLE_BASE } from '@/lib/page-title'
 import { CONTENT_LICENSE } from '@/lib/site'
 
 /**
@@ -24,24 +24,29 @@ export function jsonLdScript(data: object): { type: 'application/ld+json'; child
 export function homeJsonLd(
   origin: string,
   items: Array<{ slug: string; title: string }>,
+  options: { page: number; pageSize: number; includeCollectionPage?: boolean },
 ): object[] {
+  const website = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: 'statuslin.es',
+    url: origin,
+  }
+  if (options.includeCollectionPage === false) return [website]
+
+  const positionOffset = (options.page - 1) * options.pageSize
   return [
-    {
-      '@context': 'https://schema.org',
-      '@type': 'WebSite',
-      name: 'statuslin.es',
-      url: origin,
-    },
+    website,
     {
       '@context': 'https://schema.org',
       '@type': 'CollectionPage',
-      name: HOME_TITLE_BASE,
-      url: origin,
+      name: homePageName(options.page),
+      url: options.page > 1 ? `${origin}/?page=${options.page}` : origin,
       mainEntity: {
         '@type': 'ItemList',
         itemListElement: items.map((item, i) => ({
           '@type': 'ListItem',
-          position: i + 1,
+          position: positionOffset + i + 1,
           name: item.title,
           url: `${origin}/c/${item.slug}`,
         })),
@@ -52,9 +57,8 @@ export function homeJsonLd(
 
 /**
  * A config page as SoftwareSourceCode + breadcrumb, plus a FAQPage built from the
- * generated copy when present. The SoftwareSourceCode carries the GEO signals AI answer
- * engines weight: `dateModified` (freshness), a copy `interactionStatistic` (a real
- * stat), `runtimePlatform`, and facet `keywords`.
+ * generated copy when present. The SoftwareSourceCode carries `dateModified` (freshness),
+ * `runtimePlatform`, and facet `keywords`.
  */
 export function configJsonLd(
   origin: string,
@@ -65,7 +69,6 @@ export function configJsonLd(
     interpreter: string
     authorName: string | null
     license: string | null
-    copyCount: number
     keywords: string[]
     updatedAt: string | null
     generatedContent: GeneratedContent | null
@@ -84,11 +87,6 @@ export function configJsonLd(
       license: config.license ?? CONTENT_LICENSE.url,
       ...(config.updatedAt ? { dateModified: config.updatedAt } : {}),
       ...(config.keywords.length > 0 ? { keywords: config.keywords.join(', ') } : {}),
-      interactionStatistic: {
-        '@type': 'InteractionCounter',
-        interactionType: 'https://schema.org/InstallAction',
-        userInteractionCount: config.copyCount,
-      },
       ...(config.authorName ? { author: { '@type': 'Person', name: config.authorName } } : {}),
     },
     {
@@ -158,32 +156,32 @@ export function facetJsonLd(
   items: Array<{ slug: string; title: string }>,
   /** ISO date (YYYY-MM-DD) of the newest config in the facet, or null — a freshness signal. */
   updated: string | null,
+  options: { includeCollectionPage?: boolean } = {},
 ): object[] {
   const url = `${origin}/status-lines/${facet.slug}`
-  return [
-    {
-      '@context': 'https://schema.org',
-      '@type': 'CollectionPage',
-      name: facet.titleBase,
-      url,
-      ...(updated ? { dateModified: updated } : {}),
-      mainEntity: {
-        '@type': 'ItemList',
-        itemListElement: items.map((item, i) => ({
-          '@type': 'ListItem',
-          position: i + 1,
-          name: item.title,
-          url: `${origin}/c/${item.slug}`,
-        })),
-      },
+  const collectionPage = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: facet.titleBase,
+    url,
+    ...(updated ? { dateModified: updated } : {}),
+    mainEntity: {
+      '@type': 'ItemList',
+      itemListElement: items.map((item, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        name: item.title,
+        url: `${origin}/c/${item.slug}`,
+      })),
     },
-    {
-      '@context': 'https://schema.org',
-      '@type': 'BreadcrumbList',
-      itemListElement: [
-        { '@type': 'ListItem', position: 1, name: 'Status lines', item: origin },
-        { '@type': 'ListItem', position: 2, name: facet.titleBase, item: url },
-      ],
-    },
-  ]
+  }
+  const breadcrumbs = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Status lines', item: origin },
+      { '@type': 'ListItem', position: 2, name: facet.titleBase, item: url },
+    ],
+  }
+  return options.includeCollectionPage === false ? [breadcrumbs] : [collectionPage, breadcrumbs]
 }

--- a/src/lib/page-title.ts
+++ b/src/lib/page-title.ts
@@ -46,6 +46,29 @@ export const NOT_FOUND_TITLE = 'Status line not found — statuslin.es'
  * "community gallery", which nobody does.
  */
 export const HOME_TITLE_BASE = 'Claude Code Status Line Examples'
+export const HOME_HEADING_BASE = 'Claude Code status line examples'
+export const HOME_DESCRIPTION_BASE =
+  'Browse a gallery of Claude Code status line examples and ready-to-copy templates. See real rendered previews and copy one in a single paste.'
+
+function homePageSuffix(page: number): string {
+  return page > 1 ? ` — Page ${page}` : ''
+}
+
+export function homePageName(page: number): string {
+  return `${HOME_TITLE_BASE}${homePageSuffix(page)}`
+}
+
+export function homePageTitle(page: number): string {
+  return `${homePageName(page)} | statuslin.es`
+}
+
+export function homePageHeading(page: number): string {
+  return `${HOME_HEADING_BASE}${homePageSuffix(page)}`
+}
+
+export function homeMetaDescription(page: number, pageCount: number): string {
+  return `${HOME_DESCRIPTION_BASE}${page > 1 ? ` Page ${page} of ${pageCount}.` : ''}`
+}
 
 /** /resources title base — shared by the <title> tag and the resources JSON-LD name. */
 export const RESOURCES_TITLE_BASE = 'Claude Code Status Line Tools & Resources'

--- a/src/lib/posthog-client-errors.ts
+++ b/src/lib/posthog-client-errors.ts
@@ -1,0 +1,40 @@
+import type { PostHog } from 'posthog-js'
+
+type PostHogErrorClient = Pick<PostHog, 'captureException'>
+
+type QueuedClientError = {
+  error: unknown
+  path: string
+}
+
+let client: PostHogErrorClient | null = null
+const queuedErrors: QueuedClientError[] = []
+
+function capture(clientError: QueuedClientError): void {
+  try {
+    client?.captureException(clientError.error, {
+      source: 'router',
+      path: clientError.path,
+    })
+  } catch {
+    // Error reporting must never become another route error.
+  }
+}
+
+export function queuePostHogClientError(error: unknown): void {
+  const clientError = {
+    error,
+    path: typeof location === 'undefined' ? '/' : location.pathname,
+  }
+  if (client) {
+    capture(clientError)
+    return
+  }
+  queuedErrors.push(clientError)
+}
+
+export function connectPostHogClientErrors(posthog: PostHogErrorClient): void {
+  client = posthog
+  const errorsToFlush = queuedErrors.splice(0)
+  for (const error of errorsToFlush) capture(error)
+}

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -2,19 +2,18 @@
  * The `/sitemap.xml` builder. Lists the static public pages plus one `<url>` per published config
  * so crawlers discover the long-tail config pages without relying on link-following alone.
  *
- * `<lastmod>` uses each config's `createdAt` (the configs table tracks no update time) formatted
- * as a W3C date — Google only trusts `lastmod` when it's verifiably accurate, and a config's page
- * doesn't change after creation. `<priority>`/`<changefreq>` are omitted on purpose: Google
- * ignores them.
+ * `<lastmod>` uses the current version's review date, falling back to config creation, formatted
+ * as a W3C date. Facets and the homepage inherit the newest matching/published config date.
+ * `<priority>`/`<changefreq>` are omitted on purpose: Google ignores them.
  */
 
 /** Published config rows the sitemap needs — just enough to build each `<url>`. */
 export interface SitemapConfig {
   slug: string
-  createdAt: Date
+  updatedAt: Date
 }
 
-/** Live facet pages the sitemap should list (already filtered to page facets with a match). */
+/** Indexable facet pages the sitemap should list (already filtered to the shared threshold). */
 export interface SitemapFacet {
   slug: string
   latest: Date | null
@@ -39,7 +38,15 @@ function urlEntry(loc: string, lastmod?: string): string {
 }
 
 function buildSitemapXml(base: string, configs: SitemapConfig[], facets: SitemapFacet[]): string {
-  const staticEntries = STATIC_PATHS.map((path) => urlEntry(path === '/' ? base : `${base}${path}`))
+  const homepageUpdatedAt = configs.reduce<Date | null>(
+    (latest, config) => (latest === null || config.updatedAt > latest ? config.updatedAt : latest),
+    null,
+  )
+  const staticEntries = STATIC_PATHS.map((path) =>
+    path === '/'
+      ? urlEntry(base, homepageUpdatedAt?.toISOString().slice(0, 10))
+      : urlEntry(`${base}${path}`),
+  )
   const facetEntries = facets.map((f) =>
     urlEntry(
       `${base}/status-lines/${f.slug}`,
@@ -47,7 +54,7 @@ function buildSitemapXml(base: string, configs: SitemapConfig[], facets: Sitemap
     ),
   )
   const configEntries = configs.map((c) =>
-    urlEntry(`${base}/c/${c.slug}`, c.createdAt.toISOString().slice(0, 10)),
+    urlEntry(`${base}/c/${c.slug}`, c.updatedAt.toISOString().slice(0, 10)),
   )
   const body = [...staticEntries, ...facetEntries, ...configEntries].join('\n')
   return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${body}\n</urlset>\n`

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
 import { Route as ResourcesRouteImport } from './routes/resources'
 import { Route as MeRouteImport } from './routes/me'
 import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
+import { Route as GuideRouteImport } from './routes/guide'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AdminIndexRouteImport } from './routes/admin/index'
 import { Route as StatusLinesFacetRouteImport } from './routes/status-lines.$facet'
@@ -60,6 +61,11 @@ const MeRoute = MeRouteImport.update({
 const LlmsDottxtRoute = LlmsDottxtRouteImport.update({
   id: '/llms.txt',
   path: '/llms.txt',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const GuideRoute = GuideRouteImport.update({
+  id: '/guide',
+  path: '/guide',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -117,6 +123,7 @@ const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/guide': typeof GuideRoute
   '/llms.txt': typeof LlmsDottxtRoute
   '/me': typeof MeRoute
   '/resources': typeof ResourcesRoute
@@ -136,6 +143,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/guide': typeof GuideRoute
   '/llms.txt': typeof LlmsDottxtRoute
   '/me': typeof MeRoute
   '/resources': typeof ResourcesRoute
@@ -156,6 +164,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/guide': typeof GuideRoute
   '/llms.txt': typeof LlmsDottxtRoute
   '/me': typeof MeRoute
   '/resources': typeof ResourcesRoute
@@ -177,6 +186,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/guide'
     | '/llms.txt'
     | '/me'
     | '/resources'
@@ -196,6 +206,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/guide'
     | '/llms.txt'
     | '/me'
     | '/resources'
@@ -215,6 +226,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/guide'
     | '/llms.txt'
     | '/me'
     | '/resources'
@@ -235,6 +247,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  GuideRoute: typeof GuideRoute
   LlmsDottxtRoute: typeof LlmsDottxtRoute
   MeRoute: typeof MeRoute
   ResourcesRoute: typeof ResourcesRoute
@@ -302,6 +315,13 @@ declare module '@tanstack/react-router' {
       path: '/llms.txt'
       fullPath: '/llms.txt'
       preLoaderRoute: typeof LlmsDottxtRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/guide': {
+      id: '/guide'
+      path: '/guide'
+      fullPath: '/guide'
+      preLoaderRoute: typeof GuideRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -379,6 +399,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  GuideRoute: GuideRoute,
   LlmsDottxtRoute: LlmsDottxtRoute,
   MeRoute: MeRoute,
   ResourcesRoute: ResourcesRoute,

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,8 +1,15 @@
 import { createRouter as createTanStackRouter } from '@tanstack/react-router'
+import { queuePostHogClientError } from '@/lib/posthog-client-errors'
+import { RouteError } from '@/ui/route-error'
 import { routeTree } from './routeTree.gen'
 
 export function getRouter() {
-  return createTanStackRouter({ routeTree, scrollRestoration: true })
+  return createTanStackRouter({
+    routeTree,
+    scrollRestoration: true,
+    defaultErrorComponent: RouteError,
+    defaultOnCatch: queuePostHogClientError,
+  })
 }
 
 declare module '@tanstack/react-router' {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -3,6 +3,7 @@ import { PostHogProvider } from '@posthog/react'
 import { createRootRoute, HeadContent, Outlet, Scripts } from '@tanstack/react-router'
 import { getAnalyticsToken } from '@/lib/analytics-config'
 import { getSession } from '@/lib/auth-functions'
+import { connectPostHogClientErrors } from '@/lib/posthog-client-errors'
 import { POSTHOG_INGEST_HOST, POSTHOG_UI_HOST } from '@/lib/posthog-hosts'
 import { identifyPostHogUser } from '@/lib/posthog-identity'
 import { rootSocialMeta } from '@/og/meta'
@@ -27,8 +28,23 @@ export const Route = createRootRoute({
       { rel: 'apple-touch-icon', href: '/apple-touch-icon.png' },
     ],
   }),
+  shellComponent: RootDocument,
   component: RootComponent,
 })
+
+function RootDocument({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        {children}
+        <Scripts />
+      </body>
+    </html>
+  )
+}
 
 function RootComponent() {
   const { posthogToken, user } = Route.useLoaderData()
@@ -39,41 +55,35 @@ function RootComponent() {
     </>
   )
   return (
-    <html lang="en">
-      <head>
-        <HeadContent />
-      </head>
-      <body>
-        {/* PostHog only wraps the app when a token is present — i.e. prod. In dev/staging there's no
-            token, so we skip the provider entirely (no events, no warnings). usePostHog still returns
-            a safe no-op instance to any child that calls it. */}
-        {posthogToken ? (
-          <PostHogProvider
-            apiKey={posthogToken}
-            options={{
-              // Prod posts to '/ingest', reverse-proxied to PostHog by the Nitro route rules
-              // (first-party origin → ad-blocker resilience). Dev posts DIRECTLY to PostHog: the
-              // Vite dev proxy can't forward the event POST under Bun (it 500s). Only relevant if
-              // you set a token locally to test — prod always uses '/ingest'.
-              api_host: import.meta.env.DEV ? POSTHOG_INGEST_HOST : '/ingest',
-              ui_host: POSTHOG_UI_HOST,
-              defaults: '2025-05-24',
-              capture_exceptions: true,
-              // We only use product analytics, not session replay.
-              disable_session_recording: true,
-              debug: import.meta.env.DEV,
-              loaded: (posthog) => {
-                if (user) identifyPostHogUser(posthog, user)
-              },
-            }}
-          >
-            {body}
-          </PostHogProvider>
-        ) : (
-          body
-        )}
-        <Scripts />
-      </body>
-    </html>
+    // PostHog only wraps the app when a token is present — i.e. prod. In dev/staging there's no
+    // token, so we skip the provider entirely (no events, no warnings).
+    <>
+      {posthogToken ? (
+        <PostHogProvider
+          apiKey={posthogToken}
+          options={{
+            // Prod posts to '/ingest', reverse-proxied to PostHog by the Nitro route rules
+            // (first-party origin → ad-blocker resilience). Dev posts DIRECTLY to PostHog: the
+            // Vite dev proxy can't forward the event POST under Bun (it 500s). Only relevant if
+            // you set a token locally to test — prod always uses '/ingest'.
+            api_host: import.meta.env.DEV ? POSTHOG_INGEST_HOST : '/ingest',
+            ui_host: POSTHOG_UI_HOST,
+            defaults: '2025-05-24',
+            capture_exceptions: true,
+            // We only use product analytics, not session replay.
+            disable_session_recording: true,
+            debug: import.meta.env.DEV,
+            loaded: (posthog) => {
+              connectPostHogClientErrors(posthog)
+              if (user) identifyPostHogUser(posthog, user)
+            },
+          }}
+        >
+          {body}
+        </PostHogProvider>
+      ) : (
+        body
+      )}
+    </>
   )
 }

--- a/src/routes/c.$slug.tsx
+++ b/src/routes/c.$slug.tsx
@@ -64,7 +64,6 @@ export const Route = createFileRoute('/c/$slug')({
             interpreter: detail.interpreter,
             authorName: detail.author?.name ?? null,
             license: detail.license,
-            copyCount: detail.copyCount,
             keywords: detail.facetLinks.map((f) => f.chipLabel),
             updatedAt: detail.updatedAt,
             generatedContent: detail.generatedContent,

--- a/src/routes/guide.tsx
+++ b/src/routes/guide.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/guide')({
+  beforeLoad: () => {
+    throw redirect({ to: '/resources', statusCode: 301 })
+  },
+})

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, Link } from '@tanstack/react-router'
 import { GalleryConfigCard } from '@/gallery/config-card'
 import { getGallery } from '@/gallery/functions'
 import { GalleryControls } from '@/gallery/gallery-controls'
-import { coercePage, coerceSort, coerceTags, type GallerySort } from '@/gallery/queries'
+import { coercePage, coerceSort, coerceTags, type GallerySort, PAGE_SIZE } from '@/gallery/queries'
 import { getSession } from '@/lib/auth-functions'
 import {
   canonicalLink,
@@ -12,7 +12,7 @@ import {
   isFilteredHomeSearch,
 } from '@/lib/canonical'
 import { homeJsonLd, jsonLdScript } from '@/lib/json-ld'
-import { HOME_TITLE_BASE } from '@/lib/page-title'
+import { homeMetaDescription, homePageTitle } from '@/lib/page-title'
 import { siteUrl } from '@/lib/site'
 import { Button } from '@/ui/button'
 import { HomeHero } from '@/ui/home-hero'
@@ -47,21 +47,26 @@ export const Route = createFileRoute('/')({
       },
     }),
   }),
-  head: ({ loaderData, match }) => ({
-    meta: [
-      { title: `${HOME_TITLE_BASE} | statuslin.es` },
-      {
-        name: 'description',
-        content:
-          'Browse a community gallery of Claude Code status lines — see rendered previews and copy one into your own terminal in a single paste.',
-      },
-      ...(isFilteredHomeSearch(match.search)
-        ? [{ name: 'robots', content: 'noindex, follow' }]
-        : []),
-    ],
-    links: [canonicalLink(homeCanonicalPath(loaderData?.gallery.page ?? 1, match.search))],
-    scripts: loaderData ? homeJsonLd(siteUrl(), loaderData.gallery.cards).map(jsonLdScript) : [],
-  }),
+  head: ({ loaderData, match }) => {
+    const page = loaderData?.gallery.page ?? 1
+    const pageCount = loaderData?.gallery.pageCount ?? 1
+    const isFiltered = isFilteredHomeSearch(match.search)
+    return {
+      meta: [
+        { title: homePageTitle(page) },
+        { name: 'description', content: homeMetaDescription(page, pageCount) },
+        ...(isFiltered ? [{ name: 'robots', content: 'noindex, follow' }] : []),
+      ],
+      links: [canonicalLink(homeCanonicalPath(page, match.search))],
+      scripts: loaderData
+        ? homeJsonLd(siteUrl(), loaderData.gallery.cards, {
+            page,
+            pageSize: PAGE_SIZE,
+            includeCollectionPage: !isFiltered,
+          }).map(jsonLdScript)
+        : [],
+    }
+  },
   component: Home,
 })
 
@@ -84,10 +89,11 @@ function Home() {
   return (
     <PageShell user={user}>
       <Stack gap={9}>
-        <HomeHero />
+        <HomeHero page={page} />
         <Text muted size="sm" measure center>
-          The status line is the bar at the bottom of your Claude Code terminal. Every one here is
-          rendered from the real script, so you can see it before you copy it.
+          Explore a community gallery of Claude Code status line examples and ready-to-copy
+          templates. Every card shows previews rendered from the real script, so you can see it
+          before you copy it.
         </Text>
         <Stack gap={4}>
           <VisuallyHidden as="h2">Status lines</VisuallyHidden>

--- a/src/routes/resources.tsx
+++ b/src/routes/resources.tsx
@@ -10,7 +10,7 @@ import { ResourcesContent } from '@/resources/resources-content'
 import { PageShell } from '@/ui/shell'
 
 const DESCRIPTION =
-  'The Claude Code status line tools, generators, and guides worth knowing about, picked by hand. Plus a gallery of rendered status lines you can copy.'
+  'Explore hand-picked Claude Code status line tools, generators, guides, and resources for building and customizing your setup.'
 
 export const Route = createFileRoute('/resources')({
   loader: () => getSession(),

--- a/src/routes/status-lines.$facet.tsx
+++ b/src/routes/status-lines.$facet.tsx
@@ -29,6 +29,9 @@ export const Route = createFileRoute('/status-lines/$facet')({
       meta: [
         { title: `${titleBase} | statuslin.es` },
         { name: 'description', content: metaDescription },
+        ...(!loaderData.page.indexable
+          ? [{ name: 'robots', content: 'noindex, follow' } as const]
+          : []),
         ...staticPageSocialMeta({
           path,
           title: titleBase,
@@ -41,6 +44,7 @@ export const Route = createFileRoute('/status-lines/$facet')({
         { slug: facet.slug, titleBase },
         loaderData.page.cards.map((c) => ({ slug: c.slug, title: c.title })),
         loaderData.page.updated,
+        { includeCollectionPage: loaderData.page.indexable },
       ).map(jsonLdScript),
     }
   },

--- a/src/server/retained-asset.ts
+++ b/src/server/retained-asset.ts
@@ -1,0 +1,116 @@
+import { lstat, readFile, realpath } from 'node:fs/promises'
+import { extname, resolve, sep } from 'node:path'
+import { defineEventHandler, getRequestURL } from 'h3'
+
+const RETAINED_ASSETS_DIR = resolve(process.cwd(), '.output/public/assets')
+const IMMUTABLE_CACHE = 'public, max-age=31536000, immutable'
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.css': 'text/css; charset=utf-8',
+  '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.ttf': 'font/ttf',
+  '.webp': 'image/webp',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+}
+
+function notFound(): Response {
+  return new Response('Not Found', { status: 404 })
+}
+
+function isNotFoundError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}
+
+async function readAssetFile(path: string): Promise<ArrayBuffer> {
+  return Uint8Array.from(await readFile(path)).buffer
+}
+
+function decodePath(pathname: string): string | undefined {
+  let decoded = pathname
+  try {
+    for (let index = 0; index < 3; index++) {
+      const next = decodeURIComponent(decoded)
+      if (next === decoded) break
+      decoded = next
+    }
+  } catch {
+    return undefined
+  }
+  if (
+    !decoded.startsWith('/assets/') ||
+    decoded.includes('\0') ||
+    decoded.includes('\\') ||
+    decoded.split('/').some((segment) => segment === '..' || segment === '.')
+  ) {
+    return undefined
+  }
+  return decoded.slice('/assets/'.length)
+}
+
+async function containedRegularFile(
+  assetsDir: string,
+  assetPath: string,
+): Promise<{ filePath: string; size: number } | undefined> {
+  if (!assetPath) return undefined
+
+  try {
+    const root = await realpath(assetsDir)
+    const filePath = resolve(root, assetPath)
+    if (!filePath.startsWith(`${root}${sep}`)) return undefined
+    const [stats, canonicalPath] = await Promise.all([lstat(filePath), realpath(filePath)])
+    if (!stats.isFile() || stats.isSymbolicLink() || canonicalPath !== filePath) return undefined
+    return { filePath, size: stats.size }
+  } catch (error) {
+    if (isNotFoundError(error)) return undefined
+    throw error
+  }
+}
+
+export function createRetainedAssetHandler(
+  assetsDir = RETAINED_ASSETS_DIR,
+  readAsset: (path: string) => Promise<ArrayBuffer> = readAssetFile,
+) {
+  return defineEventHandler(async (event) => {
+    const method = event.req.method.toUpperCase()
+    if (method !== 'GET' && method !== 'HEAD') {
+      return new Response('Method Not Allowed', {
+        status: 405,
+        headers: new Headers({ allow: 'GET, HEAD' }),
+      })
+    }
+
+    const assetPath = decodePath(getRequestURL(event).pathname)
+    if (!assetPath) return notFound()
+    const file = await containedRegularFile(assetsDir, assetPath)
+    if (!file) return notFound()
+
+    const headers = new Headers({
+      'Cache-Control': IMMUTABLE_CACHE,
+      'Content-Length': String(file.size),
+      'Content-Type':
+        CONTENT_TYPES[extname(file.filePath).toLowerCase()] ?? 'application/octet-stream',
+    })
+    if (method === 'HEAD') return new Response(null, { headers })
+    try {
+      return new Response(await readAsset(file.filePath), { headers })
+    } catch (error) {
+      if (isNotFoundError(error)) return notFound()
+      throw error
+    }
+  })
+}
+
+// Nitro route modules require a default handler export.
+// biome-ignore lint/style/noDefaultExport: framework-required route-module contract
+export default createRetainedAssetHandler()

--- a/src/ui/home-hero.tsx
+++ b/src/ui/home-hero.tsx
@@ -1,3 +1,4 @@
+import { homePageHeading } from '@/lib/page-title'
 import { Wordmark } from '@/ui/wordmark'
 
 /**
@@ -6,14 +7,14 @@ import { Wordmark } from '@/ui/wordmark'
  * spent the page's most important heading on a brand nobody searches for and left the phrase
  * invisible to readers. The subtitle inherits the h1's mono font, so it reads as a terminal label.
  */
-export function HomeHero() {
+export function HomeHero({ page = 1 }: { page?: number }) {
   return (
     <h1 className="text-center font-mono text-[clamp(1.5rem,10vw,3rem)] text-foreground">
       <Wordmark size="hero" />
       {/* Explicit separator: JSX drops the whitespace between sibling elements, so without it the
-          heading reads "statuslin.esClaude Code status lines" to a screen reader. The subtitle is
+          heading reads "statuslin.esClaude Code status line examples" to a screen reader. The subtitle is
           `block`, so the space collapses and nothing moves on screen. */}{' '}
-      <span className="mt-3 block text-lg text-muted-foreground">Claude Code status lines</span>
+      <span className="mt-3 block text-lg text-muted-foreground">{homePageHeading(page)}</span>
     </h1>
   )
 }

--- a/src/ui/route-error.tsx
+++ b/src/ui/route-error.tsx
@@ -1,0 +1,24 @@
+import type { ErrorComponentProps } from '@tanstack/react-router'
+
+export function RouteError(_props: ErrorComponentProps) {
+  return (
+    <>
+      <meta name="robots" content="noindex, follow" />
+      <main className="flex min-h-screen items-center justify-center bg-background px-6 py-8">
+        <div className="flex max-w-lg flex-col items-center gap-4 text-center">
+          <h1 className="font-semibold text-2xl text-foreground">This page couldn’t load</h1>
+          <p className="text-muted-foreground">
+            A required file failed to load. Reload the page to try again.
+          </p>
+          <button
+            type="button"
+            className="inline-flex h-8 cursor-pointer items-center justify-center rounded-lg bg-primary px-2.5 font-medium text-primary-foreground text-sm hover:bg-primary/80"
+            onClick={() => location.reload()}
+          >
+            Reload page
+          </button>
+        </div>
+      </main>
+    </>
+  )
+}

--- a/test/deploy-prod.test.ts
+++ b/test/deploy-prod.test.ts
@@ -1,46 +1,175 @@
 import { describe, expect, it } from 'vitest'
-import { assertDigestUnchanged, parseStagingDigest } from '../scripts/deploy-prod'
-
-// One machine entry as `fly image show --app X --json` emits it (extra fields trimmed).
-const entry = (digest: string, machineId: string) => ({
-  Digest: digest,
-  MachineID: machineId,
-  Registry: 'registry.fly.io',
-  Repository: 'statuslines-staging',
-  Tag: 'deployment-01ABC',
-})
+import {
+  assertAssetResponse,
+  assertImageReferencesUnchanged,
+  collectProductionAssetUrls,
+} from '../scripts/deploy-prod'
 
 const SHA = `sha256:${'a'.repeat(64)}`
 
-describe('parseStagingDigest', () => {
-  it('returns the single digest every machine shares', () => {
-    const json = JSON.stringify([entry(SHA, 'm1'), entry(SHA, 'm2'), entry(SHA, 'm3')])
-    expect(parseStagingDigest(json)).toBe(SHA)
+describe('assertImageReferencesUnchanged', () => {
+  it('passes when production and staging still run the checked images', () => {
+    expect(() =>
+      assertImageReferencesUnchanged({
+        productionBefore: `registry.fly.io/statuslines@${SHA}`,
+        productionNow: `registry.fly.io/statuslines@${SHA}`,
+        stagingBefore: `registry.fly.io/statuslines-staging@${SHA}`,
+        stagingNow: `registry.fly.io/statuslines-staging@${SHA}`,
+      }),
+    ).not.toThrow()
   })
 
-  it('throws when machines run different images (deploy not settled)', () => {
+  it('rejects a concurrent staging change', () => {
     const other = `sha256:${'b'.repeat(64)}`
-    const json = JSON.stringify([entry(SHA, 'm1'), entry(other, 'm2')])
-    expect(() => parseStagingDigest(json)).toThrow(/mixed images/i)
+    expect(() =>
+      assertImageReferencesUnchanged({
+        productionBefore: `registry.fly.io/statuslines@${SHA}`,
+        productionNow: `registry.fly.io/statuslines@${SHA}`,
+        stagingBefore: `registry.fly.io/statuslines-staging@${SHA}`,
+        stagingNow: `registry.fly.io/statuslines-staging@${other}`,
+      }),
+    ).toThrow(/staging image changed/i)
   })
 
-  it('throws when no digest is present', () => {
-    expect(() => parseStagingDigest('[]')).toThrow(/no image digest/i)
-  })
-
-  it('throws on a malformed digest', () => {
-    const json = JSON.stringify([entry('sha256:not-a-real-digest', 'm1')])
-    expect(() => parseStagingDigest(json)).toThrow(/unexpected digest/i)
+  it('rejects a concurrent production change', () => {
+    const other = `sha256:${'b'.repeat(64)}`
+    expect(() =>
+      assertImageReferencesUnchanged({
+        productionBefore: `registry.fly.io/statuslines@${SHA}`,
+        productionNow: `registry.fly.io/statuslines@${other}`,
+        stagingBefore: `registry.fly.io/statuslines-staging@${SHA}`,
+        stagingNow: `registry.fly.io/statuslines-staging@${SHA}`,
+      }),
+    ).toThrow(/production image changed/i)
   })
 })
 
-describe('assertDigestUnchanged', () => {
-  it('passes when staging still runs the digest that was smoked', () => {
-    expect(() => assertDigestUnchanged(SHA, SHA)).not.toThrow()
+describe('collectProductionAssetUrls', () => {
+  it('collects same-origin scripts and styles from all required pages and follows one detail link', async () => {
+    const pages = new Map([
+      [
+        'https://statuslin.es/',
+        '<script src="/assets/home.js"></script><link rel="stylesheet" href="/assets/app.css"><a href="/c/one">One</a>',
+      ],
+      [
+        'https://statuslin.es/resources',
+        '<link rel="modulepreload" href="/assets/resources.js"><script src="https://elsewhere.test/no.js"></script>',
+      ],
+      ['https://statuslin.es/terms', '<link rel="stylesheet" href="/assets/legal.css">'],
+      ['https://statuslin.es/c/one', '<script src="/assets/detail.js"></script>'],
+    ])
+    const fetchPage = async (url: string) => {
+      const html = pages.get(url)
+      if (!html) throw new Error(`unexpected URL ${url}`)
+      return html
+    }
+
+    await expect(collectProductionAssetUrls('https://statuslin.es', fetchPage)).resolves.toEqual([
+      'https://statuslin.es/assets/app.css',
+      'https://statuslin.es/assets/detail.js',
+      'https://statuslin.es/assets/home.js',
+      'https://statuslin.es/assets/legal.css',
+      'https://statuslin.es/assets/resources.js',
+    ])
   })
 
-  it('throws when staging was redeployed between smoke and promote', () => {
-    const other = `sha256:${'b'.repeat(64)}`
-    expect(() => assertDigestUnchanged(SHA, other)).toThrow(/changed during the smoke/i)
+  it('rejects a homepage without a linked detail page', async () => {
+    await expect(
+      collectProductionAssetUrls('https://statuslin.es', async () => '<main>No configs</main>'),
+    ).rejects.toThrow(/detail page/i)
+  })
+
+  it('rejects a required page that has no qualifying same-origin asset', async () => {
+    const pages = new Map([
+      ['https://statuslin.es/', '<script src="/assets/home.js"></script><a href="/c/one">One</a>'],
+      ['https://statuslin.es/resources', '<script src="/assets/resources.js"></script>'],
+      ['https://statuslin.es/terms', '<main>No assets here</main>'],
+      ['https://statuslin.es/c/one', '<script src="/assets/detail.js"></script>'],
+    ])
+
+    await expect(
+      collectProductionAssetUrls('https://statuslin.es', async (url) => pages.get(url) ?? ''),
+    ).rejects.toThrow(/terms.*asset/i)
+  })
+})
+
+describe('assertAssetResponse', () => {
+  it('accepts a successful immutable response with an extension-appropriate type', async () => {
+    const response = new Response('console.log("old")', {
+      status: 200,
+      headers: {
+        'cache-control': 'public, max-age=31536000, immutable',
+        'content-type': 'text/javascript; charset=utf-8',
+      },
+    })
+
+    await expect(
+      assertAssetResponse('https://staging.statuslin.es/assets/old.js', response),
+    ).resolves.toBeUndefined()
+  })
+
+  it.each([
+    [new Response('missing', { status: 404 }), /status 404/i],
+    [
+      new Response('<!doctype html><title>fallback</title>', {
+        headers: {
+          'cache-control': 'public, max-age=31536000, immutable',
+          'content-type': 'text/css',
+        },
+      }),
+      /HTML body/i,
+    ],
+    [
+      new Response('body{}', {
+        headers: {
+          'cache-control': 'public, max-age=31536000, immutable, no-store',
+          'content-type': 'text/css',
+        },
+      }),
+      /no-store/i,
+    ],
+    [
+      new Response('body{}', {
+        headers: {
+          'cache-control': 'public, max-age=3600, immutable',
+          'content-type': 'text/css',
+        },
+      }),
+      /max-age/i,
+    ],
+    [
+      new Response('/* css */', {
+        headers: {
+          'cache-control': 'public, max-age=31536000, immutable, no-cache',
+          'content-type': 'text/css',
+        },
+      }),
+      /no-cache/i,
+    ],
+    ...[
+      '<!-- proxy fallback --><html><body>fallback</body></html>',
+      '<head><title>fallback</title></head>',
+      '<body>fallback</body>',
+    ].map((body): [Response, RegExp] => [
+      new Response(body, {
+        headers: {
+          'cache-control': 'public, max-age=31536000, immutable',
+          'content-type': 'text/css',
+        },
+      }),
+      /HTML body/i,
+    ]),
+    [
+      new Response('body{}', {
+        headers: { 'cache-control': 'public, max-age=31536000', 'content-type': 'text/css' },
+      }),
+      /immutable/i,
+    ],
+  ] satisfies Array<
+    [Response, RegExp]
+  >)('rejects invalid retained asset responses', async (response, message) => {
+    await expect(
+      assertAssetResponse('https://staging.statuslin.es/assets/old.css', response),
+    ).rejects.toThrow(message)
   })
 })

--- a/test/deploy-staging.test.ts
+++ b/test/deploy-staging.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { buildStagingDeployCommand, parseFlyImageReference } from '../scripts/deploy-staging'
+
+const SHA = `sha256:${'a'.repeat(64)}`
+
+const entry = (
+  digest: string,
+  machineId: string,
+  repository = 'statuslines',
+  registry = 'registry.fly.io',
+) => ({
+  Digest: digest,
+  MachineID: machineId,
+  Registry: registry,
+  Repository: repository,
+  Tag: 'deployment-01ABC',
+})
+
+describe('parseFlyImageReference', () => {
+  it('returns the unanimous full production image reference', () => {
+    const json = JSON.stringify([entry(SHA, 'm1'), entry(SHA, 'm2')])
+
+    expect(parseFlyImageReference(json, 'production')).toBe(`registry.fly.io/statuslines@${SHA}`)
+  })
+
+  it('rejects machines running mixed production images', () => {
+    const other = `sha256:${'b'.repeat(64)}`
+    const json = JSON.stringify([entry(SHA, 'm1'), entry(other, 'm2')])
+
+    expect(() => parseFlyImageReference(json, 'production')).toThrow(/mixed images/i)
+  })
+
+  it.each([
+    ['[]', /no image/i],
+    [JSON.stringify([entry('latest', 'm1')]), /digest/i],
+    [JSON.stringify([entry(SHA, 'm1', '../statuslines')]), /repository/i],
+    [JSON.stringify([entry(SHA, 'm1', 'statuslines', 'https://registry.fly.io')]), /registry/i],
+  ])('rejects malformed image data', (json, message) => {
+    expect(() => parseFlyImageReference(json, 'production')).toThrow(message)
+  })
+})
+
+describe('buildStagingDeployCommand', () => {
+  it('pins PREVIOUS_IMAGE to the exact production image', () => {
+    const image = `registry.fly.io/statuslines@${SHA}`
+
+    expect(buildStagingDeployCommand(image)).toEqual([
+      'fly',
+      'deploy',
+      '--config',
+      'fly.staging.toml',
+      '--build-arg',
+      `PREVIOUS_IMAGE=${image}`,
+    ])
+  })
+})

--- a/test/gallery/facet-discovery.test.ts
+++ b/test/gallery/facet-discovery.test.ts
@@ -1,0 +1,169 @@
+import { PGlite } from '@electric-sql/pglite'
+import { eq } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/pglite'
+import { migrate } from 'drizzle-orm/pglite/migrator'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import * as schema from '@/db/schema'
+
+const testState = vi.hoisted(() => ({ db: null as unknown }))
+
+vi.mock('@/db', () => ({
+  get db() {
+    return testState.db
+  },
+}))
+vi.mock('@tanstack/react-start', () => ({
+  createServerOnlyFn: (handler: () => unknown) => handler,
+  createServerFn: () => {
+    const wrap = (handler: (args: { data: unknown }) => unknown) => (args?: { data?: unknown }) =>
+      handler({ data: args?.data })
+    return {
+      handler: wrap,
+      inputValidator: (validator: (data: never) => unknown) => ({
+        handler: (handler: (args: { data: unknown }) => unknown) => (args: { data: never }) =>
+          handler({ data: validator(args.data) }),
+      }),
+    }
+  },
+}))
+vi.mock('@/lib/http.server', () => ({
+  withHttpStatus: (run: () => unknown) => run(),
+}))
+
+let client: PGlite
+let db: ReturnType<typeof drizzle<typeof schema>>
+let getFacetPage: typeof import('@/gallery/functions').getFacetPage
+let llmsTxtResponseForRoute: typeof import('@/gallery/functions').llmsTxtResponseForRoute
+let sitemapResponseForRoute: typeof import('@/gallery/functions').sitemapResponseForRoute
+let FacetRoute: typeof import('@/routes/status-lines.$facet').Route
+
+beforeAll(async () => {
+  process.env.BETTER_AUTH_URL = 'https://statuslin.es'
+  client = new PGlite()
+  db = drizzle({ client, schema })
+  testState.db = db
+  await migrate(db, { migrationsFolder: './drizzle' })
+  await db.insert(schema.user).values({
+    id: 'facet-discovery-author',
+    name: 'Facet Discovery Author',
+    email: 'facet-discovery@test.com',
+    emailVerified: false,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  })
+
+  await seedPublished('python-one', ['python'])
+  await seedPublished('cost-one', ['cost'])
+  await seedPublished('cost-two', ['cost'])
+  await seedPublished('git-one', ['git'])
+  await seedPublished('git-two', ['git'])
+  await seedPublished('git-three', ['git'])
+
+  const functions = await import('@/gallery/functions')
+  getFacetPage = functions.getFacetPage
+  llmsTxtResponseForRoute = functions.llmsTxtResponseForRoute
+  sitemapResponseForRoute = functions.sitemapResponseForRoute
+  FacetRoute = (await import('@/routes/status-lines.$facet')).Route
+})
+
+afterAll(async () => {
+  await client.close()
+})
+
+async function seedPublished(slug: string, allTags: string[]) {
+  const [config] = await db
+    .insert(schema.configs)
+    .values({
+      slug,
+      title: slug,
+      description: `${slug} description`,
+      authorId: 'facet-discovery-author',
+      interpreter: 'bash',
+      allTags,
+      status: 'published',
+      createdAt: new Date('2026-06-01T00:00:00Z'),
+    })
+    .returning()
+  const [version] = await db
+    .insert(schema.configVersions)
+    .values({
+      configId: config!.id,
+      versionNumber: 1,
+      source: `echo ${slug}`,
+      interpreter: 'bash',
+      contentSha256: slug.padEnd(64, '0'),
+      status: 'approved',
+    })
+    .returning()
+  await db
+    .update(schema.configs)
+    .set({ currentVersionId: version!.id })
+    .where(eq(schema.configs.id, config!.id))
+}
+
+async function headFor(facet: string) {
+  const page = await getFacetPage({ data: { facet } } as never)
+  const head = await FacetRoute.options.head?.({
+    loaderData: page ? { page, user: null } : undefined,
+  } as never)
+  return { page, head }
+}
+
+describe('facet discovery threshold', () => {
+  it('keeps facets with 1 or 2 configs accessible while only 3 is indexable', async () => {
+    const one = await getFacetPage({ data: { facet: 'python' } } as never)
+    const two = await getFacetPage({ data: { facet: 'cost' } } as never)
+    const three = await getFacetPage({ data: { facet: 'git' } } as never)
+
+    expect(one).toMatchObject({ slug: 'python', indexable: false })
+    expect(two).toMatchObject({ slug: 'cost', indexable: false })
+    expect(three).toMatchObject({ slug: 'git', indexable: true })
+  })
+
+  it.each([
+    'python',
+    'cost',
+  ])('makes the thin %s facet self-canonical and noindex without CollectionPage JSON-LD', async (facet) => {
+    const { head } = await headFor(facet)
+
+    expect(head?.links).toContainEqual({
+      rel: 'canonical',
+      href: `https://statuslin.es/status-lines/${facet}`,
+    })
+    expect(head?.meta).toContainEqual({ name: 'robots', content: 'noindex, follow' })
+    const types = (head?.scripts ?? []).map(
+      (script) => JSON.parse(String(script?.children))['@type'] as string,
+    )
+    expect(types).toEqual(['BreadcrumbList'])
+  })
+
+  it('keeps the 3-config facet indexable with collection and breadcrumb JSON-LD', async () => {
+    const { head } = await headFor('git')
+
+    expect(head?.meta).not.toContainEqual({ name: 'robots', content: 'noindex, follow' })
+    const types = (head?.scripts ?? []).map(
+      (script) => JSON.parse(String(script?.children))['@type'] as string,
+    )
+    expect(types).toEqual(['CollectionPage', 'BreadcrumbList'])
+  })
+
+  it('omits 1- and 2-config facets from sitemap and llms.txt discovery', async () => {
+    const sitemap = await (await sitemapResponseForRoute()).text()
+    const llms = await (await llmsTxtResponseForRoute()).text()
+
+    for (const facet of ['python', 'cost']) {
+      expect(sitemap).not.toContain(`/status-lines/${facet}`)
+      expect(llms).not.toContain(`/status-lines/${facet}`)
+    }
+    expect(sitemap).toContain('/status-lines/git')
+    expect(llms).toContain('/status-lines/git')
+  })
+
+  it('returns only indexable alternatives for More ways to browse', async () => {
+    const page = await getFacetPage({ data: { facet: 'python' } } as never)
+    const slugs = page?.otherFacets.map((facet) => facet.slug)
+
+    expect(slugs).toContain('git')
+    expect(slugs).not.toContain('cost')
+  })
+})

--- a/test/gallery/facet-page.test.ts
+++ b/test/gallery/facet-page.test.ts
@@ -6,8 +6,8 @@ import { liveFacetLinks, resolveLiveFacet } from '@/gallery/queries'
 
 const stats = new Map([
   ['git', { count: 3, latest: new Date(2026, 5, 2) }],
-  ['cost', { count: 1, latest: new Date(2026, 5, 1) }],
-  ['python', { count: 0, latest: null }],
+  ['cost', { count: 2, latest: new Date(2026, 5, 1) }],
+  ['python', { count: 1, latest: new Date(2026, 5, 1) }],
   ['reads-token', { count: 5, latest: new Date(2026, 5, 1) }],
 ])
 
@@ -15,9 +15,10 @@ describe('resolveLiveFacet', () => {
   it('returns the facet with just 1 match (no floor)', () => {
     expect(resolveLiveFacet('git', stats)).toBe(FACET_BY_SLUG.get('git'))
     expect(resolveLiveFacet('cost', stats)).toBe(FACET_BY_SLUG.get('cost'))
+    expect(resolveLiveFacet('python', stats)).toBe(FACET_BY_SLUG.get('python'))
   })
   it('returns null for a page facet with zero matches (page must 404, not render thin)', () => {
-    expect(resolveLiveFacet('python', stats)).toBeNull()
+    expect(resolveLiveFacet('python', new Map([['python', { count: 0, latest: null }]]))).toBeNull()
   })
   it('returns null for a page:false capability tag even with matches', () => {
     expect(resolveLiveFacet('reads-token', stats)).toBeNull()
@@ -28,16 +29,13 @@ describe('resolveLiveFacet', () => {
 })
 
 describe('liveFacetLinks', () => {
-  it('lists every page facet with at least 1 match', () => {
-    expect(liveFacetLinks(stats)).toEqual([
-      { slug: 'git', chipLabel: 'git' },
-      { slug: 'cost', chipLabel: 'cost' },
-    ])
+  it('lists page facets with 3 matches but omits facets with 1 or 2', () => {
+    expect(liveFacetLinks(stats)).toEqual([{ slug: 'git', chipLabel: 'git' }])
   })
   it('excludes page:false capability tags even with matches', () => {
     expect(liveFacetLinks(stats).map((f) => f.slug)).not.toContain('reads-token')
   })
   it('can exclude the current facet', () => {
-    expect(liveFacetLinks(stats, 'git')).toEqual([{ slug: 'cost', chipLabel: 'cost' }])
+    expect(liveFacetLinks(stats, 'git')).toEqual([])
   })
 })

--- a/test/gallery/facet-queries.test.ts
+++ b/test/gallery/facet-queries.test.ts
@@ -37,6 +37,7 @@ async function seed(
     upvoteCount?: number
     copyCount?: number
     createdAt?: Date
+    reviewedAt?: Date | null
   } = {},
 ) {
   const interpreter = opts.interpreter ?? 'bash'
@@ -70,21 +71,33 @@ async function seed(
       interpreter,
       contentSha256: slug.padEnd(64, '0'),
       status: 'approved',
+      reviewedAt: opts.reviewedAt,
     })
     .returning()
   await db
     .update(schema.configs)
     .set({ currentVersionId: ver!.id })
     .where(eq(schema.configs.id, cfg!.id))
+  return { config: cfg!, version: ver! }
 }
 
 describe('facet queries', () => {
   beforeAll(async () => {
-    await seed('git-a', {
+    const gitA = await seed('git-a', {
       tags: ['git'],
       upvoteCount: 9,
       copyCount: 5,
       createdAt: new Date(2026, 5, 1),
+      reviewedAt: new Date(2026, 6, 5),
+    })
+    await db.insert(schema.configVersions).values({
+      configId: gitA.config.id,
+      versionNumber: 2,
+      source: 'echo newer but not current',
+      interpreter: 'bash',
+      contentSha256: 'git-a-not-current'.padEnd(64, '0'),
+      status: 'approved',
+      reviewedAt: new Date(2026, 11, 31),
     })
     await seed('git-b', {
       tags: ['git', 'cost'],
@@ -93,15 +106,36 @@ describe('facet queries', () => {
       createdAt: new Date(2026, 5, 2),
     })
     await seed('git-draft', { tags: ['git'], status: 'draft' })
-    await seed('py-a', { interpreter: 'python', createdAt: new Date(2026, 5, 3) })
+    await seed('py-a', {
+      interpreter: 'python',
+      createdAt: new Date(2026, 5, 3),
+      reviewedAt: new Date(2026, 6, 7),
+    })
     await seed('plain', {})
+    await db.insert(schema.configs).values({
+      slug: 'git-orphan',
+      title: 'git-orphan',
+      description: 'desc',
+      authorId: 'u1',
+      interpreter: 'bash',
+      status: 'published',
+      tags: ['git'],
+      allTags: computeAllTags({
+        curatedTags: ['git'],
+        interpreter: 'bash',
+        networkHosts: [],
+        readsClaudeToken: false,
+      }),
+      createdAt: new Date(2026, 11, 1),
+    })
   })
 
-  it('counts published matches per facet with the newest createdAt', async () => {
+  it('counts current-version published matches with the newest effective update date', async () => {
     const stats = await getFacetStats(db)
-    expect(stats.get('git')).toEqual({ count: 2, latest: new Date(2026, 5, 2) })
+    expect(stats.get('git')).toEqual({ count: 2, latest: new Date(2026, 6, 5) })
     expect(stats.get('cost')?.count).toBe(1)
-    expect(stats.get('python')).toEqual({ count: 1, latest: new Date(2026, 5, 3) })
+    expect(stats.get('cost')?.latest).toEqual(new Date(2026, 5, 2))
+    expect(stats.get('python')).toEqual({ count: 1, latest: new Date(2026, 6, 7) })
     // every registry facet is present, even with zero matches
     expect(stats.get('powerline')).toEqual({ count: 0, latest: null })
   })

--- a/test/gallery/sitemap.test.ts
+++ b/test/gallery/sitemap.test.ts
@@ -1,4 +1,5 @@
 import { PGlite } from '@electric-sql/pglite'
+import { eq } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/pglite'
 import { migrate } from 'drizzle-orm/pglite/migrator'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
@@ -28,41 +29,94 @@ afterAll(async () => {
 })
 
 describe('getPublishedSlugsForSitemap', () => {
-  it('returns only published configs, with slug and createdAt, newest first', async () => {
-    await db.insert(schema.configs).values([
-      {
-        slug: 'pub-old',
-        title: 'Old',
-        authorId: 'u1',
+  it('returns only current-version published configs with reviewedAt or createdAt fallback', async () => {
+    const reviewed = await insertConfig('reviewed-current', 'published', '2026-01-01')
+    const [reviewedVersion] = await db
+      .insert(schema.configVersions)
+      .values({
+        configId: reviewed.id,
+        versionNumber: 1,
+        source: 'echo reviewed',
         interpreter: 'bash',
-        status: 'published',
-        createdAt: new Date('2026-01-01T00:00:00Z'),
-      },
-      {
-        slug: 'pub-new',
-        title: 'New',
-        authorId: 'u1',
+        contentSha256: 'reviewed-current'.padEnd(64, '0'),
+        status: 'approved',
+        reviewedAt: new Date('2026-04-05T12:00:00Z'),
+      })
+      .returning()
+    await db.insert(schema.configVersions).values({
+      configId: reviewed.id,
+      versionNumber: 2,
+      source: 'echo not current',
+      interpreter: 'bash',
+      contentSha256: 'reviewed-not-current'.padEnd(64, '0'),
+      status: 'approved',
+      reviewedAt: new Date('2026-12-31T00:00:00Z'),
+    })
+    await setCurrentVersion(reviewed.id, reviewedVersion!.id)
+
+    const fallback = await insertConfig('created-fallback', 'published', '2026-03-03')
+    const [fallbackVersion] = await db
+      .insert(schema.configVersions)
+      .values({
+        configId: fallback.id,
+        versionNumber: 1,
+        source: 'echo fallback',
         interpreter: 'bash',
-        status: 'published',
-        createdAt: new Date('2026-02-01T00:00:00Z'),
-      },
-      {
-        slug: 'draft-hidden',
-        title: 'Draft',
-        authorId: 'u1',
+        contentSha256: 'created-fallback'.padEnd(64, '0'),
+        status: 'approved',
+      })
+      .returning()
+    await setCurrentVersion(fallback.id, fallbackVersion!.id)
+
+    const draft = await insertConfig('draft-hidden', 'draft', '2026-06-01')
+    const [draftVersion] = await db
+      .insert(schema.configVersions)
+      .values({
+        configId: draft.id,
+        versionNumber: 1,
+        source: 'echo draft',
         interpreter: 'bash',
-        status: 'draft',
-        createdAt: new Date('2026-03-01T00:00:00Z'),
-      },
-    ])
+        contentSha256: 'draft-hidden'.padEnd(64, '0'),
+        status: 'approved',
+        reviewedAt: new Date('2026-06-02T00:00:00Z'),
+      })
+      .returning()
+    await setCurrentVersion(draft.id, draftVersion!.id)
+
+    await insertConfig('orphan-hidden', 'published', '2026-07-01')
+    await db.insert(schema.configs).values({
+      slug: 'unknown-current-hidden',
+      title: 'unknown-current-hidden',
+      authorId: 'u1',
+      interpreter: 'bash',
+      status: 'published',
+      currentVersionId: '11111111-1111-4111-8111-111111111111',
+      createdAt: new Date('2026-08-01T00:00:00Z'),
+    })
 
     const rows = await getPublishedSlugsForSitemap(db)
-    const slugs = rows.map((r) => r.slug)
-
-    expect(slugs).toContain('pub-old')
-    expect(slugs).toContain('pub-new')
-    expect(slugs).not.toContain('draft-hidden')
-    expect(slugs.indexOf('pub-new')).toBeLessThan(slugs.indexOf('pub-old'))
-    expect(rows.find((r) => r.slug === 'pub-new')?.createdAt).toBeInstanceOf(Date)
+    expect(rows).toEqual([
+      { slug: 'reviewed-current', updatedAt: new Date('2026-04-05T12:00:00Z') },
+      { slug: 'created-fallback', updatedAt: new Date('2026-03-03T00:00:00Z') },
+    ])
   })
 })
+
+async function insertConfig(slug: string, status: string, createdDate: string) {
+  const [config] = await db
+    .insert(schema.configs)
+    .values({
+      slug,
+      title: slug,
+      authorId: 'u1',
+      interpreter: 'bash',
+      status,
+      createdAt: new Date(`${createdDate}T00:00:00Z`),
+    })
+    .returning()
+  return config!
+}
+
+async function setCurrentVersion(configId: string, currentVersionId: string) {
+  await db.update(schema.configs).set({ currentVersionId }).where(eq(schema.configs.id, configId))
+}

--- a/test/lib/json-ld.test.ts
+++ b/test/lib/json-ld.test.ts
@@ -17,10 +17,14 @@ describe('jsonLdScript', () => {
 
 describe('homeJsonLd', () => {
   it('builds WebSite identity plus a CollectionPage of config URLs', () => {
-    const nodes = homeJsonLd('https://statuslin.es', [
-      { slug: 'a-1', title: 'Alpha' },
-      { slug: 'b-2', title: 'Beta' },
-    ]) as Array<Record<string, unknown>>
+    const nodes = homeJsonLd(
+      'https://statuslin.es',
+      [
+        { slug: 'a-1', title: 'Alpha' },
+        { slug: 'b-2', title: 'Beta' },
+      ],
+      { page: 1, pageSize: 10 },
+    ) as Array<Record<string, unknown>>
     expect(nodes).toHaveLength(2)
     expect(nodes[0]).toEqual({
       '@context': 'https://schema.org',
@@ -52,6 +56,30 @@ describe('homeJsonLd', () => {
       },
     })
   })
+
+  it('gives page 2 its own URL, name, and gallery-wide item positions', () => {
+    const nodes = homeJsonLd(
+      'https://statuslin.es',
+      [
+        { slug: 'a-1', title: 'Alpha' },
+        { slug: 'b-2', title: 'Beta' },
+      ],
+      { page: 2, pageSize: 10 },
+    ) as Array<Record<string, unknown>>
+
+    expect(nodes[0]).toMatchObject({
+      '@type': 'WebSite',
+      url: 'https://statuslin.es',
+    })
+    expect(nodes[1]).toMatchObject({
+      '@type': 'CollectionPage',
+      name: 'Claude Code Status Line Examples — Page 2',
+      url: 'https://statuslin.es/?page=2',
+      mainEntity: {
+        itemListElement: [{ position: 11 }, { position: 12 }],
+      },
+    })
+  })
 })
 
 describe('configJsonLd', () => {
@@ -63,7 +91,6 @@ describe('configJsonLd', () => {
     interpreter: 'bash',
     authorName: 'LindseyB',
     license: null as string | null,
-    copyCount: 12,
     keywords: ['Git', 'Token usage'],
     updatedAt: '2026-07-06',
     generatedContent: {
@@ -117,19 +144,15 @@ describe('configJsonLd', () => {
     expect(code!.license).toContain('creativecommons.org')
   })
 
-  // --- GEO enrichment: freshness, statistics, entity clarity, extractable Q&A ---
+  // --- GEO enrichment: freshness, entity clarity, extractable Q&A ---
 
-  it('enriches SoftwareSourceCode with freshness, install stat, platform, and keywords', () => {
+  it('enriches SoftwareSourceCode without presenting copies as install interactions', () => {
     const [code] = configJsonLd('https://statuslin.es', base) as Array<Record<string, unknown>>
     expect(code).toMatchObject({
       dateModified: '2026-07-06',
       runtimePlatform: 'Claude Code',
-      interactionStatistic: {
-        '@type': 'InteractionCounter',
-        interactionType: 'https://schema.org/InstallAction',
-        userInteractionCount: 12,
-      },
     })
+    expect(code).not.toHaveProperty('interactionStatistic')
     // keywords carry the facet labels (schema.org accepts a comma-separated string)
     expect(code!.keywords).toBe('Git, Token usage')
   })

--- a/test/lib/posthog-client-errors.test.ts
+++ b/test/lib/posthog-client-errors.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+afterEach(() => {
+  vi.resetModules()
+  vi.unstubAllGlobals()
+})
+
+describe('PostHog client error queue', () => {
+  it('buffers errors until connect, flushes once, then captures later errors immediately', async () => {
+    const captureException = vi.fn()
+    vi.stubGlobal('location', {
+      pathname: '/status-lines/bash',
+      search: '?private=secret',
+      hash: '#hidden',
+      href: 'https://statuslin.es/status-lines/bash?private=secret#hidden',
+    })
+    const { connectPostHogClientErrors, queuePostHogClientError } = await import(
+      '@/lib/posthog-client-errors'
+    )
+    const earlyError = new Error('early')
+    const lateError = new Error('late')
+
+    queuePostHogClientError(earlyError)
+    expect(captureException).not.toHaveBeenCalled()
+
+    connectPostHogClientErrors({ captureException })
+    connectPostHogClientErrors({ captureException })
+    queuePostHogClientError(lateError)
+
+    expect(captureException.mock.calls).toEqual([
+      [earlyError, { source: 'router', path: '/status-lines/bash' }],
+      [lateError, { source: 'router', path: '/status-lines/bash' }],
+    ])
+  })
+
+  it('keeps only the path captured at the time an early error occurs', async () => {
+    const captureException = vi.fn()
+    const currentLocation = { pathname: '/before', search: '?token=secret', hash: '#private' }
+    vi.stubGlobal('location', currentLocation)
+    const { connectPostHogClientErrors, queuePostHogClientError } = await import(
+      '@/lib/posthog-client-errors'
+    )
+    const error = new Error('early')
+
+    queuePostHogClientError(error)
+    currentLocation.pathname = '/after'
+    connectPostHogClientErrors({ captureException })
+
+    expect(captureException).toHaveBeenCalledWith(error, {
+      source: 'router',
+      path: '/before',
+    })
+  })
+
+  it('never lets PostHog failures escape the router', async () => {
+    const captureException = vi.fn(() => {
+      throw new Error('PostHog unavailable')
+    })
+    vi.stubGlobal('location', { pathname: '/terms' })
+    const { connectPostHogClientErrors, queuePostHogClientError } = await import(
+      '@/lib/posthog-client-errors'
+    )
+
+    queuePostHogClientError(new Error('early'))
+
+    expect(() => connectPostHogClientErrors({ captureException })).not.toThrow()
+    expect(() => queuePostHogClientError(new Error('late'))).not.toThrow()
+    expect(captureException).toHaveBeenCalledTimes(2)
+  })
+})

--- a/test/lib/sitemap.test.ts
+++ b/test/lib/sitemap.test.ts
@@ -4,6 +4,15 @@ import { sitemapResponse } from '@/lib/sitemap'
 const BASE = 'https://statuslin.es'
 
 describe('sitemapResponse', () => {
+  function entryFor(xml: string, loc: string): string {
+    return (
+      xml
+        .split('  <url>')
+        .find((entry) => entry.includes(`<loc>${loc}</loc>`))
+        ?.split('  </url>')[0] ?? ''
+    )
+  }
+
   it('serves application/xml with a cache header', async () => {
     const res = sitemapResponse(BASE, [], [])
     expect(res.status).toBe(200)
@@ -26,32 +35,45 @@ describe('sitemapResponse', () => {
     expect(xml).toContain(`<loc>${BASE}/terms</loc>`)
   })
 
-  it('emits a config url with a date-only lastmod from createdAt', async () => {
-    const xml = await sitemapResponse(
-      BASE,
-      [{ slug: 'my-line', createdAt: new Date('2026-01-02T03:04:05Z') }],
-      [],
-    ).text()
+  it('emits a config url with a date-only lastmod from updatedAt', async () => {
+    const config = {
+      slug: 'my-line',
+      updatedAt: new Date('2026-04-05T06:07:08Z'),
+    }
+    const xml = await sitemapResponse(BASE, [config], []).text()
     expect(xml).toContain(`<loc>${BASE}/c/my-line</loc>`)
-    expect(xml).toContain('<lastmod>2026-01-02</lastmod>')
+    expect(entryFor(xml, `${BASE}/c/my-line`)).toContain('<lastmod>2026-04-05</lastmod>')
+  })
+
+  it('dates only the homepage from the newest published config', async () => {
+    const configs = [
+      {
+        slug: 'newest',
+        updatedAt: new Date('2026-05-06T00:00:00Z'),
+      },
+      {
+        slug: 'older',
+        updatedAt: new Date('2026-03-04T00:00:00Z'),
+      },
+    ]
+    const xml = await sitemapResponse(BASE, configs, []).text()
+
+    expect(entryFor(xml, BASE)).toContain('<lastmod>2026-05-06</lastmod>')
+    for (const path of ['/resources', '/submit', '/terms']) {
+      expect(entryFor(xml, `${BASE}${path}`)).not.toContain('<lastmod>')
+    }
   })
 
   it('xml-escapes ampersands in a slug', async () => {
-    const xml = await sitemapResponse(
-      BASE,
-      [{ slug: 'a&b', createdAt: new Date('2026-01-02T00:00:00Z') }],
-      [],
-    ).text()
+    const date = new Date('2026-01-02T00:00:00Z')
+    const xml = await sitemapResponse(BASE, [{ slug: 'a&b', updatedAt: date }], []).text()
     expect(xml).toContain(`<loc>${BASE}/c/a&amp;b</loc>`)
     expect(xml).not.toContain('/c/a&b<')
   })
 
   it('xml-escapes angle brackets in a slug', async () => {
-    const xml = await sitemapResponse(
-      BASE,
-      [{ slug: 'a<b>c', createdAt: new Date('2026-01-02T00:00:00Z') }],
-      [],
-    ).text()
+    const date = new Date('2026-01-02T00:00:00Z')
+    const xml = await sitemapResponse(BASE, [{ slug: 'a<b>c', updatedAt: date }], []).text()
     expect(xml).toContain(`<loc>${BASE}/c/a&lt;b&gt;c</loc>`)
   })
 

--- a/test/routes/guide-redirect.test.ts
+++ b/test/routes/guide-redirect.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment node
+import { createMemoryHistory } from '@tanstack/react-router'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/analytics-config', () => ({
+  getAnalyticsToken: vi.fn().mockResolvedValue(null),
+}))
+vi.mock('@/lib/auth-functions', () => ({
+  getSession: vi.fn().mockResolvedValue(null),
+}))
+
+const { getRouter } = await import('@/router')
+
+describe('/guide redirect', () => {
+  it('loads through the real router as a permanent redirect to /resources', async () => {
+    const router = getRouter()
+    router.update({
+      history: createMemoryHistory({ initialEntries: ['/guide'] }),
+    })
+
+    await router.load()
+
+    expect(router.stores.statusCode.get()).toBe(301)
+    expect(router.stores.redirect.get()?.headers.get('Location')).toBe('/resources')
+  })
+})

--- a/test/routes/home-content.test.tsx
+++ b/test/routes/home-content.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@posthog/react', () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
+}))
+vi.mock('@/ui/shell', () => ({
+  PageShell: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+vi.mock('@/gallery/gallery-controls', () => ({
+  GalleryControls: () => null,
+}))
+vi.mock('@/ui/submit-cta', () => ({
+  SubmitCta: () => null,
+}))
+
+const { Route: HomeRoute } = await import('@/routes/index')
+
+describe('home content', () => {
+  it('explains the community gallery and its real-script ready-to-copy examples', () => {
+    vi.spyOn(HomeRoute, 'useLoaderData').mockReturnValue({
+      user: null,
+      gallery: {
+        cards: [],
+        page: 1,
+        pageCount: 1,
+        availableTags: [],
+      },
+    })
+    vi.spyOn(HomeRoute, 'useSearch').mockReturnValue({})
+    const Home = HomeRoute.options.component
+
+    render(Home ? <Home /> : null)
+
+    const intro = screen.getByText(/community gallery/i)
+    expect(intro.textContent).toMatch(/Claude Code status line examples/)
+    expect(intro.textContent).toMatch(/ready-to-copy templates/)
+    expect(intro.textContent).toMatch(/previews rendered from the real script/)
+  })
+})

--- a/test/routes/home-meta.test.ts
+++ b/test/routes/home-meta.test.ts
@@ -1,12 +1,80 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { Route as HomeRoute } from '@/routes/index'
 
+const ORIGINAL_URL = process.env.BETTER_AUTH_URL
+afterEach(() => {
+  process.env.BETTER_AUTH_URL = ORIGINAL_URL
+})
+
 describe('home search indexing metadata', () => {
+  it('gives page 1 the base gallery title and description', async () => {
+    const head = await HomeRoute.options.head?.({
+      loaderData: {
+        gallery: {
+          page: 1,
+          pageCount: 3,
+          cards: [],
+        },
+      },
+      match: { search: {} },
+    } as never)
+
+    expect(head?.meta).toEqual(
+      expect.arrayContaining([
+        { title: 'Claude Code Status Line Examples | statuslin.es' },
+        {
+          name: 'description',
+          content:
+            'Browse a gallery of Claude Code status line examples and ready-to-copy templates. See real rendered previews and copy one in a single paste.',
+        },
+      ]),
+    )
+  })
+
+  it('gives page 2 distinct metadata using the loader-clamped page values', async () => {
+    process.env.BETTER_AUTH_URL = 'https://statuslin.es'
+    const head = await HomeRoute.options.head?.({
+      loaderData: {
+        gallery: {
+          page: 2,
+          pageCount: 3,
+          cards: [],
+        },
+      },
+      match: { search: { page: 999 } },
+    } as never)
+
+    expect(head?.meta).toEqual(
+      expect.arrayContaining([
+        { title: 'Claude Code Status Line Examples — Page 2 | statuslin.es' },
+        {
+          name: 'description',
+          content:
+            'Browse a gallery of Claude Code status line examples and ready-to-copy templates. See real rendered previews and copy one in a single paste. Page 2 of 3.',
+        },
+      ]),
+    )
+    expect(head?.links).toContainEqual({
+      rel: 'canonical',
+      href: 'https://statuslin.es/?page=2',
+    })
+
+    const scripts = (head?.scripts ?? []) as Array<{ children: string }>
+    const collectionPage = scripts
+      .map((script) => JSON.parse(script.children) as Record<string, unknown>)
+      .find((node) => node['@type'] === 'CollectionPage')
+    expect(collectionPage).toMatchObject({
+      name: 'Claude Code Status Line Examples — Page 2',
+      url: 'https://statuslin.es/?page=2',
+    })
+  })
+
   it('renders WebSite and CollectionPage as separate JSON-LD scripts', async () => {
     const head = await HomeRoute.options.head?.({
       loaderData: {
         gallery: {
           page: 1,
+          pageCount: 1,
           cards: [{ slug: 'alpha', title: 'Alpha' }],
         },
       },
@@ -29,6 +97,22 @@ describe('home search indexing metadata', () => {
     } as never)
 
     expect(head?.meta).toContainEqual({ name: 'robots', content: 'noindex, follow' })
+  })
+
+  it('omits CollectionPage JSON-LD from filtered noindex views', async () => {
+    const head = await HomeRoute.options.head?.({
+      loaderData: {
+        gallery: {
+          page: 2,
+          pageCount: 3,
+          cards: [{ slug: 'alpha', title: 'Alpha' }],
+        },
+      },
+      match: { search: { sort: 'new', page: 2 } },
+    } as never)
+
+    const scripts = (head?.scripts ?? []) as Array<{ children: string }>
+    expect(scripts.map((script) => JSON.parse(script.children)['@type'])).toEqual(['WebSite'])
   })
 
   it('does not noindex the unfiltered gallery', async () => {

--- a/test/routes/router-client-error-boundary.test.tsx
+++ b/test/routes/router-client-error-boundary.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { createMemoryHistory, RouterProvider } from '@tanstack/react-router'
+import { render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const queuePostHogClientError = vi.fn()
+
+vi.mock('@/lib/analytics-config', () => ({
+  getAnalyticsToken: vi.fn().mockResolvedValue(null),
+}))
+vi.mock('@/lib/auth-functions', () => ({
+  getSession: vi.fn().mockResolvedValue(null),
+}))
+vi.mock('@/lib/posthog-client-errors', () => ({
+  connectPostHogClientErrors: vi.fn(),
+  queuePostHogClientError,
+}))
+
+const { getRouter } = await import('@/router')
+
+beforeEach(() => {
+  window.scrollTo = vi.fn()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('client router error boundary', () => {
+  it('reports a rejected child component preload through the configured catch hook', async () => {
+    const chunkError = new Error('failed to fetch route chunk')
+    const router = getRouter()
+    router.update({
+      history: createMemoryHistory({ initialEntries: ['/terms'] }),
+    })
+    router.routesById['/terms'].options.component = Object.assign(() => null, {
+      preload: vi.fn().mockRejectedValue(chunkError),
+    })
+
+    render(<RouterProvider router={router} />)
+
+    await waitFor(() => {
+      expect(queuePostHogClientError).toHaveBeenCalledWith(chunkError, expect.any(Object))
+    })
+  })
+})

--- a/test/routes/router-error-boundary.test.tsx
+++ b/test/routes/router-error-boundary.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment node
+import { createMemoryHistory, RouterProvider } from '@tanstack/react-router'
+import { renderToString } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+const queuePostHogClientError = vi.fn()
+
+vi.mock('@/lib/analytics-config', () => ({
+  getAnalyticsToken: vi.fn().mockResolvedValue(null),
+}))
+vi.mock('@/lib/auth-functions', () => ({
+  getSession: vi.fn().mockResolvedValue(null),
+}))
+vi.mock('@/lib/posthog-client-errors', () => ({
+  queuePostHogClientError,
+}))
+
+const { getRouter } = await import('@/router')
+
+describe('router error boundary', () => {
+  it('preserves the document when a child route component preload rejects', async () => {
+    const chunkError = new Error('failed to fetch route chunk')
+    const router = getRouter()
+    router.update({
+      history: createMemoryHistory({ initialEntries: ['/terms'] }),
+    })
+    router.routesById['/terms'].options.component = Object.assign(() => null, {
+      preload: vi.fn().mockRejectedValue(chunkError),
+    })
+
+    await router.load()
+    const html = renderToString(<RouterProvider router={router} />)
+
+    expect(router.stores.statusCode.get()).toBe(500)
+    expect(html).toContain('<html')
+    expect(html).toContain('<head>')
+    expect(html).toContain('<body>')
+    expect(html).toContain('This page couldn’t load')
+    expect(html).toContain('<meta name="robots" content="noindex, follow"')
+  })
+})

--- a/test/routes/static-page-meta.test.ts
+++ b/test/routes/static-page-meta.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
+import { Route as ResourcesRoute } from '@/routes/resources'
 import { Route as SubmitRoute } from '@/routes/submit'
 import { Route as TermsRoute } from '@/routes/terms'
 
@@ -8,6 +9,18 @@ afterEach(() => {
 })
 
 describe('static page social metadata', () => {
+  it('keeps /resources focused on tools and learning resources instead of the gallery', async () => {
+    process.env.BETTER_AUTH_URL = 'https://statuslin.es'
+    const head = await ResourcesRoute.options.head?.({} as never)
+    const description = head?.meta?.find((entry) => entry?.name === 'description')?.content ?? ''
+
+    expect(description).toMatch(/tools/i)
+    expect(description).toMatch(/generators/i)
+    expect(description).toMatch(/guides/i)
+    expect(description).toMatch(/resources/i)
+    expect(description).not.toMatch(/gallery/i)
+  })
+
   it('gives /submit its own share metadata', async () => {
     process.env.BETTER_AUTH_URL = 'https://statuslin.es'
     const head = await SubmitRoute.options.head?.({} as never)

--- a/test/scripts/retain-build-assets.test.ts
+++ b/test/scripts/retain-build-assets.test.ts
@@ -1,0 +1,152 @@
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, test } from 'vitest'
+import { retainBuildAssets } from '../../scripts/retain-build-assets'
+
+const MANIFEST = '.asset-generations.json'
+const fixtureRoots = new Set<string>()
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), 'retain-assets-'))
+  fixtureRoots.add(root)
+  const currentAssetsDir = join(root, 'current')
+  const previousAssetsDir = join(root, 'previous')
+  await mkdir(currentAssetsDir)
+  await mkdir(previousAssetsDir)
+  return { currentAssetsDir, previousAssetsDir }
+}
+
+afterEach(async () => {
+  await Promise.all([...fixtureRoots].map((root) => rm(root, { recursive: true, force: true })))
+  fixtureRoots.clear()
+})
+
+async function put(root: string, path: string, contents = path) {
+  const target = join(root, path)
+  await mkdir(join(target, '..'), { recursive: true })
+  await writeFile(target, contents)
+}
+
+async function manifest(root: string, generations: string[][]) {
+  await writeFile(join(root, MANIFEST), JSON.stringify({ version: 1, generations }))
+}
+
+describe('retainBuildAssets', () => {
+  test('accepts an empty legacy bootstrap directory', async () => {
+    const dirs = await fixture()
+    await put(dirs.currentAssetsDir, 'current.js')
+
+    await retainBuildAssets(dirs)
+
+    expect(JSON.parse(await readFile(join(dirs.currentAssetsDir, MANIFEST), 'utf8'))).toEqual({
+      version: 1,
+      generations: [['current.js']],
+    })
+  })
+
+  test('treats legacy files without a manifest as one prior generation', async () => {
+    const dirs = await fixture()
+    await put(dirs.currentAssetsDir, 'current.js')
+    await put(dirs.previousAssetsDir, 'legacy.js')
+
+    await retainBuildAssets(dirs)
+
+    expect(await readFile(join(dirs.currentAssetsDir, 'legacy.js'), 'utf8')).toBe('legacy.js')
+    expect(
+      JSON.parse(await readFile(join(dirs.currentAssetsDir, MANIFEST), 'utf8')).generations,
+    ).toEqual([['current.js'], ['legacy.js']])
+  })
+
+  test('keeps the current plus nineteen prior distinct generations', async () => {
+    const dirs = await fixture()
+    await put(dirs.currentAssetsDir, 'current.js')
+    const generations = Array.from({ length: 21 }, (_, index) => [`old-${index}.js`])
+    for (const generation of generations) await put(dirs.previousAssetsDir, generation[0]!)
+    await manifest(dirs.previousAssetsDir, generations)
+
+    await retainBuildAssets(dirs)
+
+    const stored = JSON.parse(await readFile(join(dirs.currentAssetsDir, MANIFEST), 'utf8'))
+    expect(stored.generations).toHaveLength(20)
+    expect(stored.generations.at(-1)).toEqual(['old-18.js'])
+    await expect(readFile(join(dirs.currentAssetsDir, 'old-19.js'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    })
+  })
+
+  test('deduplicates repeated generations and identical files', async () => {
+    const dirs = await fixture()
+    await put(dirs.currentAssetsDir, 'same.js', 'same')
+    await put(dirs.previousAssetsDir, 'same.js', 'same')
+    await manifest(dirs.previousAssetsDir, [['same.js'], ['same.js']])
+
+    await retainBuildAssets(dirs)
+
+    const stored = JSON.parse(await readFile(join(dirs.currentAssetsDir, MANIFEST), 'utf8'))
+    expect(stored.generations).toEqual([['same.js']])
+    expect(await readFile(join(dirs.currentAssetsDir, 'same.js'), 'utf8')).toBe('same')
+  })
+
+  test('rejects a filename collision with different contents', async () => {
+    const dirs = await fixture()
+    await put(dirs.currentAssetsDir, 'collision.js', 'current')
+    await put(dirs.previousAssetsDir, 'collision.js', 'previous')
+    await manifest(dirs.previousAssetsDir, [['collision.js']])
+
+    await expect(retainBuildAssets(dirs)).rejects.toThrow('collision.js')
+  })
+
+  test('rejects malformed manifests', async () => {
+    const dirs = await fixture()
+    await put(dirs.currentAssetsDir, 'current.js')
+    await writeFile(join(dirs.previousAssetsDir, MANIFEST), '{"version":1,"generations":"bad"}')
+
+    await expect(retainBuildAssets(dirs)).rejects.toThrow('manifest')
+  })
+
+  test('rejects manifest entries whose files are missing', async () => {
+    const dirs = await fixture()
+    await put(dirs.currentAssetsDir, 'current.js')
+    await manifest(dirs.previousAssetsDir, [['missing.js']])
+
+    await expect(retainBuildAssets(dirs)).rejects.toThrow('missing.js')
+  })
+
+  test.each([
+    '../escape.js',
+    '/absolute.js',
+    'nested\\\\escape.js',
+    '',
+  ])('rejects unsafe manifest path %j', async (unsafePath: string) => {
+    const dirs = await fixture()
+    await put(dirs.currentAssetsDir, 'current.js')
+    await manifest(dirs.previousAssetsDir, [[unsafePath]])
+
+    await expect(retainBuildAssets(dirs)).rejects.toThrow('unsafe')
+  })
+
+  test('rejects symlinked prior files', async () => {
+    const dirs = await fixture()
+    await put(dirs.currentAssetsDir, 'current.js')
+    await put(join(dirs.previousAssetsDir, '..'), 'outside.js')
+    await symlink(
+      join(dirs.previousAssetsDir, '..', 'outside.js'),
+      join(dirs.previousAssetsDir, 'link.js'),
+    )
+    await manifest(dirs.previousAssetsDir, [['link.js']])
+
+    await expect(retainBuildAssets(dirs)).rejects.toThrow('link.js')
+  })
+
+  test('rejects files beneath a symlinked prior directory', async () => {
+    const dirs = await fixture()
+    await put(dirs.currentAssetsDir, 'current.js')
+    const outsideDir = join(dirs.previousAssetsDir, '..', 'outside')
+    await put(outsideDir, 'secret.js', 'secret')
+    await symlink(outsideDir, join(dirs.previousAssetsDir, 'nested'))
+    await manifest(dirs.previousAssetsDir, [['nested/secret.js']])
+
+    await expect(retainBuildAssets(dirs)).rejects.toThrow('nested/secret.js')
+  })
+})

--- a/test/scripts/smoke.test.ts
+++ b/test/scripts/smoke.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest'
+import {
+  assertFirstPartyResources,
+  assertHomeDocument,
+  browserCommandOutput,
+  collectInitialBrowserResources,
+  EXPECTED_HOME,
+} from '../../scripts/smoke'
+
+const validHome = {
+  bodyText: `${EXPECTED_HOME.h1} Trending`,
+  canonical: 'https://statuslin.es',
+  h1: EXPECTED_HOME.h1,
+  title: EXPECTED_HOME.title,
+}
+
+describe('browserCommandOutput', () => {
+  it('keeps successful structured stdout separate from informational stderr', () => {
+    expect(
+      browserCommandOutput(
+        '"{\\"title\\":\\"Claude Code Status Line Examples | statuslin.es\\"}"\n',
+        '[agent-browser] restore: loaded; save: saved\n',
+        0,
+      ),
+    ).toBe('"{\\"title\\":\\"Claude Code Status Line Examples | statuslin.es\\"}"')
+  })
+
+  it('reports stderr when agent-browser exits unsuccessfully', () => {
+    expect(() => browserCommandOutput('', 'browser command failed\n', 1)).toThrow(
+      /browser command failed/i,
+    )
+  })
+})
+
+describe('assertHomeDocument', () => {
+  it('accepts the expected production homepage shell', () => {
+    expect(() => assertHomeDocument(validHome, 'https://statuslin.es')).not.toThrow()
+  })
+
+  it.each([
+    [{ ...validHome, title: 'statuslin.es' }, /title/i],
+    [{ ...validHome, canonical: 'https://statuslin.es/wrong' }, /canonical/i],
+    [{ ...validHome, canonical: 'https://statuslin.es/?page=2' }, /canonical/i],
+    [{ ...validHome, canonical: 'https://statuslin.es/#gallery' }, /canonical/i],
+    [{ ...validHome, h1: 'Wrong heading' }, /h1/i],
+    [{ ...validHome, bodyText: '' }, /empty body/i],
+    [{ ...validHome, bodyText: 'Application error: failed to render' }, /error shell/i],
+  ])('rejects an invalid homepage document', (document, message) => {
+    expect(() => assertHomeDocument(document, 'https://statuslin.es')).toThrow(message)
+  })
+})
+
+describe('assertFirstPartyResources', () => {
+  it('collects the historical SSR modulepreload shape as a first-party resource', () => {
+    document.head.innerHTML =
+      '<link rel="modulepreload" href="/assets/chunk-old.js"><link rel="preconnect" href="https://elsewhere.test">'
+
+    expect(collectInitialBrowserResources(document, 'https://statuslin.es')).toEqual([
+      {
+        kind: 'modulepreload',
+        url: 'https://statuslin.es/assets/chunk-old.js',
+      },
+    ])
+  })
+
+  it('rejects a failed modulepreload collected from the browser DOM', () => {
+    document.head.innerHTML = '<link rel="modulepreload" href="/assets/old.js">'
+    const resources = collectInitialBrowserResources(document, 'https://statuslin.es').map(
+      (resource) => ({ ...resource, status: 404 }),
+    )
+
+    expect(() => assertFirstPartyResources(resources, 'https://statuslin.es')).toThrow(
+      /old\.js.*404/i,
+    )
+  })
+
+  it('accepts successful same-origin scripts, stylesheets, and modulepreloads', () => {
+    expect(() =>
+      assertFirstPartyResources(
+        [
+          { kind: 'script', status: 200, url: 'https://statuslin.es/assets/app.js' },
+          { kind: 'stylesheet', status: 200, url: 'https://statuslin.es/assets/app.css' },
+          { kind: 'modulepreload', status: 200, url: 'https://statuslin.es/assets/chunk.js' },
+          { kind: 'script', status: 0, url: 'https://analytics.example/script.js' },
+        ],
+        'https://statuslin.es',
+      ),
+    ).not.toThrow()
+  })
+
+  it('rejects a failed same-origin script or stylesheet', () => {
+    expect(() =>
+      assertFirstPartyResources(
+        [{ kind: 'script', status: 404, url: 'https://statuslin.es/assets/old.js' }],
+        'https://statuslin.es',
+      ),
+    ).toThrow(/old\.js.*404/i)
+  })
+
+  it('rejects a page with no initial same-origin script, stylesheet, or modulepreload', () => {
+    expect(() =>
+      assertFirstPartyResources(
+        [{ kind: 'script', status: 200, url: 'https://analytics.example/script.js' }],
+        'https://statuslin.es',
+      ),
+    ).toThrow(/no same-origin.*resource/i)
+  })
+})

--- a/test/server/posthog-error-plugin.test.ts
+++ b/test/server/posthog-error-plugin.test.ts
@@ -1,0 +1,56 @@
+import { H3 } from 'h3'
+import { createHooks } from 'hookable'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const captureServerException = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/posthog-server', () => ({ captureServerException }))
+vi.mock('nitro', () => ({
+  definePlugin: (plugin: unknown) => plugin,
+}))
+
+const plugin = (await import('@/server/posthog-error-plugin')).default as unknown as (app: {
+  hooks: {
+    hook: (
+      name: 'error',
+      callback: (error: Error, context: Record<string, unknown>) => void,
+    ) => void
+  }
+}) => void
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('PostHog Nitro error plugin', () => {
+  it('reports an unhandled request while H3 preserves its generated 500 response', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const hooks = createHooks<{
+      error: (error: Error, context: Record<string, unknown>) => void
+    }>()
+    plugin({ hooks })
+    const fatalError = new Error('fatal SSR render')
+    const app = new H3({
+      async onError(error, event) {
+        await hooks.callHook('error', error, { event })
+      },
+    })
+    app.on('GET', '/fatal', () => {
+      throw fatalError
+    })
+
+    const response = await app.request('https://statuslin.es/fatal')
+
+    expect(response.status).toBe(500)
+    expect(captureServerException).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 500, cause: fatalError }),
+      {
+        source: 'ssr',
+        properties: {
+          path: '/fatal',
+          method: 'GET',
+        },
+      },
+    )
+  })
+})

--- a/test/server/retained-asset.test.ts
+++ b/test/server/retained-asset.test.ts
@@ -1,0 +1,155 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createApp, toWebHandler } from 'h3'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { createRetainedAssetHandler } from '@/server/retained-asset'
+
+const fixtureRoots = new Set<string>()
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), 'retained-handler-'))
+  fixtureRoots.add(root)
+  const assetsDir = join(root, 'assets')
+  await mkdir(assetsDir)
+  return { root, assetsDir }
+}
+
+afterEach(async () => {
+  await Promise.all([...fixtureRoots].map((root) => rm(root, { recursive: true, force: true })))
+  fixtureRoots.clear()
+})
+
+async function request(
+  assetsDir: string,
+  path: string,
+  method = 'GET',
+  fallback = vi.fn(() => new Response('SSR fallback', { status: 418 })),
+  readAsset?: (path: string) => Promise<ArrayBuffer>,
+) {
+  const app = createApp()
+    .all('/assets/**', createRetainedAssetHandler(assetsDir, readAsset))
+    .all('/**', fallback)
+  const handler = toWebHandler(app)
+  return handler(new Request(`http://localhost${path}`, { method }))
+}
+
+describe('retained asset handler', () => {
+  test.each([
+    ['app.js', 'text/javascript'],
+    ['app.css', 'text/css'],
+    ['font.woff2', 'font/woff2'],
+  ])('serves %s with its MIME type and immutable caching', async (filename: string, contentType: string) => {
+    const { assetsDir } = await fixture()
+    await writeFile(join(assetsDir, filename), 'contents')
+
+    const response = await request(assetsDir, `/assets/${filename}`)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain(contentType)
+    expect(response.headers.get('cache-control')).toBe('public, max-age=31536000, immutable')
+    expect(await response.text()).toBe('contents')
+  })
+
+  test('answers HEAD without a body', async () => {
+    const { assetsDir } = await fixture()
+    await writeFile(join(assetsDir, 'app.js'), 'contents')
+
+    const response = await request(assetsDir, '/assets/app.js', 'HEAD')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-length')).toBe('8')
+    expect(await response.text()).toBe('')
+  })
+
+  test('returns 404 for a missing retained asset', async () => {
+    const { assetsDir } = await fixture()
+    expect((await request(assetsDir, '/assets/missing.js')).status).toBe(404)
+  })
+
+  test('returns 405 with Allow for unsupported methods', async () => {
+    const { assetsDir } = await fixture()
+    const response = await request(assetsDir, '/assets/app.js', 'POST')
+    expect(response.status).toBe(405)
+    expect(response.headers.get('allow')).toBe('GET, HEAD')
+  })
+
+  test.each([
+    '/assets/missing.js',
+    '/assets/%252e%252e%252fsecret.js',
+    '/assets/%2e%2e%2fsecret.js',
+    '/assets/nested%5csecret.js',
+    '/assets/nul%00.js',
+  ])('returns handler 404 before the catch-all for asset-routed path %s', async (path: string) => {
+    const { assetsDir } = await fixture()
+    const fallback = vi.fn(() => new Response('SSR fallback', { status: 418 }))
+
+    const response = await request(assetsDir, path, 'GET', fallback)
+
+    expect(response.status).toBe(404)
+    expect(await response.text()).toBe('Not Found')
+    expect(fallback).not.toHaveBeenCalled()
+  })
+
+  test.each([
+    '/assets/../secret.js',
+    '/assets/%2e%2e/secret.js',
+  ])('documents URL normalization outside the asset-route contract for %s', async (path: string) => {
+    const { assetsDir } = await fixture()
+    const fallback = vi.fn(() => new Response('SSR fallback', { status: 418 }))
+    // WHATWG URL parsing removes `/assets/..` before H3 matches routes, so these requests never
+    // enter the production `/assets/**` handler. A broad production catch-all is intentionally
+    // outside this handler's contract; the application's normal catch-all owns the normalized URL.
+    expect(new Request(`http://localhost${path}`).url).toBe('http://localhost/secret.js')
+
+    const response = await request(assetsDir, path, 'GET', fallback)
+
+    expect(response.status).toBe(418)
+    expect(await response.text()).toBe('SSR fallback')
+    expect(fallback).toHaveBeenCalledOnce()
+  })
+
+  test('returns handler 404 before the catch-all when the asset directory is missing', async () => {
+    const { root } = await fixture()
+    const fallback = vi.fn(() => new Response('SSR fallback', { status: 418 }))
+
+    const response = await request(join(root, 'missing-assets'), '/assets/app.js', 'GET', fallback)
+
+    expect(response.status).toBe(404)
+    expect(fallback).not.toHaveBeenCalled()
+  })
+
+  test('returns handler 404 when the file disappears before the final read', async () => {
+    const { assetsDir } = await fixture()
+    await writeFile(join(assetsDir, 'raced.js'), 'contents')
+    const fallback = vi.fn(() => new Response('SSR fallback', { status: 418 }))
+    const disappeared = Object.assign(new Error('gone'), { code: 'ENOENT' })
+    const readAsset = vi.fn<(path: string) => Promise<ArrayBuffer>>().mockRejectedValue(disappeared)
+
+    const response = await request(assetsDir, '/assets/raced.js', 'GET', fallback, readAsset)
+
+    expect(response.status).toBe(404)
+    expect(fallback).not.toHaveBeenCalled()
+    expect(readAsset).toHaveBeenCalledOnce()
+  })
+
+  test('preserves unexpected errors from the final read', async () => {
+    const { assetsDir } = await fixture()
+    await writeFile(join(assetsDir, 'denied.js'), 'contents')
+    const denied = Object.assign(new Error('denied'), { code: 'EACCES' })
+    const readAsset = vi.fn<(path: string) => Promise<ArrayBuffer>>().mockRejectedValue(denied)
+
+    const response = await request(assetsDir, '/assets/denied.js', 'GET', undefined, readAsset)
+
+    expect(response.status).toBe(500)
+    expect(readAsset).toHaveBeenCalledOnce()
+  })
+
+  test('does not follow symlinks outside the asset root', async () => {
+    const { root, assetsDir } = await fixture()
+    await writeFile(join(root, 'secret.js'), 'secret')
+    await symlink(join(root, 'secret.js'), join(assetsDir, 'link.js'))
+
+    expect((await request(assetsDir, '/assets/link.js')).status).toBe(404)
+  })
+})

--- a/test/ui/home-hero.test.tsx
+++ b/test/ui/home-hero.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
+import { HOME_HEADING_BASE } from '@/lib/page-title'
 import { HomeHero } from '@/ui/home-hero'
 
 describe('HomeHero', () => {
@@ -17,9 +18,9 @@ describe('HomeHero', () => {
     const h1s = container.querySelectorAll('h1')
     expect(h1s).toHaveLength(1)
     // Exact text, not toContain: JSX drops whitespace between sibling elements, so without an
-    // explicit separator this reads "statuslin.esClaude Code status lines" to anything that
+    // explicit separator this reads "statuslin.esClaude Code status line examples" to anything that
     // walks text nodes — a screen reader announcing the heading, or a crawler.
-    expect(h1s[0]?.textContent).toBe('statuslin.es Claude Code status lines')
+    expect(h1s[0]?.textContent).toBe(`statuslin.es ${HOME_HEADING_BASE}`)
   })
 
   it('shows the keyword phrase to sighted readers instead of hiding it', () => {
@@ -28,8 +29,19 @@ describe('HomeHero', () => {
     // crawlers, invisible to readers. It is the visible hero subtitle now, so nothing in
     // the hero may be screen-reader-only.
     expect(container.querySelector('.sr-only')).toBeNull()
-    const subtitle = screen.getByText('Claude Code status lines')
+    const subtitle = screen.getByText(HOME_HEADING_BASE)
     expect(subtitle.className).not.toContain('sr-only')
     expect(subtitle.className).toContain('text-muted-foreground')
+  })
+
+  it('adds the loader-clamped page number to the page 2 heading', () => {
+    render(<HomeHero page={2} />)
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: 'statuslin.es Claude Code status line examples — Page 2',
+      }),
+    ).toBeTruthy()
   })
 })

--- a/test/ui/route-error.test.tsx
+++ b/test/ui/route-error.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { RouteError } from '@/ui/route-error'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('RouteError', () => {
+  it('offers a reload and keeps the failed page out of search results', () => {
+    const reload = vi.fn()
+    vi.stubGlobal('location', { reload })
+
+    render(<RouteError error={new Error('chunk failed')} reset={vi.fn()} />)
+
+    expect(screen.getByRole('heading', { name: 'This page couldn’t load' })).toBeTruthy()
+    expect(
+      screen.getByText('A required file failed to load. Reload the page to try again.'),
+    ).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reload page' }))
+
+    expect(reload).toHaveBeenCalledOnce()
+    expect(document.head.querySelector('meta[name="robots"]')?.getAttribute('content')).toBe(
+      'noindex, follow',
+    )
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -152,6 +152,16 @@ export default defineConfig(({ mode }) => ({
             // Server-side error capture: this plugin registers a Nitro `error` hook that forwards SSR
             // crashes / uncaught exceptions / unhandled rejections to PostHog (src/lib/posthog-server).
             plugins: ['./src/server/posthog-error-plugin.ts'],
+            // Nitro's generated static-asset manifest contains only this build's files. Its static
+            // middleware runs first and falls through on a miss; this route then serves retained
+            // generations before the catch-all TanStack renderer. Keep it method-agnostic so the
+            // handler itself returns 405 for methods other than GET/HEAD.
+            handlers: [
+              {
+                route: '/assets/**',
+                handler: './src/server/retained-asset.ts',
+              },
+            ],
             routeRules: {
               // Prod equivalent of the dev `server.proxy` above. Vite's server.proxy is DEV-ONLY, so
               // without these the browser's events (which POST to api_host '/ingest') would hit the


### PR DESCRIPTION
## Summary

- Keep crawlable document metadata intact when route chunks fail, and capture early client and server rendering errors.
- Retain prior fingerprinted assets across releases and validate real production assets before promotion.
- Correct homepage pagination, resources intent, the legacy guide redirect, thin-facet indexing, sitemap freshness, and structured data.
- Strengthen production smoke coverage for metadata, hydration, and first-party browser resources.

## Verification

- bun run check: 167 passed test files, 1,085 passed tests, zero failures.
- Production Docker image rebuilt from commit 27c7ac8 and passed read-only SEO HTTP assertions.
- Real-browser smoke passed against that production image, including hydration and all initial first-party assets.