### PR TITLE
fix: reduce gallery memory pressure

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -108,7 +108,7 @@ push from*, never read by the servers.
 
 Staging and prod use **separate Fly config files** so each sizes its machines independently:
 
-- **`fly.toml`** — production (`app = "statuslines"`): web `shared-cpu-2x` / 1GB, worker
+- **`fly.toml`** — production (`app = "statuslines"`): web `shared-cpu-2x` / 2GB, worker
   `shared-cpu-1x` / 512MB (separate `[[vm]]` blocks — only web needs to absorb a launch spike),
   `min_machines_running = 1`. Add web headroom with `fly scale count web=N`.
 - **`fly.staging.toml`** — staging (`app = "statuslines-staging"`): `shared-cpu-1x` / 512MB,
@@ -122,8 +122,9 @@ Fly can't include one file from another, so `[build]`, `[processes]`, `[http_ser
 **Why two files instead of `fly scale vm`:** a `fly scale vm` / `fly scale memory` change is **reset
 on the next deploy** whenever a `[[vm]]` block is in the config. Prod ships by promoting the staging
 image, so that promote would shrink prod back every time — the size has to live in the config file.
-The sizing rationale: memory clears a measured OOM cliff; the lower `soft_limit` makes Fly add a
-machine before the box is in trouble.
+The sizing rationale: local repeated-wave profiling reproduced large transient SSR peaks before
+delayed collection. The 2GB allocation provides operational headroom; the lower `soft_limit` makes
+Fly add a machine before the box is in trouble.
 
 ## Deploying
 

--- a/fly.toml
+++ b/fly.toml
@@ -39,14 +39,13 @@ primary_region = "iad"
 [deploy]
   release_command = "bun run src/db/migrate.ts"
 
-# Per-process machine sizing. Only the public web server needs to absorb a launch spike, so
-# it gets shared-cpu-2x (≈2× the throughput of the 1x that collapsed at ~50 visits/s) and 1GB
-# (clears the measured OOM cliff: peak RSS 446MB of 512 under load). Add horizontal headroom
-# with `fly scale count web=N`. Numbers are starting points — tune against live metrics.
+# Per-process machine sizing. Repeated-wave profiling reproduced transient gallery SSR peaks with
+# delayed collection, so shared-cpu-2x and 2GB give the public web process operational headroom
+# while that allocation pressure is reduced. Add horizontal headroom with `fly scale count web=N`.
 [[vm]]
   processes = ["web"]
   size = "shared-cpu-2x"
-  memory = "1gb"
+  memory = "2gb"
 
 # The render worker just orchestrates E2B sandboxes (the heavy lifting runs in E2B, not here)
 # and submissions are rate-limited, so it stays at the small, already-proven size.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "seed:community": "bun run scripts/run-seed-community.ts",
     "generate:content": "bun run scripts/generate-content.ts",
     "profile:bench": "bun run scripts/profiling/bench-phases.ts",
+    "profile:memory": "PROFILE_MEMORY_HOST=127.0.0.1 bun run scripts/profiling/memory-loop.ts",
     "profile:server": "bun run scripts/profiling/profile-server.ts",
     "dev:login": "bun run scripts/dev-login.ts",
     "prepare": "simple-git-hooks"

--- a/scripts/profiling/memory-loop.ts
+++ b/scripts/profiling/memory-loop.ts
@@ -1,0 +1,474 @@
+import { spawn, spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { connect, createServer } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+type Workload = 'aborted' | 'assets' | 'gallery' | 'mixed' | 'og'
+type ProfileRuntime = 'bun' | 'node'
+
+interface ProbeSample {
+  elapsedMs: number
+  loopLagMs: number
+  rssMb: number
+  heapUsedMb: number
+  heapTotalMb: number
+  externalMb: number
+  arrayBuffersMb: number
+}
+
+interface LoadResult {
+  durationMs: number
+  p95Ms: number
+  responseBytes: number
+}
+
+type MemoryWaveInput = {
+  baselineRssMb: number
+  peakRssMb: number
+  maxGrowthMb: number
+  settledRssMb: number[]
+  maxPlateauGrowthMb: number
+  retentionGrowthMb: number
+}
+
+export function memoryWaveVerdict({
+  baselineRssMb,
+  peakRssMb,
+  settledRssMb,
+  maxGrowthMb,
+  maxPlateauGrowthMb,
+  retentionGrowthMb,
+}: MemoryWaveInput): {
+  peakGrowthMb: number
+  finalPlateauGrowthMb: number
+  ongoingRetention: boolean
+  passed: boolean
+} {
+  const peakGrowthMb = peakRssMb - baselineRssMb
+  const settledGrowthMb = settledRssMb.map(
+    (rss, index) => rss - (settledRssMb[index - 1] ?? baselineRssMb),
+  )
+  const finalPlateauGrowthMb = (settledRssMb.at(-1) ?? baselineRssMb) - baselineRssMb
+  const ongoingRetention = settledGrowthMb.some((growth, index) => {
+    const previousGrowth = settledGrowthMb[index - 1]
+    return (
+      previousGrowth !== undefined &&
+      growth >= retentionGrowthMb &&
+      previousGrowth >= retentionGrowthMb
+    )
+  })
+  return {
+    peakGrowthMb,
+    finalPlateauGrowthMb,
+    ongoingRetention,
+    passed:
+      !ongoingRetention &&
+      peakGrowthMb <= maxGrowthMb &&
+      finalPlateauGrowthMb <= maxPlateauGrowthMb,
+  }
+}
+
+export function parseProbeSamples(csv: string): ProbeSample[] {
+  return csv
+    .trim()
+    .split('\n')
+    .slice(1)
+    .flatMap((row) => {
+      const values = row.split(',')
+      const sample = {
+        elapsedMs: Number(values[1]),
+        loopLagMs: Number(values[2]),
+        rssMb: Number(values[3]),
+        heapUsedMb: Number(values[4]),
+        heapTotalMb: Number(values[5]),
+        externalMb: Number(values[6]),
+        arrayBuffersMb: Number(values[7]),
+      }
+      return Object.values(sample).every(Number.isFinite) ? [sample] : []
+    })
+}
+
+export const PROFILE_DEFAULTS = {
+  requests: 400,
+  waves: 3,
+  concurrency: 16,
+  maxGrowthMb: 120,
+  settleMs: 30_000,
+  maxPlateauGrowthMb: 20,
+  retentionGrowthMb: 30,
+} as const
+const MINIMUM_PROFILE_RUNTIME_MS = 30 * 60 * 1000
+const RESULTS = 'scripts/profiling/results'
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+function buildProductionApp(): void {
+  const result = spawnSync('bun', ['run', 'build'], { stdio: 'inherit' })
+  if (result.status !== 0) throw new Error('production build failed')
+  if (!existsSync('.output/server/index.mjs')) {
+    throw new Error('production build missing after bun run build')
+  }
+}
+
+async function availablePort(host: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer()
+    server.once('error', reject)
+    server.listen(0, host, () => {
+      const address = server.address()
+      if (address === null || typeof address === 'string') {
+        server.close()
+        reject(new Error('could not allocate a profiling port'))
+        return
+      }
+      server.close((error) => {
+        if (error) reject(error)
+        else resolve(address.port)
+      })
+    })
+  })
+}
+
+function argument(name: string, args: string[] = process.argv): string | undefined {
+  const prefix = `--${name}=`
+  return args.find((value) => value.startsWith(prefix))?.slice(prefix.length)
+}
+
+export function profileRuntimeArgument(args: string[]): ProfileRuntime {
+  const value = argument('runtime', args) ?? 'bun'
+  if (value === 'bun' || value === 'node') return value
+  throw new Error(`unknown runtime: ${value}`)
+}
+
+export function profileServerRuntimeFlags(args: string[]): string[] {
+  if (!args.includes('--smol')) return []
+  if (profileRuntimeArgument(args) !== 'bun') throw new Error('--smol requires --runtime=bun')
+  return ['--smol']
+}
+
+function preloadFlag(runtime: ProfileRuntime): '--import' | '--preload' {
+  return runtime === 'bun' ? '--preload' : '--import'
+}
+
+function positiveNumber(name: string, fallback: number, args: string[] = process.argv): number {
+  const raw = argument(name, args)
+  if (!raw) return fallback
+  const value = Number(raw)
+  if (!Number.isFinite(value) || value <= 0) throw new Error(`--${name} must be positive`)
+  return value
+}
+
+export function profilePlanArguments(args: string[]): {
+  requests: number
+  waves: number
+  settleMs: number
+} {
+  return {
+    requests: positiveNumber('requests', PROFILE_DEFAULTS.requests, args),
+    waves: positiveNumber('waves', PROFILE_DEFAULTS.waves, args),
+    settleMs: positiveNumber('settle-ms', PROFILE_DEFAULTS.settleMs, args),
+  }
+}
+
+export function profileMaximumRuntimeMs({
+  waves,
+  settleMs,
+}: {
+  waves: number
+  settleMs: number
+}): number {
+  return Math.max(MINIMUM_PROFILE_RUNTIME_MS, (waves + 1) * settleMs + 300_000)
+}
+
+function workloadArgument(): Workload {
+  const value = argument('workload') ?? 'mixed'
+  if (
+    value === 'aborted' ||
+    value === 'assets' ||
+    value === 'gallery' ||
+    value === 'mixed' ||
+    value === 'og'
+  ) {
+    return value
+  }
+  throw new Error(`unknown workload: ${value}`)
+}
+
+async function waitReady(base: string): Promise<string> {
+  for (let attempt = 0; attempt < 60; attempt++) {
+    try {
+      const response = await fetch(base)
+      if (response.ok) return await response.text()
+    } catch {
+      // Server is still starting.
+    }
+    await sleep(100)
+  }
+  throw new Error(`server never became ready at ${base}`)
+}
+
+function assetPaths(html: string): string[] {
+  return Array.from(html.matchAll(/(?:href|src)="(\/assets\/[^"?]+)"/g))
+    .flatMap((match) => (match[1] === undefined ? [] : [match[1]]))
+    .filter((path, index, paths) => paths.indexOf(path) === index)
+}
+
+async function consume(url: string): Promise<number> {
+  const response = await fetch(url)
+  if (!response.ok) throw new Error(`${response.status} from ${url}`)
+  return (await response.arrayBuffer()).byteLength
+}
+
+async function abortRequest(host: string, port: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const socket = connect({ host, port })
+    socket.once('error', reject)
+    socket.once('connect', () => {
+      socket.write(`GET / HTTP/1.1\r\nHost: ${host}:${port}\r\nConnection: close\r\n\r\n`)
+      setTimeout(() => {
+        socket.destroy()
+        resolve()
+      }, 2)
+    })
+  })
+}
+
+async function runConcurrent(
+  requests: number,
+  concurrency: number,
+  task: (index: number) => Promise<void>,
+): Promise<void> {
+  let next = 0
+  const worker = async () => {
+    while (next < requests) {
+      const index = next
+      next += 1
+      await task(index)
+    }
+  }
+  await Promise.all(Array.from({ length: concurrency }, worker))
+}
+
+function readProbeSamples(probePath: string): ProbeSample[] {
+  if (!existsSync(probePath)) return []
+  return parseProbeSamples(readFileSync(probePath, 'utf8'))
+}
+
+function latestSample(samples: ProbeSample[]): ProbeSample {
+  const sample = samples.at(-1)
+  if (!sample) throw new Error('memory probe produced no samples')
+  return sample
+}
+
+function peakSample(samples: ProbeSample[]): ProbeSample {
+  if (samples.length === 0) throw new Error('memory probe produced no samples during load wave')
+  return samples.reduce((peak, sample) => (sample.rssMb > peak.rssMb ? sample : peak))
+}
+
+function percentile95(samples: number[]): number {
+  const sorted = [...samples].sort((a, b) => a - b)
+  return sorted[Math.max(0, Math.ceil(sorted.length * 0.95) - 1)] ?? 0
+}
+
+async function runLoad(
+  base: string,
+  host: string,
+  port: number,
+  workload: Workload,
+  paths: string[],
+  requests: number,
+  concurrency: number,
+): Promise<LoadResult> {
+  const latencies: number[] = []
+  let responseBytes = 0
+  const startedAt = performance.now()
+  await runConcurrent(requests, concurrency, async (index) => {
+    const requestStartedAt = performance.now()
+    const bytes =
+      workload === 'aborted'
+        ? await abortRequest(host, port).then(() => 0)
+        : workload === 'og'
+          ? await consume(`${base}/og/home.png`)
+          : await consume(`${base}${paths[index % paths.length]}`)
+    latencies.push(performance.now() - requestStartedAt)
+    if (responseBytes === 0) responseBytes = bytes
+  })
+  return {
+    durationMs: Math.round(performance.now() - startedAt),
+    p95Ms: Math.round(percentile95(latencies)),
+    responseBytes,
+  }
+}
+
+interface ProfileWorkloadInput {
+  base: string
+  host: string
+  port: number
+  workload: Workload
+  requestedPath: string
+  requests: number
+  waves: number
+  concurrency: number
+  settleMs: number
+  probePath: string
+  maxGrowthMb: number
+  maxPlateauGrowthMb: number
+  retentionGrowthMb: number
+  runtime: ProfileRuntime
+  runtimeMode: 'default' | 'smol'
+}
+
+async function profileWorkload(input: ProfileWorkloadInput): Promise<boolean> {
+  const readinessUrl =
+    input.workload === 'assets' || input.workload === 'mixed'
+      ? input.base
+      : `${input.base}${input.requestedPath}`
+  const html = await waitReady(readinessUrl)
+  const assets = assetPaths(html)
+  if ((input.workload === 'assets' || input.workload === 'mixed') && assets.length === 0) {
+    throw new Error('gallery HTML contained no build assets')
+  }
+  const paths =
+    input.workload === 'gallery'
+      ? [input.requestedPath]
+      : input.workload === 'assets'
+        ? assets
+        : ['/', ...assets]
+  const warmup = await runLoad(
+    input.base,
+    input.host,
+    input.port,
+    input.workload,
+    paths,
+    input.requests,
+    input.concurrency,
+  )
+  await sleep(input.settleMs)
+  let samples = readProbeSamples(input.probePath)
+  const baseline = latestSample(samples)
+  console.log(
+    `[memory-loop] warmup requests=${input.requests} duration_ms=${warmup.durationMs} p95_ms=${warmup.p95Ms} response_bytes=${warmup.responseBytes} settled_rss_mb=${baseline.rssMb} settled_heap_used_mb=${baseline.heapUsedMb} settled_external_mb=${baseline.externalMb} settled_array_buffers_mb=${baseline.arrayBuffersMb}`,
+  )
+
+  const settledRssMb: number[] = []
+  const wavePeaks: ProbeSample[] = []
+  for (let wave = 1; wave <= input.waves; wave++) {
+    const sampleOffset = samples.length
+    const load = await runLoad(
+      input.base,
+      input.host,
+      input.port,
+      input.workload,
+      paths,
+      input.requests,
+      input.concurrency,
+    )
+    await sleep(input.settleMs)
+    samples = readProbeSamples(input.probePath)
+    const waveSamples = samples.slice(sampleOffset)
+    const peak = peakSample(waveSamples)
+    const settled = latestSample(waveSamples)
+    wavePeaks.push(peak)
+    settledRssMb.push(settled.rssMb)
+    console.log(
+      `[memory-loop] wave=${wave} requests=${input.requests} duration_ms=${load.durationMs} p95_ms=${load.p95Ms} response_bytes=${load.responseBytes} peak_rss_mb=${peak.rssMb} settled_rss_mb=${settled.rssMb} settled_heap_used_mb=${settled.heapUsedMb} settled_heap_total_mb=${settled.heapTotalMb} settled_external_mb=${settled.externalMb} settled_array_buffers_mb=${settled.arrayBuffersMb}`,
+    )
+  }
+
+  const observedPeakRssMb = Math.max(...wavePeaks.map((sample) => sample.rssMb))
+  const verdict = memoryWaveVerdict({
+    baselineRssMb: baseline.rssMb,
+    peakRssMb: observedPeakRssMb,
+    settledRssMb,
+    maxGrowthMb: input.maxGrowthMb,
+    maxPlateauGrowthMb: input.maxPlateauGrowthMb,
+    retentionGrowthMb: input.retentionGrowthMb,
+  })
+  console.log(
+    `[memory-loop] runtime=${input.runtime} runtime_mode=${input.runtimeMode} workload=${input.workload} path=${input.requestedPath} waves=${input.waves} requests_per_wave=${input.requests} baseline_rss_mb=${baseline.rssMb} peak_rss_mb=${observedPeakRssMb} peak_growth_mb=${verdict.peakGrowthMb} final_plateau_growth_mb=${verdict.finalPlateauGrowthMb} ongoing_retention=${verdict.ongoingRetention} budget_mb=${input.maxGrowthMb} plateau_budget_mb=${input.maxPlateauGrowthMb} verdict=${verdict.passed ? 'PASS' : 'FAIL'}`,
+  )
+  return verdict.passed
+}
+
+async function main(): Promise<void> {
+  const runtime = profileRuntimeArgument(process.argv)
+  buildProductionApp()
+  const host = process.env.PROFILE_MEMORY_HOST
+  if (!host) throw new Error('PROFILE_MEMORY_HOST is required')
+  const port = await availablePort(host)
+  const workload = workloadArgument()
+  const { requests, waves, settleMs } = profilePlanArguments(process.argv)
+  const concurrency = positiveNumber('concurrency', PROFILE_DEFAULTS.concurrency)
+  const maxGrowthMb = positiveNumber('max-growth-mb', PROFILE_DEFAULTS.maxGrowthMb)
+  const maxPlateauGrowthMb = positiveNumber(
+    'max-plateau-growth-mb',
+    PROFILE_DEFAULTS.maxPlateauGrowthMb,
+  )
+  const retentionGrowthMb = positiveNumber(
+    'retention-growth-mb',
+    PROFILE_DEFAULTS.retentionGrowthMb,
+  )
+  const requestedPath = argument('path') ?? '/'
+  const heapProfile = process.argv.includes('--heap-profile')
+  if (!requestedPath.startsWith('/')) throw new Error('--path must start with /')
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'statuslines-memory-loop-'))
+  const probePath = join(temporaryDirectory, 'probe.csv')
+  const env = { ...process.env }
+  env.HOST = host
+  env.NODE_ENV = 'production'
+  env.PORT = String(port)
+  env.PROFILE_MAX_MS = String(profileMaximumRuntimeMs({ waves, settleMs }))
+  env.PROFILE_PROBE_OUT = probePath
+
+  const profileName = `${new Date().toISOString().replace(/[:.]/g, '-')}.${runtime}.${workload}.heapsnapshot`
+  const runtimeFlags = profileServerRuntimeFlags(process.argv)
+  const serverArgs = [
+    ...runtimeFlags,
+    ...(heapProfile
+      ? ['--heap-prof', '--heap-prof-dir', RESULTS, '--heap-prof-name', profileName]
+      : []),
+    preloadFlag(runtime),
+    './scripts/profiling/probe.ts',
+    '.output/server/index.mjs',
+  ]
+  const server = spawn(runtime, serverArgs, { env, stdio: 'inherit' })
+  if (server.pid === undefined) throw new Error('profile server did not start')
+  const base = `http://${host}:${port}`
+
+  try {
+    const passed = await profileWorkload({
+      base,
+      host,
+      port,
+      workload,
+      requestedPath,
+      requests,
+      waves,
+      concurrency,
+      settleMs,
+      probePath,
+      maxGrowthMb,
+      maxPlateauGrowthMb,
+      retentionGrowthMb,
+      runtime,
+      runtimeMode: runtimeFlags.includes('--smol') ? 'smol' : 'default',
+    })
+    if (!passed) process.exitCode = 1
+  } finally {
+    server.kill('SIGUSR2')
+    await Promise.race([
+      new Promise<void>((resolve) => server.once('exit', () => resolve())),
+      sleep(5000).then(() => server.kill('SIGKILL')),
+    ])
+    if (heapProfile) console.log(`[memory-loop] heap_profile=${RESULTS}/${profileName}`)
+    rmSync(temporaryDirectory, { recursive: true, force: true })
+  }
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/profiling/probe.ts
+++ b/scripts/profiling/probe.ts
@@ -1,26 +1,30 @@
 import { appendFileSync } from 'node:fs'
 
 /**
- * Profiling-only probe. Attached with `bun --preload` ONLY by scripts/profiling/profile-server.ts —
- * production runs the server plain (`bun run .output/server/index.mjs`, see Dockerfile), so this
- * never loads there. It samples event-loop lag (how late a fixed-interval timer fires = the JS
- * thread being blocked) and RSS, appending to the CSV named by PROFILE_PROBE_OUT. No-ops if that
- * env var is unset, so even an accidental preload does nothing.
+ * Profiling-only probe. Attached with Bun's `--preload` or Node's `--import` ONLY by the profiling
+ * scripts — production runs the server plain (`bun run .output/server/index.mjs`, see Dockerfile),
+ * so this never loads there. It samples event-loop lag and each process memory category, appending
+ * to the CSV named by PROFILE_PROBE_OUT. No-ops if that env var is unset, so even an accidental
+ * preload does nothing.
  */
 const out = process.env.PROFILE_PROBE_OUT
 if (out) {
   const INTERVAL_MS = 200
-  appendFileSync(out, 'iso,elapsed_ms,loop_lag_ms,rss_mb\n')
+  appendFileSync(
+    out,
+    'iso,elapsed_ms,loop_lag_ms,rss_mb,heap_used_mb,heap_total_mb,external_mb,array_buffers_mb\n',
+  )
   const start = performance.now()
   let last = start
   setInterval(() => {
     const now = performance.now()
     const lagMs = Math.max(0, now - last - INTERVAL_MS)
     last = now
-    const rssMb = Math.round(process.memoryUsage().rss / 1024 / 1024)
+    const memory = process.memoryUsage()
+    const mb = (bytes: number) => Math.round(bytes / 1024 / 1024)
     appendFileSync(
       out,
-      `${new Date().toISOString()},${Math.round(now - start)},${lagMs.toFixed(1)},${rssMb}\n`,
+      `${new Date().toISOString()},${Math.round(now - start)},${lagMs.toFixed(1)},${mb(memory.rss)},${mb(memory.heapUsed)},${mb(memory.heapTotal)},${mb(memory.external)},${mb(memory.arrayBuffers)}\n`,
     )
   }, INTERVAL_MS)
 

--- a/src/gallery/card-rows.ts
+++ b/src/gallery/card-rows.ts
@@ -1,8 +1,42 @@
-import type { configs, configVersions, user } from '@/db/schema'
+import { configs, configVersions, user } from '@/db/schema'
 import { type AnsiSegment, INTERPRETERS, type Interpreter } from '@/render/types'
 import type { GalleryCard } from './queries'
 
 const VALID_INTERPRETERS = new Set<Interpreter>(INTERPRETERS)
+
+export const galleryCardSelection = {
+  config: {
+    id: configs.id,
+    slug: configs.slug,
+    title: configs.title,
+    description: configs.description,
+    interpreter: configs.interpreter,
+    copyCount: configs.copyCount,
+    allTags: configs.allTags,
+  },
+  version: {
+    contentSha256: configVersions.contentSha256,
+    networkHosts: configVersions.networkHosts,
+    readsClaudeToken: configVersions.readsClaudeToken,
+  },
+  author: {
+    name: user.name,
+    username: user.username,
+    image: user.image,
+  },
+}
+
+type GalleryCardRow = {
+  config: Pick<
+    typeof configs.$inferSelect,
+    'allTags' | 'copyCount' | 'description' | 'id' | 'interpreter' | 'slug' | 'title'
+  >
+  version: Pick<
+    typeof configVersions.$inferSelect,
+    'contentSha256' | 'networkHosts' | 'readsClaudeToken'
+  >
+  author: Pick<typeof user.$inferSelect, 'image' | 'name' | 'username'> | null
+}
 
 /** Narrows the free-form DB `interpreter` column to the Interpreter union; falls back to 'bash'. */
 export function coerceInterpreter(value: string): Interpreter {
@@ -11,11 +45,7 @@ export function coerceInterpreter(value: string): Interpreter {
 
 /** Shared row → GalleryCard mapping for the home gallery and facet pages. */
 export function mapCardRows(
-  rows: Array<{
-    config: typeof configs.$inferSelect
-    version: typeof configVersions.$inferSelect
-    author: typeof user.$inferSelect | null
-  }>,
+  rows: GalleryCardRow[],
   cardPreviews: Map<string, AnsiSegment[]>,
 ): GalleryCard[] {
   return rows.map((r) => ({

--- a/src/gallery/facet-queries.ts
+++ b/src/gallery/facet-queries.ts
@@ -1,7 +1,7 @@
 import { and, desc, eq, sql } from 'drizzle-orm'
 import type { PgDatabase } from 'drizzle-orm/pg-core'
 import { configs, configVersions, user } from '@/db/schema'
-import { mapCardRows } from './card-rows'
+import { galleryCardSelection, mapCardRows } from './card-rows'
 import { ALL_TAG_SLUGS, FACET_BY_SLUG, FACETS, type Facet } from './facets'
 import { type GalleryCard, selectCardPreviews } from './queries'
 
@@ -66,7 +66,7 @@ export async function getAvailableTags(db: Db): Promise<string[]> {
 /** A facet page's cards: published matches, most-copied first, newest as the tiebreak. */
 export async function getFacetCards(db: Db, facet: Facet): Promise<GalleryCard[]> {
   const rows = await db
-    .select({ config: configs, version: configVersions, author: user })
+    .select(galleryCardSelection)
     .from(configs)
     .innerJoin(configVersions, eq(configVersions.id, configs.currentVersionId))
     .leftJoin(user, eq(user.id, configs.authorId))

--- a/src/gallery/queries.ts
+++ b/src/gallery/queries.ts
@@ -5,7 +5,7 @@ import { configs, configVersions, previews, user } from '@/db/schema'
 import { ALL_TAG_SLUGS } from '@/gallery/facets'
 import { getPreviews } from '@/render/store'
 import type { AnsiSegment, Interpreter, RenderedPreview } from '@/render/types'
-import { coerceInterpreter, mapCardRows } from './card-rows'
+import { coerceInterpreter, galleryCardSelection, mapCardRows } from './card-rows'
 import { trendingScore } from './trending'
 
 // biome-ignore lint/suspicious/noExplicitAny: db type varies by driver (postgres-js/pglite); query surface identical.
@@ -114,7 +114,7 @@ export async function getPublishedConfigs(
     tags.length > 0 ? sql`${configs.allTags} @> ${JSON.stringify(tags)}::jsonb` : undefined
 
   const rows = await db
-    .select({ config: configs, version: configVersions, author: user })
+    .select(galleryCardSelection)
     .from(configs)
     .innerJoin(configVersions, eq(configVersions.id, configs.currentVersionId))
     .leftJoin(user, eq(user.id, configs.authorId))
@@ -145,20 +145,21 @@ export async function selectCardPreviews(
 ): Promise<Map<string, AnsiSegment[]>> {
   const bySha = new Map<string, AnsiSegment[]>()
   if (shas.length === 0) return bySha
+  // Choose one row in Postgres; fetching every scenario returned about 7× unused preview data.
   const rows = await db
-    .select({
+    .selectDistinctOn([previews.scriptSha], {
       scriptSha: previews.scriptSha,
-      scenarioKey: previews.scenarioKey,
       segments: previews.segments,
     })
     .from(previews)
     .where(inArray(previews.scriptSha, shas))
+    .orderBy(
+      previews.scriptSha,
+      desc(sql`${previews.scenarioKey} = ${CARD_SCENARIO}`),
+      previews.scenarioKey,
+    )
   for (const row of rows) {
-    const segments = row.segments as AnsiSegment[]
-    // clean-main always wins; otherwise keep the first scenario seen for this sha.
-    if (row.scenarioKey === CARD_SCENARIO || !bySha.has(row.scriptSha)) {
-      bySha.set(row.scriptSha, segments)
-    }
+    bySha.set(row.scriptSha, row.segments as AnsiSegment[])
   }
   return bySha
 }

--- a/test/gallery/facet-queries.test.ts
+++ b/test/gallery/facet-queries.test.ts
@@ -155,6 +155,25 @@ describe('facet queries', () => {
     expect(cards.map((c) => c.slug)).toEqual(['py-a'])
   })
 
+  it('does not fetch heavyweight version content for facet cards', async () => {
+    const loggedQueries: string[] = []
+    const loggedDb = drizzle({
+      client,
+      schema,
+      logger: {
+        logQuery: (query) => {
+          loggedQueries.push(query)
+        },
+      },
+    })
+
+    await getFacetCards(loggedDb, FACET_BY_SLUG.get('git')!)
+
+    expect(loggedQueries[0]).not.toMatch(
+      /"config_versions"\."(?:source|source_html|generated_content)"/,
+    )
+  })
+
   it('a page tag with only 1 config is live (no floor)', async () => {
     const stats = await getFacetStats(db)
     expect(resolveLiveFacet('cost', stats)?.slug).toBe('cost')

--- a/test/gallery/queries.test.ts
+++ b/test/gallery/queries.test.ts
@@ -4,7 +4,7 @@ import { drizzle } from 'drizzle-orm/pglite'
 import { migrate } from 'drizzle-orm/pglite/migrator'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import * as schema from '@/db/schema'
-import { getPublishedConfigs } from '@/gallery/queries'
+import { getPublishedConfigs, selectCardPreviews } from '@/gallery/queries'
 import { trendingScore } from '@/gallery/trending'
 import { storePreviews } from '@/render/store'
 
@@ -127,6 +127,37 @@ describe('getPublishedConfigs', () => {
     const cards = await getPublishedConfigs(db)
     expect(cards.find((c) => c.slug === 'net-yes')?.networkHosts).toEqual(['wttr.in'])
     expect(cards.find((c) => c.slug === 'net-no')?.networkHosts).toEqual([])
+  })
+})
+
+describe('selectCardPreviews', () => {
+  it('prefers clean-main and falls back deterministically when it is missing', async () => {
+    const preferredSha = 'preferred-preview'.padEnd(64, '0')
+    const fallbackSha = 'fallback-preview'.padEnd(64, '0')
+    const preview = (scriptSha: string, scenarioKey: string, text: string) => ({
+      scriptSha,
+      scenarioKey,
+      segments: [{ text, fg: null, bg: null, bold: false, italic: false, underline: false }],
+      rawStdout: text,
+      exitCode: 0,
+      timedOut: 0,
+      trace: { networkAttempts: [], sensitiveReads: [], spawnedProcesses: [] },
+    })
+    await db
+      .insert(schema.previews)
+      .values([
+        preview(preferredSha, 'a-first', 'not preferred'),
+        preview(preferredSha, 'clean-main', 'preferred'),
+        preview(fallbackSha, 'z-last', 'later fallback'),
+        preview(fallbackSha, 'a-first', 'first fallback'),
+      ])
+
+    const selected = await selectCardPreviews(db, [preferredSha, fallbackSha])
+
+    expect({
+      preferred: selected.get(preferredSha)?.[0]?.text,
+      fallback: selected.get(fallbackSha)?.[0]?.text,
+    }).toEqual({ preferred: 'preferred', fallback: 'first fallback' })
   })
 })
 
@@ -311,6 +342,42 @@ describe('getPublishedConfigs sorting', () => {
 // Placed last on purpose: this seeds extra configs, and the tests above share one accumulating
 // PGlite db, so seeding earlier would push their fixtures off page 1.
 describe('getPublishedConfigs query count', () => {
+  it('does not fetch heavyweight version content for gallery cards', async () => {
+    const loggedQueries: string[] = []
+    const loggedDb = drizzle({
+      client,
+      schema,
+      logger: {
+        logQuery: (query) => {
+          loggedQueries.push(query)
+        },
+      },
+    })
+
+    await getPublishedConfigs(loggedDb)
+
+    expect(loggedQueries[0]).not.toMatch(
+      /"config_versions"\."(?:source|source_html|generated_content)"/,
+    )
+  })
+
+  it('fetches at most one preview row per gallery card', async () => {
+    const loggedQueries: string[] = []
+    const loggedDb = drizzle({
+      client,
+      schema,
+      logger: {
+        logQuery: (query) => {
+          loggedQueries.push(query)
+        },
+      },
+    })
+
+    await getPublishedConfigs(loggedDb)
+
+    expect(loggedQueries[1]).toMatch(/^select distinct on \("previews"\."script_sha"\)/)
+  })
+
   it('issues a constant number of queries regardless of card count (no N+1)', async () => {
     // A page of N cards must not fan out into 1 + N queries (one preview lookup per card).
     // Build a second Drizzle over the SAME PGlite client with a counting logger, so only the

--- a/test/profiling/memory-loop.test.ts
+++ b/test/profiling/memory-loop.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import {
+  memoryWaveVerdict,
+  parseProbeSamples,
+  profileMaximumRuntimeMs,
+  profilePlanArguments,
+  profileRuntimeArgument,
+  profileServerRuntimeFlags,
+} from '../../scripts/profiling/memory-loop'
+
+describe('profileRuntimeArgument', () => {
+  it('selects Node from the public runtime argument', () => {
+    expect(profileRuntimeArgument(['--runtime=node'])).toBe('node')
+  })
+
+  it('enables Bun small-heap mode from the public flag', () => {
+    expect(profileServerRuntimeFlags(['--smol'])).toEqual(['--smol'])
+  })
+})
+
+describe('profilePlanArguments', () => {
+  it('defaults to one warm-up and three measured waves with a long settle', () => {
+    expect(profilePlanArguments([])).toEqual({
+      requests: 400,
+      waves: 3,
+      settleMs: 30_000,
+    })
+  })
+
+  it('allows slow runtime modes to finish before the safety backstop', () => {
+    expect(profileMaximumRuntimeMs({ waves: 3, settleMs: 30_000 })).toBe(1_800_000)
+  })
+})
+
+describe('memoryWaveVerdict', () => {
+  it('measures the final settled plateau from the post-warmup baseline', () => {
+    expect(
+      memoryWaveVerdict({
+        baselineRssMb: 250,
+        peakRssMb: 330,
+        settledRssMb: [290, 310, 320],
+        maxGrowthMb: 120,
+        maxPlateauGrowthMb: 20,
+        retentionGrowthMb: 30,
+      }),
+    ).toEqual({
+      peakGrowthMb: 80,
+      finalPlateauGrowthMb: 70,
+      ongoingRetention: false,
+      passed: false,
+    })
+  })
+
+  it('detects ongoing retention across consecutive settled waves', () => {
+    expect(
+      memoryWaveVerdict({
+        baselineRssMb: 250,
+        peakRssMb: 390,
+        settledRssMb: [290, 325, 360],
+        maxGrowthMb: 120,
+        maxPlateauGrowthMb: 20,
+        retentionGrowthMb: 30,
+      }),
+    ).toEqual({
+      peakGrowthMb: 140,
+      finalPlateauGrowthMb: 110,
+      ongoingRetention: true,
+      passed: false,
+    })
+  })
+
+  it('fails when consecutive waves retain memory before the final plateau', () => {
+    expect(
+      memoryWaveVerdict({
+        baselineRssMb: 250,
+        peakRssMb: 350,
+        settledRssMb: [280, 310, 310],
+        maxGrowthMb: 120,
+        maxPlateauGrowthMb: 20,
+        retentionGrowthMb: 30,
+      }),
+    ).toEqual({
+      peakGrowthMb: 100,
+      finalPlateauGrowthMb: 60,
+      ongoingRetention: true,
+      passed: false,
+    })
+  })
+})
+
+describe('parseProbeSamples', () => {
+  it('reads each process memory category reported by the probe', () => {
+    expect(
+      parseProbeSamples(
+        'iso,elapsed_ms,loop_lag_ms,rss_mb,heap_used_mb,heap_total_mb,external_mb,array_buffers_mb\n2026-08-18T12:00:00.000Z,200,0.4,244,98,110,42,17\n',
+      ),
+    ).toEqual([
+      {
+        elapsedMs: 200,
+        loopLagMs: 0.4,
+        rssMb: 244,
+        heapUsedMb: 98,
+        heapTotalMb: 110,
+        externalMb: 42,
+        arrayBuffersMb: 17,
+      },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- Reduce transient allocation pressure when rendering gallery and facet cards.
- Add a repeated-wave memory profiler that distinguishes peak growth from continuing retention.
- Increase production web memory headroom while preserving the existing worker size.

## Changes

- Select only the config, version, and author fields used by gallery cards.
- Select one deterministic preview row per card in PostgreSQL, preferring the primary scenario.
- Cover the narrowed projections and preview-selection behavior with database tests.
- Record RSS, heap, external memory, array buffers, and event-loop lag across repeated profiling waves.
- Document the production sizing rationale and keep the deployment configuration as its source of truth.

## Verification

- `bun run check`
- 172 test files passed, 2 skipped
- 1,124 tests passed, 11 skipped
- Typecheck, lint, front-end, and dependency-boundary gates passed