### PR TITLE
fix: stop aborted GitHub OAuth fetches from becoming unhandled rejections

### DIFF
--- a/src/lib/sign-in.ts
+++ b/src/lib/sign-in.ts
@@ -49,7 +49,9 @@ export function startGitHubSignIn(
     returnPath: trackedReturnPath,
     [CURRENT_URL_PROPERTY]: trackedReturnPath,
   })
-  void authClient.signIn.social({ provider: 'github', callbackURL: returnPath })
+  void authClient.signIn.social({ provider: 'github', callbackURL: returnPath }).catch(() => {
+    // Aborted or failed OAuth fetch: the user can click Sign in again.
+  })
 }
 
 /** Consume the short-lived OAuth intent after the callback returns to the app. */

--- a/src/ui/app-header.tsx
+++ b/src/ui/app-header.tsx
@@ -28,6 +28,8 @@ async function handleSignOut(posthog: PostHog) {
   posthog.reset()
   try {
     await authClient.signOut()
+  } catch {
+    // Sign-out fetch can fail during page teardown; still send them home.
   } finally {
     // Even if the sign-out call fails, reload home — the fresh page reflects the real session.
     window.location.assign('/')

--- a/test/lib/sign-in.test.ts
+++ b/test/lib/sign-in.test.ts
@@ -53,4 +53,17 @@ describe('startGitHubSignIn', () => {
       $current_url: '/',
     })
   })
+
+  it('does not leak an unhandled rejection when GitHub OAuth fetch fails', async () => {
+    const onUnhandled = vi.fn()
+    process.on('unhandledRejection', onUnhandled)
+    socialSignIn.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    startGitHubSignIn('/')
+    await Promise.resolve()
+    await Promise.resolve()
+
+    process.off('unhandledRejection', onUnhandled)
+    expect(onUnhandled).not.toHaveBeenCalled()
+  })
 })

--- a/test/ui/app-header.test.tsx
+++ b/test/ui/app-header.test.tsx
@@ -119,6 +119,24 @@ describe('AppHeader', () => {
     await waitFor(() => expect(assign).toHaveBeenCalledWith('/'))
   })
 
+  it('reloads home when sign-out fetch fails without an unhandled rejection', async () => {
+    const onUnhandled = vi.fn()
+    process.on('unhandledRejection', onUnhandled)
+    signOut.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+
+    render(
+      <AppHeader user={{ name: 'Ada Lovelace', username: 'ada', image: null, role: 'user' }} />,
+    )
+    openMenu(screen.getByText('@ada'))
+    fireEvent.click(await screen.findByText('Log out'))
+
+    await waitFor(() => expect(assign).toHaveBeenCalledWith('/'))
+    await Promise.resolve()
+    await Promise.resolve()
+    process.off('unhandledRejection', onUnhandled)
+    expect(onUnhandled).not.toHaveBeenCalled()
+  })
+
   it('includes a Review menu item only for admins', async () => {
     render(
       <AppHeader user={{ name: 'Ada Lovelace', username: 'ada', image: null, role: 'admin' }} />,


### PR DESCRIPTION
## Summary
- GitHub sign-in fired `authClient.signIn.social` with no rejection handler, so aborted crawler and network fetches showed up in PostHog as unhandled `TypeError: Failed to fetch`.
- Catch those failures at the sign-in and sign-out call sites so they are not unhandled rejections. Sign-out still sends the user home.

## Changes
- `startGitHubSignIn` `.catch()`es the Better Auth social fetch.
- Header sign-out `catch`es a failed fetch, then still `location.assign('/')`.
- Tests assert a rejected OAuth or sign-out fetch does not become `unhandledrejection`.