### PR TITLE
feat(seo): restore /guide and index gallery status lines for search

### DIFF
--- a/docs/frontend-guidelines.md
+++ b/docs/frontend-guidelines.md
@@ -96,7 +96,8 @@ Vertical rhythm between page sections is `Stack gap` on the parent — no margin
 
 | Export | File | What it does |
 | --- | --- | --- |
-| `<CodeBlock>` | `src/ui/code-block.tsx` | Styled `<pre>` block for source display |
+| `<CopyButton>` / `<Copyable>` | `src/ui/copy-button.tsx` | Clipboard control; `Copyable` overlays it on a code well |
+| `<CodeBlock>` | `src/ui/code-block.tsx` | Styled `<pre>` block for source display; pass `text` to copy |
 | `<SectionCard title action={…}>` | `src/ui/section-card.tsx` | Section with header + optional action slot |
 | `<ScenarioRow>` | `src/ui/scenario-row.tsx` | Labeled row for scenario-level content |
 | `<Notice tone="info\|error">` | `src/ui/notice.tsx` | Inline status / error notice |

--- a/src/adopt/adopt-actions.tsx
+++ b/src/adopt/adopt-actions.tsx
@@ -1,10 +1,8 @@
-import { Check, Copy } from 'lucide-react'
-import { useState } from 'react'
 import { toast } from 'sonner'
 import { buildClaudePrompt } from '@/adopt/install'
 import type { RecordedCopyController } from '@/adopt/use-recorded-copy'
 import type { Interpreter } from '@/render/types'
-import { Button } from '@/ui/button'
+import { CopyButton } from '@/ui/copy-button'
 import { CopyCount } from '@/ui/copy-count'
 import { Row } from '@/ui/layout'
 
@@ -17,49 +15,24 @@ interface AdoptPromptProps {
 
 /** Title-row adopt control: primary "Copy install prompt" button + the displayed copy count. */
 export function AdoptPrompt({ source, interpreter, title, controller }: AdoptPromptProps) {
-  const [copied, setCopied] = useState(false)
-
-  function copyPrompt() {
-    controller.copy(buildClaudePrompt({ source, interpreter, title }), 'prompt', () => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-      toast('Prompt copied', {
-        description: 'Paste it into Claude Code to set up this status line.',
-      })
+  function onCopied() {
+    controller.record('prompt')
+    toast('Prompt copied', {
+      description: 'Paste it into Claude Code to set up this status line.',
     })
   }
 
   return (
     <Row gap={3} wrap>
-      <Button size="lg" onClick={copyPrompt} aria-label={`Copy install prompt — ${title}`}>
-        {copied ? <Check /> : <Copy />}
-        {copied ? 'Copied!' : 'Copy install prompt'}
-      </Button>
+      <CopyButton
+        text={buildClaudePrompt({ source, interpreter, title })}
+        label="Copy install prompt"
+        size="lg"
+        variant="default"
+        ariaLabel={`Copy install prompt — ${title}`}
+        onCopied={onCopied}
+      />
       <CopyCount count={controller.count} />
     </Row>
-  )
-}
-
-interface CopyScriptButtonProps {
-  source: string
-  controller: RecordedCopyController
-}
-
-/** Source-card control: outline button copying raw source through the page's shared recorder. */
-export function CopyScriptButton({ source, controller }: CopyScriptButtonProps) {
-  const [copied, setCopied] = useState(false)
-
-  function copyScript() {
-    controller.copy(source, 'script', () => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    })
-  }
-
-  return (
-    <Button variant="outline" size="lg" onClick={copyScript}>
-      {copied ? <Check /> : <Copy />}
-      {copied ? 'Copied!' : 'Copy script'}
-    </Button>
   )
 }

--- a/src/adopt/use-recorded-copy.ts
+++ b/src/adopt/use-recorded-copy.ts
@@ -5,13 +5,14 @@ import { recordCopyFn } from '@/adopt/functions'
 
 export interface RecordedCopyController {
   count: number
-  copy: (text: string, kind: CopyKind, onCopied: () => void) => void
+  record: (kind: CopyKind) => void
 }
 
 /**
- * Shared copy-and-record logic for adopt controls: clipboard write → optimistic
- * count bump → server reconcile (only a positive total is adopted, so an
- * unpublished/missing config returning 0 doesn't regress the display).
+ * Shared record-and-reconcile logic for adopt controls: optimistic count bump →
+ * server reconcile (only a positive total is adopted, so an unpublished/missing
+ * config returning 0 doesn't regress the display). Callers write the clipboard
+ * themselves (CopyButton) and invoke `record` only after a successful write.
  *
  * The PostHog copy event fires server-side (in recordCopyFn), not here — ad blockers can't strip a
  * server event, and copies are the North Star metric. We pass the browser's distinct + session ids
@@ -68,18 +69,5 @@ export function useRecordedCopy(configId: string, copyCount: number): RecordedCo
     }
   }
 
-  /** Writes `text` to the clipboard; on success calls `onCopied` and records the copy. */
-  function copy(text: string, kind: CopyKind, onCopied: () => void) {
-    navigator.clipboard
-      .writeText(text)
-      .then(() => {
-        onCopied()
-        void record(kind)
-      })
-      .catch(() => {
-        // Clipboard denied/unavailable — don't claim "Copied!" or bump the count.
-      })
-  }
-
-  return { count, copy }
+  return { count, record }
 }

--- a/src/guide/examples.ts
+++ b/src/guide/examples.ts
@@ -1,0 +1,45 @@
+import { resolveResets } from '@/render/scenario-helpers'
+import { SCENARIOS } from '@/render/scenarios'
+
+/**
+ * Everything the /guide page shows as an example, in one place so the page
+ * component stays small and every example is testable:
+ * - SAMPLE_STDIN_JSON is DERIVED from src/render/scenarios.ts (whose tests enforce
+ *   coverage of every field Claude Code sends), never hand-written.
+ * - MINIMAL_SCRIPT is executed by test/guide/examples.test.ts against real payloads.
+ * - SETTINGS_SNIPPET matches the official docs (code.claude.com/docs/en/statusline).
+ */
+
+/** Fixed "now" for resolving rate-limit reset offsets into absolute epochs, so the
+ * rendered example is deterministic. 2026-06-21T00:26:40Z — any constant works. */
+const SAMPLE_NOW_EPOCH = 1_782_000_000
+
+const cleanMain = SCENARIOS.find((s) => s.key === 'clean-main')
+if (!cleanMain) throw new Error('clean-main scenario missing from SCENARIOS')
+
+/** The full JSON Claude Code pipes to a status line script, pretty-printed. */
+export const SAMPLE_STDIN_JSON = JSON.stringify(
+  resolveResets(cleanMain.stdin, SAMPLE_NOW_EPOCH),
+  null,
+  2,
+)
+
+/** A minimal working status line: model, directory basename, context usage. */
+export const MINIMAL_SCRIPT = `#!/bin/bash
+input=$(cat)
+model=$(jq -r '.model.display_name' <<<"$input")
+dir=$(jq -r '.workspace.current_dir' <<<"$input")
+pct=$(jq -r '.context_window.used_percentage // 0' <<<"$input")
+echo "[$model] \${dir##*/} · \${pct}% context"
+`
+
+/** What MINIMAL_SCRIPT prints for SAMPLE_STDIN_JSON (asserted by the test suite). */
+export const MINIMAL_SCRIPT_OUTPUT = '[Opus 4.8] app · 22% context'
+
+/** The settings.json wiring, exactly as the official docs specify. */
+export const SETTINGS_SNIPPET = `{
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh"
+  }
+}`

--- a/src/guide/functions.ts
+++ b/src/guide/functions.ts
@@ -1,0 +1,39 @@
+import { createServerFn } from '@tanstack/react-start'
+import { MINIMAL_SCRIPT, SAMPLE_STDIN_JSON, SETTINGS_SNIPPET } from '@/guide/examples'
+import { highlightSource } from '@/lib/highlight'
+
+/**
+ * Shiki-highlighted HTML for the /guide page's three code blocks. The inputs
+ * (SAMPLE_STDIN_JSON, MINIMAL_SCRIPT, SETTINGS_SNIPPET) are module constants, so the
+ * highlighted result is computed once per server process and reused for every request.
+ */
+let highlightsPromise: Promise<{
+  payloadHtml: string
+  scriptHtml: string
+  settingsHtml: string
+}> | null = null
+
+function computeGuideHighlights() {
+  if (!highlightsPromise) {
+    highlightsPromise = Promise.all([
+      highlightSource(SAMPLE_STDIN_JSON, 'json'),
+      highlightSource(MINIMAL_SCRIPT, 'bash'),
+      highlightSource(SETTINGS_SNIPPET, 'json'),
+    ]).then(([payloadHtml, scriptHtml, settingsHtml]) => ({
+      payloadHtml,
+      scriptHtml,
+      settingsHtml,
+    }))
+    // Don't cache a rejection: a failed first run would otherwise poison the module-level
+    // cache and 500 every /guide request until a process restart. Reset so the next request
+    // retries; the rejection itself still propagates to the caller that triggered it.
+    highlightsPromise.catch(() => {
+      highlightsPromise = null
+    })
+  }
+  return highlightsPromise
+}
+
+export const getGuideHighlights = createServerFn({ method: 'GET' }).handler(() =>
+  computeGuideHighlights(),
+)

--- a/src/guide/guide-content.tsx
+++ b/src/guide/guide-content.tsx
@@ -1,0 +1,231 @@
+import {
+  MINIMAL_SCRIPT,
+  MINIMAL_SCRIPT_OUTPUT,
+  SAMPLE_STDIN_JSON,
+  SETTINGS_SNIPPET,
+} from '@/guide/examples'
+import type { AnsiSegment } from '@/render/types'
+import { Card, CardContent, CardHeader, CardTitle } from '@/ui/card'
+import { HighlightedCode } from '@/ui/highlighted-code'
+import { Grid, Stack } from '@/ui/layout'
+import { Notice } from '@/ui/notice'
+import { SectionCard } from '@/ui/section-card'
+import { StatuslinePreview } from '@/ui/statusline-preview'
+import { Heading, Text, TextLink } from '@/ui/text'
+
+const DOCS_URL = 'https://code.claude.com/docs/en/statusline'
+
+const EXAMPLE_SEGMENTS: AnsiSegment[] = [
+  {
+    text: MINIMAL_SCRIPT_OUTPUT,
+    fg: null,
+    bg: null,
+    bold: false,
+    italic: false,
+    underline: false,
+  },
+]
+
+/**
+ * The /guide page body. Example strings live in src/guide/examples.ts; this file is
+ * prose and layout. Code blocks are pre-highlighted server-side and passed in as `highlights`.
+ */
+export function GuideContent({
+  highlights,
+}: {
+  highlights: { payloadHtml: string; scriptHtml: string; settingsHtml: string }
+}) {
+  return (
+    <Stack gap={6}>
+      <Stack gap={3}>
+        <Heading level={1}>How to set up a Claude Code status line</Heading>
+        <Text muted>
+          The status line is the bar at the bottom of Claude Code. Each time it refreshes, Claude
+          Code runs your shell script, sends it a JSON snapshot on stdin, and shows whatever the
+          script prints. Start with a fast path, or skip to wiring a script by hand.
+        </Text>
+      </Stack>
+
+      <Stack gap={3}>
+        <Heading level={2}>The fast paths</Heading>
+        <Grid>
+          <Card>
+            <CardHeader>
+              <CardTitle>Run /statusline</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Text muted size="sm">
+                Inside Claude Code, describe what you want, like{' '}
+                <Text inline mono>
+                  /statusline show model, directory, and context usage
+                </Text>
+                . It writes the script to{' '}
+                <Text inline mono>
+                  ~/.claude/
+                </Text>{' '}
+                and updates your settings. Done.
+              </Text>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Copy from the gallery</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Text muted size="sm">
+                Every config shows exactly what it renders before you install it.{' '}
+                <TextLink to="/">Browse the gallery</TextLink>.
+              </Text>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Stack>
+
+      <SectionCard title="Wire up a script by hand" headingLevel={2}>
+        <Stack gap={6}>
+          <Stack gap={3}>
+            <Text muted>
+              Save a script to{' '}
+              <Text inline mono>
+                ~/.claude/statusline.sh
+              </Text>
+              , make it executable (
+              <Text inline mono>
+                chmod +x ~/.claude/statusline.sh
+              </Text>
+              ), and point the{' '}
+              <Text inline mono>
+                statusLine
+              </Text>{' '}
+              setting in{' '}
+              <Text inline mono>
+                ~/.claude/settings.json
+              </Text>{' '}
+              at it:
+            </Text>
+            <HighlightedCode
+              html={highlights.settingsHtml}
+              text={SETTINGS_SNIPPET}
+              copyLabel="Copy settings"
+            />
+            <Text muted>
+              Claude Code reloads settings on its own. The status line appears on your next message.
+              Two optional fields:{' '}
+              <Text inline mono>
+                padding
+              </Text>{' '}
+              adds horizontal space so the line isn't flush with the edge, and{' '}
+              <Text inline mono>
+                refreshInterval
+              </Text>{' '}
+              re-runs the script every N seconds if you show a clock or other live data. The{' '}
+              <TextLink href={DOCS_URL}>official docs</TextLink> list the rest.
+            </Text>
+          </Stack>
+
+          <Stack gap={3}>
+            <Heading level={3}>The JSON your script receives</Heading>
+            <Text muted>
+              Your script gets one JSON object on stdin per update. This is a real payload, the same
+              one this site uses to render every gallery preview:
+            </Text>
+            <HighlightedCode
+              html={highlights.payloadHtml}
+              text={SAMPLE_STDIN_JSON}
+              copyLabel="Copy JSON"
+            />
+            <Text muted>
+              Most scripts only need a few fields:{' '}
+              <Text inline mono>
+                model.display_name
+              </Text>
+              ,{' '}
+              <Text inline mono>
+                workspace.current_dir
+              </Text>
+              ,{' '}
+              <Text inline mono>
+                context_window.used_percentage
+              </Text>
+              , and{' '}
+              <Text inline mono>
+                cost.total_cost_usd
+              </Text>
+              . Each{' '}
+              <Text inline mono>
+                rate_limits
+              </Text>{' '}
+              window has a usage percentage and a{' '}
+              <Text inline mono>
+                resets_at
+              </Text>{' '}
+              unix timestamp.
+            </Text>
+          </Stack>
+
+          <Stack gap={3}>
+            <Heading level={3}>A minimal working script</Heading>
+            <Text muted>
+              Three fields, one{' '}
+              <Text inline mono>
+                jq
+              </Text>{' '}
+              call each:
+            </Text>
+            <HighlightedCode
+              html={highlights.scriptHtml}
+              text={MINIMAL_SCRIPT}
+              copyLabel="Copy script"
+            />
+            <Text muted size="sm">
+              For the payload above it prints:
+            </Text>
+            <StatuslinePreview segments={EXAMPLE_SEGMENTS} />
+            <Text muted>
+              You can try it without opening Claude Code: save that JSON to a file and run{' '}
+              <Text inline mono>
+                bash statusline.sh &lt; sample.json
+              </Text>
+              . This repo's tests run that exact script against real payloads on every commit.
+            </Text>
+          </Stack>
+        </Stack>
+      </SectionCard>
+
+      <Stack gap={3}>
+        <Heading level={2}>Two pitfalls</Heading>
+        <Notice tone="info">
+          Git status isn't in the payload. Scripts that show a branch run{' '}
+          <Text inline mono>
+            git
+          </Text>{' '}
+          themselves against{' '}
+          <Text inline mono>
+            workspace.current_dir
+          </Text>
+          . That's how gallery configs do it, even though Claude Code never sends a branch.
+        </Notice>
+        <Notice tone="info">
+          <Text inline mono>
+            context_window.used_percentage
+          </Text>{' '}
+          is null at the start of a fresh session. Guard it (
+          <Text inline mono>
+            {'// 0'}
+          </Text>{' '}
+          in jq) or the bar reads "null" until the first response.
+        </Notice>
+      </Stack>
+
+      <Stack gap={3}>
+        <Heading level={2}>Going further</Heading>
+        <Text muted>
+          Want more than a few fields? The{' '}
+          <TextLink to="/resources">tools & resources list</TextLink> has themes, widgets, and usage
+          trackers. Or <TextLink to="/">copy a status line from the gallery</TextLink> and tweak it.
+          If you build one you like, <TextLink to="/submit">submit it to the gallery</TextLink>.
+        </Text>
+      </Stack>
+    </Stack>
+  )
+}

--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -1,5 +1,5 @@
 import type { GeneratedContent } from '@/content/types'
-import { homePageName, RESOURCES_TITLE_BASE } from '@/lib/page-title'
+import { GUIDE_TITLE_BASE, homePageName, RESOURCES_TITLE_BASE } from '@/lib/page-title'
 import { CONTENT_LICENSE } from '@/lib/site'
 
 /**
@@ -125,6 +125,28 @@ function configFaqJsonLd(title: string, content: GeneratedContent | null): objec
     }))
   if (mainEntity.length === 0) return null
   return { '@context': 'https://schema.org', '@type': 'FAQPage', mainEntity }
+}
+
+/** The /guide page as a TechArticle plus a breadcrumb trail back to the gallery. */
+export function guideJsonLd(origin: string, description: string): object[] {
+  const url = `${origin}/guide`
+  return [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'TechArticle',
+      headline: GUIDE_TITLE_BASE,
+      url,
+      description,
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Status lines', item: origin },
+        { '@type': 'ListItem', position: 2, name: GUIDE_TITLE_BASE, item: url },
+      ],
+    },
+  ]
 }
 
 /** The /resources page as a CollectionPage listing the external tools/resources. */

--- a/src/lib/llms.ts
+++ b/src/lib/llms.ts
@@ -22,6 +22,7 @@ function corePageLinks(base: string): string[] {
   return [
     `- [Gallery](${base}/): every published status line, sorted by trending, newest, or most copied`,
     `- [Submit a status line](${base}/submit): add your own`,
+    `- [Guide](${base}/guide): how to wire a Claude Code status line by hand, with a tested example`,
     `- [Resources](${base}/resources): related Claude Code status line tools`,
   ]
 }

--- a/src/lib/page-title.ts
+++ b/src/lib/page-title.ts
@@ -41,14 +41,14 @@ export function configMetaDescription(description: string | null | undefined): s
 export const NOT_FOUND_TITLE = 'Status line not found — statuslin.es'
 
 /**
- * The home page's title base — shared by the <title> tag and the home JSON-LD name. Targets
- * "claude code status line examples", a phrase visitors actually search, rather than
- * "community gallery", which nobody does.
+ * The home page's title base — shared by the <title> tag and the home JSON-LD name. These are
+ * community-submitted configs, not samples, so the title says "status lines" rather than
+ * "examples" or "templates".
  */
-export const HOME_TITLE_BASE = 'Claude Code Status Line Examples'
-export const HOME_HEADING_BASE = 'Claude Code status line examples'
+export const HOME_TITLE_BASE = 'Claude Code Status Lines'
+export const HOME_HEADING_BASE = 'Claude Code status lines'
 export const HOME_DESCRIPTION_BASE =
-  'Browse a gallery of Claude Code status line examples and ready-to-copy templates. See real rendered previews and copy one in a single paste.'
+  'Browse a community gallery of Claude Code status lines. See real rendered previews and copy one in a single paste.'
 
 function homePageSuffix(page: number): string {
   return page > 1 ? ` — Page ${page}` : ''
@@ -69,6 +69,13 @@ export function homePageHeading(page: number): string {
 export function homeMetaDescription(page: number, pageCount: number): string {
   return `${HOME_DESCRIPTION_BASE}${page > 1 ? ` Page ${page} of ${pageCount}.` : ''}`
 }
+
+/** /guide title base — shared by the <title> tag and the guide JSON-LD headline. */
+export const GUIDE_TITLE_BASE = 'How to Set Up a Claude Code Status Line'
+
+/** /guide meta description — shared by the description tag, OG, and TechArticle JSON-LD. */
+export const GUIDE_DESCRIPTION =
+  'How to set up a Claude Code status line: the statusLine setting, the JSON your script gets, and a tested example you can copy.'
 
 /** /resources title base — shared by the <title> tag and the resources JSON-LD name. */
 export const RESOURCES_TITLE_BASE = 'Claude Code Status Line Tools & Resources'

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -20,7 +20,7 @@ export interface SitemapFacet {
 }
 
 /** Always-present public pages, as paths relative to the origin. */
-const STATIC_PATHS = ['/', '/resources', '/submit', '/terms']
+const STATIC_PATHS = ['/', '/guide', '/resources', '/submit', '/terms']
 
 /** Escape the five XML entities so a slug with `&`/`<` can't break the document. */
 function xmlEscape(value: string): string {

--- a/src/resources/resources-content.tsx
+++ b/src/resources/resources-content.tsx
@@ -19,11 +19,48 @@ export function ResourcesContent({ signedIn }: { signedIn: boolean }) {
       <Stack gap={3}>
         <Heading level={1}>Claude Code status line tools & resources</Heading>
 
-        <Text muted measure>
-          A short, opinionated list of the status line tools and reading we'd point a friend at. The
-          descriptions are ours, not the projects' own marketing. If you want a good status line
-          without installing anything, <TextLink to="/">the gallery</TextLink> is full of
-          ready-to-copy examples.
+        <Text muted>
+          A short, opinionated list of status line tools and reading we'd point a friend at. The
+          descriptions are ours, not the projects' own marketing. Want a rendered status line you
+          can copy? <TextLink to="/">Browse the gallery</TextLink>. Wiring a script by hand? See the{' '}
+          <TextLink to="/guide">setup guide</TextLink>.
+        </Text>
+      </Stack>
+
+      <Stack gap={3}>
+        <Heading level={2}>Four ways to get a status line</Heading>
+        <Text muted>
+          The built-in{' '}
+          <Text inline mono>
+            /statusline
+          </Text>{' '}
+          command is the fastest start: describe what you want inside Claude Code, and it writes the
+          script and settings for you. Use it if you don't have a status line yet.
+        </Text>
+        <Text muted>
+          Install a tool from the list below if you want a terminal UI, themes, or widgets without
+          maintaining a script. Start with ccstatusline or claude-powerline.
+        </Text>
+        <Text muted>
+          Copy a reviewed script from <TextLink to="/">the gallery</TextLink> if you want a rendered
+          preview and a one-paste install — no extra runtime. Powerline look:{' '}
+          <TextLink to="/c/$slug" params={{ slug: 'powerline-dracula-6936b97c' }}>
+            Powerline Dracula
+          </TextLink>
+          . Token counters:{' '}
+          <TextLink to="/status-lines/$facet" params={{ facet: 'token-usage' }}>
+            status lines that show token usage
+          </TextLink>
+          . Looking for ohugonnot/claude-code-statusline?{' '}
+          <TextLink to="/c/$slug" params={{ slug: 'quota-fallback-2a730aa6' }}>
+            Quota Fallback
+          </TextLink>{' '}
+          is the reviewed gallery copy.
+        </Text>
+        <Text muted>
+          Write a script by hand when you want to own every field. The{' '}
+          <TextLink to="/guide">setup guide</TextLink> uses the same JSON this site uses for gallery
+          previews, and a script the tests execute on every commit.
         </Text>
       </Stack>
 
@@ -56,7 +93,7 @@ export function ResourcesContent({ signedIn }: { signedIn: boolean }) {
         <CardContent>
           <Stack gap={3}>
             <Heading level={2}>Get listed</Heading>
-            <Text muted measure>
+            <Text muted>
               If you've made a status line you like,{' '}
               <TextLink to="/submit">submit it to the gallery</TextLink> and it gets its own preview
               page. Built a tool that belongs on this list? Email{' '}

--- a/src/review/dashboard-card-parts.tsx
+++ b/src/review/dashboard-card-parts.tsx
@@ -121,7 +121,9 @@ export function SubmissionDetails({
         </Details>
       ) : null}
       <Details summary="Source">
-        <CodeBlock compact>{source}</CodeBlock>
+        <CodeBlock compact text={source}>
+          {source}
+        </CodeBlock>
       </Details>
     </>
   )

--- a/src/routes/c.$slug.tsx
+++ b/src/routes/c.$slug.tsx
@@ -1,7 +1,7 @@
 import { usePostHog } from '@posthog/react'
 import { createFileRoute, notFound } from '@tanstack/react-router'
 import { useEffect } from 'react'
-import { AdoptPrompt, CopyScriptButton } from '@/adopt/adopt-actions'
+import { AdoptPrompt } from '@/adopt/adopt-actions'
 import { useRecordedCopy } from '@/adopt/use-recorded-copy'
 import { ConfigBadges } from '@/gallery/config-badges'
 import { tagLabel } from '@/gallery/facets'
@@ -179,12 +179,13 @@ function ConfigDetail() {
         </SectionCard>
 
         {/* Source */}
-        <SectionCard
-          title="Source"
-          headingLevel={2}
-          action={<CopyScriptButton source={detail.source} controller={copyController} />}
-        >
-          <HighlightedCode html={detail.sourceHtml} />
+        <SectionCard title="Source" headingLevel={2}>
+          <HighlightedCode
+            html={detail.sourceHtml}
+            text={detail.source}
+            copyLabel="Copy script"
+            onCopied={() => copyController.record('script')}
+          />
         </SectionCard>
 
         {/* Auto-generated copy — the SEO answer to "what does this status line do?" */}

--- a/src/routes/guide.tsx
+++ b/src/routes/guide.tsx
@@ -1,7 +1,37 @@
-import { createFileRoute, redirect } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
+import { getGuideHighlights } from '@/guide/functions'
+import { GuideContent } from '@/guide/guide-content'
+import { getSession } from '@/lib/auth-functions'
+import { canonicalLink } from '@/lib/canonical'
+import { guideJsonLd, jsonLdScript } from '@/lib/json-ld'
+import { GUIDE_DESCRIPTION, GUIDE_TITLE_BASE } from '@/lib/page-title'
+import { siteUrl } from '@/lib/site'
+import { staticPageSocialMeta } from '@/og/meta'
+import { PageShell } from '@/ui/shell'
 
 export const Route = createFileRoute('/guide')({
-  beforeLoad: () => {
-    throw redirect({ to: '/resources', statusCode: 301 })
-  },
+  loader: async () => ({ user: await getSession(), highlights: await getGuideHighlights() }),
+  head: () => ({
+    meta: [
+      { title: `${GUIDE_TITLE_BASE} | statuslin.es` },
+      { name: 'description', content: GUIDE_DESCRIPTION },
+      ...staticPageSocialMeta({
+        path: '/guide',
+        title: GUIDE_TITLE_BASE,
+        description: GUIDE_DESCRIPTION,
+      }),
+    ],
+    links: [canonicalLink('/guide')],
+    scripts: guideJsonLd(siteUrl(), GUIDE_DESCRIPTION).map(jsonLdScript),
+  }),
+  component: Guide,
 })
+
+function Guide() {
+  const { user, highlights } = Route.useLoaderData()
+  return (
+    <PageShell user={user}>
+      <GuideContent highlights={highlights} />
+    </PageShell>
+  )
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -19,7 +19,7 @@ import { HomeHero } from '@/ui/home-hero'
 import { Row, Stack } from '@/ui/layout'
 import { PageShell } from '@/ui/shell'
 import { SubmitCta } from '@/ui/submit-cta'
-import { Text } from '@/ui/text'
+import { Text, TextLink } from '@/ui/text'
 import { VisuallyHidden } from '@/ui/visually-hidden'
 
 export const Route = createFileRoute('/')({
@@ -91,9 +91,9 @@ function Home() {
       <Stack gap={9}>
         <HomeHero page={page} />
         <Text muted size="sm" measure center>
-          Explore a community gallery of Claude Code status line examples and ready-to-copy
-          templates. Every card shows previews rendered from the real script, so you can see it
-          before you copy it.
+          Explore a community gallery of Claude Code status lines. Every card shows previews
+          rendered from the real script, so you can see it before you copy it. To wire one up
+          yourself, read the <TextLink to="/guide">setup guide</TextLink>.
         </Text>
         <Stack gap={4}>
           <VisuallyHidden as="h2">Status lines</VisuallyHidden>

--- a/src/ui/app-header.tsx
+++ b/src/ui/app-header.tsx
@@ -48,6 +48,9 @@ export function AppHeader({ user = null }: { user?: AppHeaderUser | null }) {
         </Link>
         <nav className="flex items-center gap-2">
           <Button asChild variant="ghost" size="lg">
+            <Link to="/guide">Guide</Link>
+          </Button>
+          <Button asChild variant="ghost" size="lg">
             <Link to="/resources">Resources</Link>
           </Button>
           {user ? <UserMenu user={user} /> : <SignInButton />}

--- a/src/ui/code-block.tsx
+++ b/src/ui/code-block.tsx
@@ -1,18 +1,28 @@
 import type * as React from 'react'
+import { Copyable } from '@/ui/copy-button'
 
 /**
  * Monospace source block. The default is the detail-page `<pre>`; `compact` is the
  * tighter admin-review variant nested inside a `<details>` (less padding, top margin).
+ * Pass `text` to overlay the shared copy control.
  */
 export function CodeBlock({
   compact = false,
+  text,
+  copyLabel,
   children,
 }: {
-  compact?: boolean
+  compact?: boolean | undefined
+  text?: string | undefined
+  copyLabel?: string | undefined
   children: React.ReactNode
 }) {
   const className = compact
     ? 'mt-2 overflow-x-auto rounded-md bg-sunken p-3 font-mono text-foreground text-sm'
     : 'overflow-x-auto rounded-md bg-sunken p-4 font-mono text-foreground text-sm'
-  return <pre className={className}>{children}</pre>
+  return (
+    <Copyable text={text} copyLabel={copyLabel}>
+      <pre className={className}>{children}</pre>
+    </Copyable>
+  )
 }

--- a/src/ui/copy-button.tsx
+++ b/src/ui/copy-button.tsx
@@ -1,0 +1,84 @@
+import { Check, Copy } from 'lucide-react'
+import type * as React from 'react'
+import { useState } from 'react'
+import { Button } from '@/ui/button'
+
+const COPIED_MS = 2000
+
+/**
+ * Clipboard control used by code wells and adopt CTAs. Writes `text`, swaps the
+ * label to Copied! on success, and calls `onCopied` only after a successful write
+ * so callers can record analytics without duplicating clipboard logic.
+ */
+export function CopyButton({
+  text,
+  label = 'Copy',
+  copiedLabel = 'Copied!',
+  size = 'sm',
+  variant = 'outline',
+  iconOnly = false,
+  ariaLabel,
+  onCopied,
+}: {
+  text: string
+  label?: string | undefined
+  copiedLabel?: string | undefined
+  size?: 'sm' | 'lg' | 'icon-sm' | undefined
+  variant?: 'outline' | 'ghost' | 'default' | undefined
+  iconOnly?: boolean | undefined
+  ariaLabel?: string | undefined
+  onCopied?: (() => void) | undefined
+}) {
+  const [copied, setCopied] = useState(false)
+  const name = copied ? copiedLabel : label
+
+  function handleClick() {
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        setCopied(true)
+        setTimeout(() => setCopied(false), COPIED_MS)
+        onCopied?.()
+      })
+      .catch(() => {
+        // Clipboard denied/unavailable — don't claim Copied!.
+      })
+  }
+
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      size={iconOnly ? 'icon-sm' : size}
+      onClick={handleClick}
+      aria-label={ariaLabel ?? name}
+    >
+      {copied ? <Check /> : <Copy />}
+      {iconOnly ? null : name}
+    </Button>
+  )
+}
+
+/** Positions an icon copy control over a sunken code well. */
+export function Copyable({
+  text,
+  copyLabel = 'Copy',
+  onCopied,
+  children,
+}: {
+  text?: string | undefined
+  copyLabel?: string | undefined
+  onCopied?: (() => void) | undefined
+  children: React.ReactNode
+}) {
+  return (
+    <div className="relative">
+      {children}
+      {text !== undefined ? (
+        <div className="absolute top-2 right-2 z-10">
+          <CopyButton iconOnly text={text} label={copyLabel} onCopied={onCopied} />
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/ui/highlighted-code.tsx
+++ b/src/ui/highlighted-code.tsx
@@ -1,9 +1,27 @@
+import { Copyable } from '@/ui/copy-button'
+
 /**
  * Renders Shiki's server-generated, syntax-highlighted source HTML. Safe to inject: Shiki escapes
  * the code text (see src/lib/highlight.ts), so the string is markup we produced, not user markup.
- * Appearance lives in the `.shiki` rule in src/styles/app.css.
+ * Appearance lives in the `.shiki` rule in src/styles/app.css. Pass `text` to overlay the shared
+ * copy control (the highlighted HTML is display-only; `text` is what actually hits the clipboard).
  */
-export function HighlightedCode({ html }: { html: string }) {
+export function HighlightedCode({
+  html,
+  text,
+  copyLabel,
+  onCopied,
+}: {
+  html: string
+  text?: string | undefined
+  copyLabel?: string | undefined
+  onCopied?: (() => void) | undefined
+}) {
   // biome-ignore lint/security/noDangerouslySetInnerHtml: server-generated, Shiki-escaped HTML.
-  return <div dangerouslySetInnerHTML={{ __html: html }} />
+  const well = <div dangerouslySetInnerHTML={{ __html: html }} />
+  return (
+    <Copyable text={text} copyLabel={copyLabel} onCopied={onCopied}>
+      {well}
+    </Copyable>
+  )
 }

--- a/src/ui/home-hero.tsx
+++ b/src/ui/home-hero.tsx
@@ -12,7 +12,7 @@ export function HomeHero({ page = 1 }: { page?: number }) {
     <h1 className="text-center font-mono text-[clamp(1.5rem,10vw,3rem)] text-foreground">
       <Wordmark size="hero" />
       {/* Explicit separator: JSX drops the whitespace between sibling elements, so without it the
-          heading reads "statuslin.esClaude Code status line examples" to a screen reader. The subtitle is
+          heading reads "statuslin.esClaude Code status lines" to a screen reader. The subtitle is
           `block`, so the space collapses and nothing moves on screen. */}{' '}
       <span className="mt-3 block text-lg text-muted-foreground">{homePageHeading(page)}</span>
     </h1>

--- a/src/ui/site-footer.tsx
+++ b/src/ui/site-footer.tsx
@@ -4,7 +4,7 @@ import { TextLink } from '@/ui/text'
 
 /**
  * Shared bottom footer on every page: the centered text links — the GitHub source,
- * a mailto report (the abuse-report path), the Resources and Terms pages,
+ * a mailto report (the abuse-report path), the Guide, Resources and Terms pages,
  * separated by dots.
  */
 export function SiteFooter() {
@@ -23,6 +23,10 @@ export function SiteFooter() {
         ·
         <TextLink href={`mailto:${CONTACT_EMAIL}`} aria-label="Report or contact" size="sm">
           Email
+        </TextLink>
+        ·
+        <TextLink to="/guide" size="sm">
+          Guide
         </TextLink>
         ·
         <TextLink to="/resources" size="sm">

--- a/test/adopt/adopt-actions.test.tsx
+++ b/test/adopt/adopt-actions.test.tsx
@@ -2,9 +2,10 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { AdoptPrompt, CopyScriptButton } from '@/adopt/adopt-actions'
+import { AdoptPrompt } from '@/adopt/adopt-actions'
 import { buildClaudePrompt } from '@/adopt/install'
 import { useRecordedCopy } from '@/adopt/use-recorded-copy'
+import { HighlightedCode } from '@/ui/highlighted-code'
 
 const recordCopyFn = vi.hoisted(() => vi.fn())
 vi.mock('@/adopt/functions', () => ({ recordCopyFn }))
@@ -27,6 +28,8 @@ const props = {
   copyCount: 5,
 }
 
+const SOURCE_HTML = '<pre class="shiki"><code>echo hi</code></pre>'
+
 // The prompt button's accessible name is its (stable) aria-label, which keeps the
 // visible "Copy install prompt" text inside it (WCAG label-in-name).
 const promptButton = () =>
@@ -42,7 +45,12 @@ function SharedCopyActions() {
         title={props.title}
         controller={controller}
       />
-      <CopyScriptButton source={props.source} controller={controller} />
+      <HighlightedCode
+        html={SOURCE_HTML}
+        text={props.source}
+        copyLabel="Copy script"
+        onCopied={() => controller.record('script')}
+      />
     </>
   )
 }
@@ -57,11 +65,6 @@ function PromptHarness() {
       controller={controller}
     />
   )
-}
-
-function ScriptHarness() {
-  const controller = useRecordedCopy(props.configId, props.copyCount)
-  return <CopyScriptButton source={props.source} controller={controller} />
 }
 
 beforeEach(() => {
@@ -80,7 +83,7 @@ afterEach(() => {
 })
 
 describe('AdoptPrompt', () => {
-  it('shares one reconciled count across both copy actions', async () => {
+  it('shares one reconciled count across prompt and source-overlay copy', async () => {
     let resolveScriptCopy!: (count: number) => void
     const scriptCopy = new Promise<number>((resolve) => {
       resolveScriptCopy = resolve
@@ -153,9 +156,9 @@ describe('AdoptPrompt', () => {
   })
 })
 
-describe('CopyScriptButton', () => {
-  it('copies the raw source and records the copy', async () => {
-    render(<ScriptHarness />)
+describe('config source overlay', () => {
+  it('copies the raw source and records kind script, without a prompt toast', async () => {
+    render(<SharedCopyActions />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Copy script' }))
 
@@ -165,33 +168,6 @@ describe('CopyScriptButton', () => {
         data: { configId: 'cfg-1', kind: 'script', distinctId: 'did-test', sessionId: 'sid-test' },
       }),
     )
-    // Must NOT fire a prompt toast.
     expect(toast).not.toHaveBeenCalled()
-  })
-
-  it('stays the outline variant during the "Copied!" swap (no variant flash)', async () => {
-    render(<ScriptHarness />)
-    const button = screen.getByRole('button')
-    // Outline at rest: background-only, no coral fill.
-    expect(button.className).toContain('bg-background')
-    expect(button.className).not.toContain('bg-primary')
-
-    fireEvent.click(button)
-
-    await waitFor(() => expect(screen.getByText('Copied!')).toBeTruthy())
-    // Still outline while "Copied!" shows — same element, no variant flash.
-    expect(button.className).toContain('bg-background')
-    expect(button.className).not.toContain('bg-primary')
-  })
-
-  it('does not show "Copied!" or record when the clipboard rejects', async () => {
-    writeText.mockRejectedValue(new Error('denied'))
-    render(<ScriptHarness />)
-
-    fireEvent.click(screen.getByRole('button', { name: 'Copy script' }))
-
-    await waitFor(() => expect(writeText).toHaveBeenCalled())
-    expect(screen.queryByText('Copied!')).toBeNull()
-    expect(recordCopyFn).not.toHaveBeenCalled()
   })
 })

--- a/test/adopt/use-recorded-copy.test.tsx
+++ b/test/adopt/use-recorded-copy.test.tsx
@@ -11,8 +11,6 @@ vi.mock('@posthog/react', () => ({
   usePostHog: () => ({ get_distinct_id: () => 'did-test', get_session_id: () => 'sid-test' }),
 }))
 
-const writeText = vi.fn<(text: string) => Promise<void>>()
-
 function deferred<T>() {
   let resolve!: (value: T) => void
   const promise = new Promise<T>((resolvePromise) => {
@@ -22,22 +20,16 @@ function deferred<T>() {
 }
 
 beforeEach(() => {
-  writeText.mockReset().mockResolvedValue(undefined)
   recordCopyFn.mockReset().mockResolvedValue(6)
-  Object.defineProperty(navigator, 'clipboard', {
-    value: { writeText },
-    configurable: true,
-    writable: true,
-  })
 })
 
 describe('useRecordedCopy', () => {
-  it('optimistically bumps the count on copy', async () => {
+  it('optimistically bumps the count on record', async () => {
     const { result } = renderHook(() => useRecordedCopy('cfg-1', 5))
     expect(result.current.count).toBe(5)
 
     await act(async () => {
-      result.current.copy('text', 'prompt', () => {})
+      await result.current.record('prompt')
     })
 
     await waitFor(() => expect(result.current.count).toBe(6))
@@ -48,7 +40,7 @@ describe('useRecordedCopy', () => {
     const { result } = renderHook(() => useRecordedCopy('cfg-1', 5))
 
     await act(async () => {
-      result.current.copy('text', 'prompt', () => {})
+      await result.current.record('prompt')
     })
 
     await waitFor(() => expect(result.current.count).toBe(42))
@@ -59,7 +51,7 @@ describe('useRecordedCopy', () => {
     const { result } = renderHook(() => useRecordedCopy('cfg-1', 5))
 
     await act(async () => {
-      result.current.copy('text', 'prompt', () => {})
+      await result.current.record('prompt')
     })
 
     // Optimistic count (5 -> 6) must hold; a 0 from the server is ignored.
@@ -67,17 +59,15 @@ describe('useRecordedCopy', () => {
     await waitFor(() => expect(result.current.count).toBe(6))
   })
 
-  it('keeps clipboard success and the optimistic count when recording rejects', async () => {
+  it('keeps the optimistic count when recording rejects', async () => {
     recordCopyFn.mockRejectedValue(new Error('offline'))
-    const onCopied = vi.fn()
     const { result } = renderHook(() => useRecordedCopy('cfg-1', 5))
 
     await act(async () => {
-      result.current.copy('text', 'prompt', onCopied)
+      await result.current.record('prompt')
     })
 
     await waitFor(() => expect(recordCopyFn).toHaveBeenCalled())
-    expect(onCopied).toHaveBeenCalledOnce()
     expect(result.current.count).toBe(6)
   })
 
@@ -88,8 +78,8 @@ describe('useRecordedCopy', () => {
     const { result } = renderHook(() => useRecordedCopy('cfg-1', 5))
 
     act(() => {
-      result.current.copy('prompt', 'prompt', () => {})
-      result.current.copy('script', 'script', () => {})
+      void result.current.record('prompt')
+      void result.current.record('script')
     })
     await waitFor(() => expect(recordCopyFn).toHaveBeenCalledTimes(2))
     await waitFor(() => expect(result.current.count).toBe(7))
@@ -108,8 +98,8 @@ describe('useRecordedCopy', () => {
     const { result } = renderHook(() => useRecordedCopy('cfg-1', 5))
 
     act(() => {
-      result.current.copy('prompt', 'prompt', () => {})
-      result.current.copy('script', 'script', () => {})
+      void result.current.record('prompt')
+      void result.current.record('script')
     })
     await waitFor(() => expect(recordCopyFn).toHaveBeenCalledTimes(2))
 
@@ -125,7 +115,9 @@ describe('useRecordedCopy', () => {
     recordCopyFn.mockReturnValueOnce(response.promise)
     const { result } = renderHook(() => useRecordedCopy('cfg-1', 5))
 
-    act(() => result.current.copy('text', 'prompt', () => {}))
+    act(() => {
+      void result.current.record('prompt')
+    })
     await waitFor(() => expect(result.current.count).toBe(6))
 
     await act(async () => response.resolve(5))
@@ -140,7 +132,9 @@ describe('useRecordedCopy', () => {
       { initialProps: { configId: 'cfg-1', count: 5 } },
     )
 
-    act(() => result.current.copy('text', 'prompt', () => {}))
+    act(() => {
+      void result.current.record('prompt')
+    })
     await waitFor(() => expect(recordCopyFn).toHaveBeenCalledOnce())
 
     rerender({ configId: 'cfg-2', count: 2 })
@@ -148,18 +142,5 @@ describe('useRecordedCopy', () => {
 
     await act(async () => oldResponse.resolve(10))
     expect(result.current.count).toBe(2)
-  })
-
-  it('does not bump the count when the clipboard rejects', async () => {
-    writeText.mockRejectedValue(new Error('denied'))
-    const { result } = renderHook(() => useRecordedCopy('cfg-1', 5))
-
-    await act(async () => {
-      result.current.copy('text', 'prompt', () => {})
-    })
-
-    await waitFor(() => expect(writeText).toHaveBeenCalled())
-    expect(recordCopyFn).not.toHaveBeenCalled()
-    expect(result.current.count).toBe(5)
   })
 })

--- a/test/guide/examples.test.ts
+++ b/test/guide/examples.test.ts
@@ -1,0 +1,55 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  MINIMAL_SCRIPT,
+  MINIMAL_SCRIPT_OUTPUT,
+  SAMPLE_STDIN_JSON,
+  SETTINGS_SNIPPET,
+} from '@/guide/examples'
+import { SCENARIOS } from '@/render/scenarios'
+
+const hasJq = spawnSync('jq', ['--version']).status === 0
+
+function runScript(stdin: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'guide-example-'))
+  const path = join(dir, 'statusline.sh')
+  writeFileSync(path, MINIMAL_SCRIPT)
+  const result = spawnSync('bash', [path], { input: stdin, encoding: 'utf8' })
+  expect(result.status).toBe(0)
+  return result.stdout.trim()
+}
+
+describe('guide examples', () => {
+  it('sample stdin is the real clean-main scenario payload (full schema, resolved resets)', () => {
+    const parsed = JSON.parse(SAMPLE_STDIN_JSON) as Record<string, unknown>
+    const cleanMain = SCENARIOS.find((s) => s.key === 'clean-main')
+    if (!cleanMain) throw new Error('clean-main scenario missing')
+    expect(Object.keys(parsed).sort()).toEqual(Object.keys(cleanMain.stdin).sort())
+    const rl = parsed.rate_limits as { five_hour: { resets_at: number } }
+    expect(rl.five_hour.resets_at).toBeGreaterThan(1_700_000_000)
+  })
+
+  it('settings snippet is valid JSON with the documented statusLine shape', () => {
+    const parsed = JSON.parse(SETTINGS_SNIPPET) as {
+      statusLine: { type: string; command: string }
+    }
+    expect(parsed.statusLine.type).toBe('command')
+    expect(parsed.statusLine.command).toBe('~/.claude/statusline.sh')
+  })
+
+  it.skipIf(!hasJq)(
+    'the example script produces the documented output for the sample payload',
+    () => {
+      expect(runScript(SAMPLE_STDIN_JSON)).toBe(MINIMAL_SCRIPT_OUTPUT)
+    },
+  )
+
+  it.skipIf(!hasJq)('the example script survives a fresh session (null used_percentage)', () => {
+    const fresh = SCENARIOS.find((s) => s.key === 'fresh-session')
+    if (!fresh) throw new Error('fresh-session scenario missing')
+    expect(runScript(JSON.stringify(fresh.stdin))).toBe('[Opus 4.8] app · 0% context')
+  })
+})

--- a/test/guide/guide-content.test.tsx
+++ b/test/guide/guide-content.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ to, children, ...props }: { to: string; children: React.ReactNode }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+const { MINIMAL_SCRIPT, MINIMAL_SCRIPT_OUTPUT, SAMPLE_STDIN_JSON, SETTINGS_SNIPPET } = await import(
+  '@/guide/examples'
+)
+const { GuideContent } = await import('@/guide/guide-content')
+
+const esc = (s: string) =>
+  s.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+const pre = (s: string) => `<pre class="shiki"><code>${esc(s)}</code></pre>`
+const highlights = {
+  payloadHtml: pre(SAMPLE_STDIN_JSON),
+  scriptHtml: pre(MINIMAL_SCRIPT),
+  settingsHtml: pre(SETTINGS_SNIPPET),
+}
+
+describe('GuideContent', () => {
+  it('renders the h1 and all section headings', () => {
+    render(<GuideContent highlights={highlights} />)
+    expect(
+      screen.getByRole('heading', { level: 1, name: /how to set up a claude code status line/i }),
+    ).toBeTruthy()
+    for (const heading of [
+      /the fast paths/i,
+      /wire up a script by hand/i,
+      /two pitfalls/i,
+      /going further/i,
+    ]) {
+      expect(screen.getByRole('heading', { level: 2, name: heading })).toBeTruthy()
+    }
+    for (const heading of [/the json your script receives/i, /a minimal working script/i]) {
+      expect(screen.getByRole('heading', { level: 3, name: heading })).toBeTruthy()
+    }
+    expect(screen.queryByRole('heading', { level: 2, name: /the json/i })).toBeNull()
+  })
+
+  it('shows the example output once, next to the script, not in the intro', () => {
+    const { container } = render(<GuideContent highlights={highlights} />)
+    const page = container.textContent ?? ''
+    expect(page).not.toContain("That's the whole mechanism")
+    expect(page).not.toContain('What the script on this page prints')
+    const previews = [...container.querySelectorAll('code')].filter(
+      (el) => el.textContent === MINIMAL_SCRIPT_OUTPUT && !el.closest('.shiki'),
+    )
+    expect(previews).toHaveLength(1)
+    expect(previews[0]?.parentElement?.previousElementSibling?.textContent).toMatch(
+      /for the payload above it prints/i,
+    )
+  })
+
+  it('shows the real payload fields, the script, its output, and the settings snippet', () => {
+    const { container } = render(<GuideContent highlights={highlights} />)
+    const page = container.textContent ?? ''
+    for (const field of [
+      '"context_window"',
+      '"used_percentage"',
+      '"total_cost_usd"',
+      '"display_name"',
+      '"rate_limits"',
+      '"transcript_path"',
+    ]) {
+      expect(page).toContain(field)
+    }
+    expect(page).toContain('jq -r')
+    expect(page).toContain(MINIMAL_SCRIPT_OUTPUT)
+    expect(page).toContain('"statusLine"')
+  })
+
+  it('copies each code well from its overlay control', async () => {
+    const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    })
+    render(<GuideContent highlights={highlights} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy settings' }))
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(SETTINGS_SNIPPET))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy JSON' }))
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(SAMPLE_STDIN_JSON))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy script' }))
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(MINIMAL_SCRIPT))
+  })
+
+  it('keeps the gallery fast path a link inside a card, not a card that is a link', () => {
+    render(<GuideContent highlights={highlights} />)
+    const heading = screen.getByRole('heading', { name: /copy from the gallery/i })
+    expect(heading.querySelector('a')).toBeNull()
+    expect(screen.getByRole('link', { name: /browse the gallery/i })).toBeTruthy()
+  })
+
+  it('links to the gallery, resources, submit, and the official docs', () => {
+    const { container } = render(<GuideContent highlights={highlights} />)
+    for (const href of ['/', '/resources', '/submit']) {
+      expect(container.querySelector(`a[href="${href}"]`)).not.toBeNull()
+    }
+    expect(
+      container.querySelector('a[href="https://code.claude.com/docs/en/statusline"]'),
+    ).not.toBeNull()
+  })
+})

--- a/test/lib/json-ld.test.ts
+++ b/test/lib/json-ld.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest'
-import { configJsonLd, facetJsonLd, homeJsonLd, jsonLdScript, resourcesJsonLd } from '@/lib/json-ld'
+import {
+  configJsonLd,
+  facetJsonLd,
+  guideJsonLd,
+  homeJsonLd,
+  jsonLdScript,
+  resourcesJsonLd,
+} from '@/lib/json-ld'
+import { GUIDE_DESCRIPTION, GUIDE_TITLE_BASE } from '@/lib/page-title'
 
 describe('jsonLdScript', () => {
   it('serializes to an application/ld+json script descriptor', () => {
@@ -35,7 +43,7 @@ describe('homeJsonLd', () => {
     expect(nodes[1]).toEqual({
       '@context': 'https://schema.org',
       '@type': 'CollectionPage',
-      name: 'Claude Code Status Line Examples',
+      name: 'Claude Code Status Lines',
       url: 'https://statuslin.es',
       mainEntity: {
         '@type': 'ItemList',
@@ -73,7 +81,7 @@ describe('homeJsonLd', () => {
     })
     expect(nodes[1]).toMatchObject({
       '@type': 'CollectionPage',
-      name: 'Claude Code Status Line Examples — Page 2',
+      name: 'Claude Code Status Lines — Page 2',
       url: 'https://statuslin.es/?page=2',
       mainEntity: {
         itemListElement: [{ position: 11 }, { position: 12 }],
@@ -209,6 +217,35 @@ describe('configJsonLd', () => {
     const questions = faq!.mainEntity as Array<{ name: string }>
     expect(questions).toHaveLength(1)
     expect(questions[0]!.name).toBe('What does Powerline Dracula show?')
+  })
+})
+
+describe('guideJsonLd', () => {
+  it('emits TechArticle plus a breadcrumb trail, never HowTo', () => {
+    const nodes = guideJsonLd('https://statuslin.es', GUIDE_DESCRIPTION) as Array<
+      Record<string, unknown>
+    >
+    expect(nodes.some((node) => node['@type'] === 'HowTo')).toBe(false)
+    expect(nodes[0]).toEqual({
+      '@context': 'https://schema.org',
+      '@type': 'TechArticle',
+      headline: GUIDE_TITLE_BASE,
+      url: 'https://statuslin.es/guide',
+      description: GUIDE_DESCRIPTION,
+    })
+    expect(nodes[1]).toEqual({
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Status lines', item: 'https://statuslin.es' },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: GUIDE_TITLE_BASE,
+          item: 'https://statuslin.es/guide',
+        },
+      ],
+    })
   })
 })
 

--- a/test/lib/llms.test.ts
+++ b/test/lib/llms.test.ts
@@ -21,6 +21,7 @@ describe('buildLlmsTxt', () => {
     expect(txt).toContain('(https://statuslin.es/)') // gallery home
     expect(txt).toMatch(/sorted by trending, newest, or most copied/i)
     expect(txt).toContain('(https://statuslin.es/submit)')
+    expect(txt).toContain('(https://statuslin.es/guide)')
     expect(txt).toContain('(https://statuslin.es/resources)')
   })
 

--- a/test/lib/page-title.test.ts
+++ b/test/lib/page-title.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   configMetaDescription,
   configPageTitle,
+  GUIDE_DESCRIPTION,
+  GUIDE_TITLE_BASE,
   HOME_TITLE_BASE,
   NOT_FOUND_TITLE,
   RESOURCES_TITLE_BASE,
@@ -29,7 +31,7 @@ describe('configPageTitle', () => {
   })
 
   it('exposes the home title base for the title tag and JSON-LD to share', () => {
-    expect(HOME_TITLE_BASE).toBe('Claude Code Status Line Examples')
+    expect(HOME_TITLE_BASE).toBe('Claude Code Status Lines')
   })
 
   it('keeps the rendered home title inside the length Google shows', () => {
@@ -40,6 +42,8 @@ describe('configPageTitle', () => {
 describe('static page titles', () => {
   it('state the target keyword', () => {
     expect(RESOURCES_TITLE_BASE).toBe('Claude Code Status Line Tools & Resources')
+    expect(GUIDE_TITLE_BASE).toBe('How to Set Up a Claude Code Status Line')
+    expect(GUIDE_DESCRIPTION).toMatch(/tested example you can copy/)
   })
 })
 

--- a/test/lib/sitemap.test.ts
+++ b/test/lib/sitemap.test.ts
@@ -27,9 +27,10 @@ describe('sitemapResponse', () => {
     expect(xml).toContain('</urlset>')
   })
 
-  it('includes the static home, resources, submit, and terms pages', async () => {
+  it('includes the static home, guide, resources, submit, and terms pages', async () => {
     const xml = await sitemapResponse(BASE, [], []).text()
     expect(xml).toContain(`<loc>${BASE}</loc>`)
+    expect(xml).toContain(`<loc>${BASE}/guide</loc>`)
     expect(xml).toContain(`<loc>${BASE}/resources</loc>`)
     expect(xml).toContain(`<loc>${BASE}/submit</loc>`)
     expect(xml).toContain(`<loc>${BASE}/terms</loc>`)
@@ -59,7 +60,7 @@ describe('sitemapResponse', () => {
     const xml = await sitemapResponse(BASE, configs, []).text()
 
     expect(entryFor(xml, BASE)).toContain('<lastmod>2026-05-06</lastmod>')
-    for (const path of ['/resources', '/submit', '/terms']) {
+    for (const path of ['/guide', '/resources', '/submit', '/terms']) {
       expect(entryFor(xml, `${BASE}${path}`)).not.toContain('<lastmod>')
     }
   })

--- a/test/resources/resources-content.test.tsx
+++ b/test/resources/resources-content.test.tsx
@@ -1,14 +1,31 @@
 // @vitest-environment jsdom
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
+import { RESOURCES_TITLE_BASE } from '@/lib/page-title'
 
-// ResourcesContent's internal links use TanStack Router's <Link>; stub it to a plain anchor.
 vi.mock('@tanstack/react-router', () => ({
-  Link: ({ to, children, ...props }: { to: string; children: React.ReactNode }) => (
-    <a href={to} {...props}>
-      {children}
-    </a>
-  ),
+  Link: ({
+    to,
+    params,
+    children,
+    ...props
+  }: {
+    to: string
+    params?: Record<string, string>
+    children: React.ReactNode
+  }) => {
+    let href = to
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        href = href.replace(`$${key}`, value)
+      }
+    }
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    )
+  },
 }))
 
 const { RESOURCE_SECTIONS } = await import('@/resources/data')
@@ -22,6 +39,7 @@ describe('ResourcesContent', () => {
     expect(
       screen.getByRole('heading', { level: 1, name: /claude code status line tools & resources/i }),
     ).toBeTruthy()
+    expect(RESOURCES_TITLE_BASE).toBe('Claude Code Status Line Tools & Resources')
     for (const section of RESOURCE_SECTIONS) {
       expect(screen.getByRole('heading', { level: 2, name: section.title })).toBeTruthy()
     }
@@ -43,13 +61,29 @@ describe('ResourcesContent', () => {
     expect(screen.getAllByText('GitHub').length).toBeGreaterThanOrEqual(1)
   })
 
-  it('cross-links the gallery, and shows the submit button when signed out', () => {
+  it('cross-links the gallery, guide, and submit, and shows the submit button when signed out', () => {
     const { container } = render(<ResourcesContent signedIn={false} />)
-    for (const href of ['/', '/submit']) {
+    for (const href of ['/', '/guide', '/submit']) {
       expect(container.querySelector(`a[href="${href}"]`)).not.toBeNull()
     }
     expect(screen.getByRole('heading', { level: 2, name: /get listed/i })).toBeTruthy()
     expect(screen.getByText('Submit a status line')).toBeTruthy()
+  })
+
+  it('compares four setup paths without FAQPage schema', () => {
+    const { container } = render(<ResourcesContent signedIn={false} />)
+    expect(
+      screen.getByRole('heading', { level: 2, name: /four ways to get a status line/i }),
+    ).toBeTruthy()
+    expect(container.innerHTML).not.toMatch(/FAQPage/)
+  })
+
+  it('links only indexable gallery targets, not the thin powerline facet', () => {
+    const { container } = render(<ResourcesContent signedIn={false} />)
+    expect(container.querySelector('a[href="/c/powerline-dracula-6936b97c"]')).not.toBeNull()
+    expect(container.querySelector('a[href="/status-lines/token-usage"]')).not.toBeNull()
+    expect(container.querySelector('a[href="/c/quota-fallback-2a730aa6"]')).not.toBeNull()
+    expect(container.querySelector('a[href="/status-lines/powerline"]')).toBeNull()
   })
 
   it('links to /submit when signed in', () => {

--- a/test/routes/guide-redirect.test.ts
+++ b/test/routes/guide-redirect.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment node
 import { createMemoryHistory } from '@tanstack/react-router'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { GUIDE_DESCRIPTION, GUIDE_TITLE_BASE } from '@/lib/page-title'
+import { Route as GuideRoute } from '@/routes/guide'
 
 vi.mock('@/lib/analytics-config', () => ({
   getAnalyticsToken: vi.fn().mockResolvedValue(null),
@@ -8,11 +10,23 @@ vi.mock('@/lib/analytics-config', () => ({
 vi.mock('@/lib/auth-functions', () => ({
   getSession: vi.fn().mockResolvedValue(null),
 }))
+vi.mock('@/guide/functions', () => ({
+  getGuideHighlights: vi.fn().mockResolvedValue({
+    payloadHtml: '<pre></pre>',
+    scriptHtml: '<pre></pre>',
+    settingsHtml: '<pre></pre>',
+  }),
+}))
 
 const { getRouter } = await import('@/router')
 
-describe('/guide redirect', () => {
-  it('loads through the real router as a permanent redirect to /resources', async () => {
+const ORIGINAL = process.env.BETTER_AUTH_URL
+afterEach(() => {
+  process.env.BETTER_AUTH_URL = ORIGINAL
+})
+
+describe('/guide page', () => {
+  it('loads through the real router as a self-canonical 200, not a redirect', async () => {
     const router = getRouter()
     router.update({
       history: createMemoryHistory({ initialEntries: ['/guide'] }),
@@ -20,7 +34,50 @@ describe('/guide redirect', () => {
 
     await router.load()
 
-    expect(router.stores.statusCode.get()).toBe(301)
-    expect(router.stores.redirect.get()?.headers.get('Location')).toBe('/resources')
+    expect(router.stores.statusCode.get()).not.toBe(301)
+    expect(router.stores.redirect.get()).toBeFalsy()
+    expect(router.state.location.pathname).toBe('/guide')
+  })
+
+  it('emits unique title, description, canonical, and social meta', async () => {
+    process.env.BETTER_AUTH_URL = 'https://statuslin.es'
+    const head = await GuideRoute.options.head?.({} as never)
+
+    expect(head?.meta).toEqual(
+      expect.arrayContaining([
+        { title: `${GUIDE_TITLE_BASE} | statuslin.es` },
+        { name: 'description', content: GUIDE_DESCRIPTION },
+        { property: 'og:url', content: 'https://statuslin.es/guide' },
+        { property: 'og:title', content: GUIDE_TITLE_BASE },
+        { property: 'og:description', content: GUIDE_DESCRIPTION },
+      ]),
+    )
+    expect(head?.links).toContainEqual({
+      rel: 'canonical',
+      href: 'https://statuslin.es/guide',
+    })
+  })
+
+  it('emits TechArticle and BreadcrumbList JSON-LD, never HowTo', async () => {
+    process.env.BETTER_AUTH_URL = 'https://statuslin.es'
+    const head = await GuideRoute.options.head?.({} as never)
+    const nodes = ((head?.scripts ?? []) as Array<{ children: string }>).map(
+      (script) => JSON.parse(script.children) as Record<string, unknown>,
+    )
+
+    expect(nodes.some((node) => node['@type'] === 'HowTo')).toBe(false)
+    expect(nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          '@type': 'TechArticle',
+          headline: GUIDE_TITLE_BASE,
+          url: 'https://statuslin.es/guide',
+          description: GUIDE_DESCRIPTION,
+        }),
+        expect.objectContaining({
+          '@type': 'BreadcrumbList',
+        }),
+      ]),
+    )
   })
 })

--- a/test/routes/home-content.test.tsx
+++ b/test/routes/home-content.test.tsx
@@ -3,9 +3,18 @@ import { render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
-vi.mock('@posthog/react', () => ({
-  usePostHog: () => ({ capture: vi.fn() }),
-}))
+vi.mock('@tanstack/react-router', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-router')>('@tanstack/react-router')
+  return {
+    ...actual,
+    Link: ({ to, children, ...props }: { to: string; children: React.ReactNode }) => (
+      <a href={to} {...props}>
+        {children}
+      </a>
+    ),
+  }
+})
 vi.mock('@/ui/shell', () => ({
   PageShell: ({ children }: { children: ReactNode }) => <>{children}</>,
 }))
@@ -19,7 +28,7 @@ vi.mock('@/ui/submit-cta', () => ({
 const { Route: HomeRoute } = await import('@/routes/index')
 
 describe('home content', () => {
-  it('explains the community gallery and its real-script ready-to-copy examples', () => {
+  it('explains the community gallery of real submitted status lines', () => {
     vi.spyOn(HomeRoute, 'useLoaderData').mockReturnValue({
       user: null,
       gallery: {
@@ -35,8 +44,10 @@ describe('home content', () => {
     render(Home ? <Home /> : null)
 
     const intro = screen.getByText(/community gallery/i)
-    expect(intro.textContent).toMatch(/Claude Code status line examples/)
-    expect(intro.textContent).toMatch(/ready-to-copy templates/)
+    expect(intro.textContent).toMatch(/Claude Code status lines/)
+    expect(intro.textContent).not.toMatch(/examples/)
+    expect(intro.textContent).not.toMatch(/templates/)
     expect(intro.textContent).toMatch(/previews rendered from the real script/)
+    expect(intro.querySelector('a[href="/guide"]')).not.toBeNull()
   })
 })

--- a/test/routes/home-meta.test.ts
+++ b/test/routes/home-meta.test.ts
@@ -21,11 +21,11 @@ describe('home search indexing metadata', () => {
 
     expect(head?.meta).toEqual(
       expect.arrayContaining([
-        { title: 'Claude Code Status Line Examples | statuslin.es' },
+        { title: 'Claude Code Status Lines | statuslin.es' },
         {
           name: 'description',
           content:
-            'Browse a gallery of Claude Code status line examples and ready-to-copy templates. See real rendered previews and copy one in a single paste.',
+            'Browse a community gallery of Claude Code status lines. See real rendered previews and copy one in a single paste.',
         },
       ]),
     )
@@ -46,11 +46,11 @@ describe('home search indexing metadata', () => {
 
     expect(head?.meta).toEqual(
       expect.arrayContaining([
-        { title: 'Claude Code Status Line Examples — Page 2 | statuslin.es' },
+        { title: 'Claude Code Status Lines — Page 2 | statuslin.es' },
         {
           name: 'description',
           content:
-            'Browse a gallery of Claude Code status line examples and ready-to-copy templates. See real rendered previews and copy one in a single paste. Page 2 of 3.',
+            'Browse a community gallery of Claude Code status lines. See real rendered previews and copy one in a single paste. Page 2 of 3.',
         },
       ]),
     )
@@ -64,7 +64,7 @@ describe('home search indexing metadata', () => {
       .map((script) => JSON.parse(script.children) as Record<string, unknown>)
       .find((node) => node['@type'] === 'CollectionPage')
     expect(collectionPage).toMatchObject({
-      name: 'Claude Code Status Line Examples — Page 2',
+      name: 'Claude Code Status Lines — Page 2',
       url: 'https://statuslin.es/?page=2',
     })
   })

--- a/test/scripts/smoke.test.ts
+++ b/test/scripts/smoke.test.ts
@@ -19,11 +19,11 @@ describe('browserCommandOutput', () => {
   it('keeps successful structured stdout separate from informational stderr', () => {
     expect(
       browserCommandOutput(
-        '"{\\"title\\":\\"Claude Code Status Line Examples | statuslin.es\\"}"\n',
+        '"{\\"title\\":\\"Claude Code Status Lines | statuslin.es\\"}"\n',
         '[agent-browser] restore: loaded; save: saved\n',
         0,
       ),
-    ).toBe('"{\\"title\\":\\"Claude Code Status Line Examples | statuslin.es\\"}"')
+    ).toBe('"{\\"title\\":\\"Claude Code Status Lines | statuslin.es\\"}"')
   })
 
   it('reports stderr when agent-browser exits unsuccessfully', () => {

--- a/test/ui/app-header.test.tsx
+++ b/test/ui/app-header.test.tsx
@@ -67,6 +67,13 @@ describe('AppHeader', () => {
     expect(container.querySelector('a[href="/resources"]')).not.toBeNull()
   })
 
+  it('links to the guide page when signed out', () => {
+    const { container } = render(<AppHeader user={null} />)
+    const guide = container.querySelector('a[href="/guide"]') as HTMLAnchorElement
+    expect(guide).not.toBeNull()
+    expect(guide.textContent).toMatch(/guide/i)
+  })
+
   it('links to the resources page when signed in', () => {
     const { container } = render(
       <AppHeader user={{ name: 'Ada Lovelace', username: 'ada', image: null, role: 'user' }} />,

--- a/test/ui/copy-button.test.tsx
+++ b/test/ui/copy-button.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CopyButton } from '@/ui/copy-button'
+
+const writeText = vi.fn<(text: string) => Promise<void>>()
+
+beforeEach(() => {
+  writeText.mockReset().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('CopyButton', () => {
+  it('copies the given text and swaps the label to Copied!', async () => {
+    render(<CopyButton text="echo hi" label="Copy script" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy script' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('echo hi'))
+    expect(screen.getByRole('button', { name: 'Copied!' })).toBeTruthy()
+  })
+
+  it('calls onCopied only after a successful clipboard write', async () => {
+    const onCopied = vi.fn()
+    render(<CopyButton text="payload" onCopied={onCopied} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
+
+    await waitFor(() => expect(onCopied).toHaveBeenCalledOnce())
+  })
+
+  it('does not show Copied! or call onCopied when the clipboard rejects', async () => {
+    writeText.mockRejectedValue(new Error('denied'))
+    const onCopied = vi.fn()
+    render(<CopyButton text="payload" label="Copy JSON" onCopied={onCopied} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy JSON' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalled())
+    expect(screen.queryByRole('button', { name: 'Copied!' })).toBeNull()
+    expect(onCopied).not.toHaveBeenCalled()
+  })
+
+  it('stays outline while Copied! shows', async () => {
+    render(<CopyButton text="x" variant="outline" />)
+    const button = screen.getByRole('button', { name: 'Copy' })
+    expect(button.className).toContain('bg-background')
+    expect(button.className).not.toContain('bg-primary')
+
+    fireEvent.click(button)
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Copied!' })).toBeTruthy())
+    expect(button.className).toContain('bg-background')
+    expect(button.className).not.toContain('bg-primary')
+  })
+})

--- a/test/ui/highlighted-code.test.tsx
+++ b/test/ui/highlighted-code.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { HighlightedCode } from '@/ui/highlighted-code'
+
+const writeText = vi.fn<(text: string) => Promise<void>>()
+
+beforeEach(() => {
+  writeText.mockReset().mockResolvedValue(undefined)
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+    writable: true,
+  })
+})
+
+const html = '<pre class="shiki"><code>echo hi</code></pre>'
+
+describe('HighlightedCode', () => {
+  it('renders the highlighted markup without a copy control when text is omitted', () => {
+    const { container } = render(<HighlightedCode html={html} />)
+    expect(container.querySelector('.shiki')?.textContent).toBe('echo hi')
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('copies the raw text from the overlay control', async () => {
+    render(<HighlightedCode html={html} text="echo hi" copyLabel="Copy script" />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy script' }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('echo hi'))
+  })
+})

--- a/test/ui/home-hero.test.tsx
+++ b/test/ui/home-hero.test.tsx
@@ -18,7 +18,7 @@ describe('HomeHero', () => {
     const h1s = container.querySelectorAll('h1')
     expect(h1s).toHaveLength(1)
     // Exact text, not toContain: JSX drops whitespace between sibling elements, so without an
-    // explicit separator this reads "statuslin.esClaude Code status line examples" to anything that
+    // explicit separator this reads "statuslin.esClaude Code status lines" to anything that
     // walks text nodes — a screen reader announcing the heading, or a crawler.
     expect(h1s[0]?.textContent).toBe(`statuslin.es ${HOME_HEADING_BASE}`)
   })
@@ -40,7 +40,7 @@ describe('HomeHero', () => {
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: 'statuslin.es Claude Code status line examples — Page 2',
+        name: 'statuslin.es Claude Code status lines — Page 2',
       }),
     ).toBeTruthy()
   })

--- a/test/ui/section-card.test.tsx
+++ b/test/ui/section-card.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 
 import { CodeBlock } from '@/ui/code-block'
 import { SectionCard } from '@/ui/section-card'
@@ -52,5 +52,17 @@ describe('CodeBlock', () => {
     const pre = container.querySelector('pre') as HTMLElement
     expect(pre.className).toContain('p-3')
     expect(pre.className).toContain('mt-2')
+  })
+
+  it('copies the source when text is provided', async () => {
+    const writeText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    })
+    render(<CodeBlock text="echo hi">echo hi</CodeBlock>)
+    fireEvent.click(screen.getByRole('button', { name: 'Copy' }))
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('echo hi'))
   })
 })

--- a/test/ui/site-footer.test.tsx
+++ b/test/ui/site-footer.test.tsx
@@ -51,4 +51,11 @@ describe('SiteFooter', () => {
     expect(resources).not.toBeNull()
     expect(resources.textContent).toMatch(/resources/i)
   })
+
+  it('links to the guide page', () => {
+    const { container } = render(<SiteFooter />)
+    const guide = container.querySelector('a[href="/guide"]') as HTMLAnchorElement
+    expect(guide).not.toBeNull()
+    expect(guide.textContent).toMatch(/guide/i)
+  })
 })


### PR DESCRIPTION
## Summary
- Restore `/guide` as a 200 with a unique title, canonical, and TechArticle + BreadcrumbList JSON-LD, instead of redirecting away.
- Add Guide to the sitemap, `llms.txt`, header, footer, and home intro so the setup page can be discovered and crawled.
- Drop “examples” / “templates” from the home title and copy: gallery configs are status lines you copy, not samples.

## Changes
- `/guide` body: fast paths as non-interactive cards, one “wire up a script by hand” section, scenario-derived stdin JSON, a tested minimal script, pitfalls as notices.
- `/resources`: deeper intro and a four-path comparison with links into the gallery (`Powerline Dracula`, token-usage facet, `Quota Fallback`).
- Shared `CopyButton` / `Copyable` overlay on guide wells, config source, and the install prompt.
- Home title is now **Claude Code Status Lines**; smoke expects that string.

Dogfooded on https://staging.statuslin.es/. The four-path gallery links 404 there because those configs are not in the staging DB; they 200 on production.